### PR TITLE
이니 step1

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
+		D9AAFC4B25625E10005CD76A /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9AAFC4A25625E10005CD76A /* Fruit.swift */; };
+		D9AAFC4E2562607B005CD76A /* JuiceMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9AAFC4D2562607B005CD76A /* JuiceMenu.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +28,8 @@
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C73DAF44255D0CDF00020D38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMaker.swift; sourceTree = "<group>"; };
+		D9AAFC4A25625E10005CD76A /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
+		D9AAFC4D2562607B005CD76A /* JuiceMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMenu.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -66,6 +70,8 @@
 				C73DAF3F255D0CDE00020D38 /* Assets.xcassets */,
 				C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */,
 				C73DAF44255D0CDF00020D38 /* Info.plist */,
+				D9AAFC4A25625E10005CD76A /* Fruit.swift */,
+				D9AAFC4D2562607B005CD76A /* JuiceMenu.swift */,
 			);
 			path = JuiceMaker;
 			sourceTree = "<group>";
@@ -140,10 +146,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9AAFC4B25625E10005CD76A /* Fruit.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
+				D9AAFC4E2562607B005CD76A /* JuiceMenu.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JuiceMaker/JuiceMaker/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Fruit.swift
@@ -1,0 +1,18 @@
+//
+//  Fruit.swift
+//  JuiceMaker
+//
+//  Created by 강인희 on 2020/11/16.
+//
+
+import Foundation
+
+class Fruit {
+    var fruitName: String
+    var currentStock: Int
+    
+    init(fruitName: String, currentStock: Int) {
+        self.fruitName = fruitName
+        self.currentStock = currentStock
+    }
+}

--- a/JuiceMaker/JuiceMaker/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/JuiceMaker.swift
@@ -7,3 +7,117 @@
 import Foundation
 
 /// 쥬스 메이커 타입 
+struct JuiceMaker {
+    private var fruitStockList: [Fruit] = []
+    private var menuList: [JuiceMenu] = []
+    
+    private var strawberry = Fruit(fruitName: "strawberry", currentStock: 10)
+    private var banana = Fruit(fruitName: "banana", currentStock: 10)
+    private var pineapple = Fruit(fruitName: "pineapple", currentStock: 10)
+    private var kiwi = Fruit(fruitName: "kiwi", currentStock: 10)
+    private var mango = Fruit(fruitName: "mango", currentStock: 10)
+    
+    init() {
+        self.fruitStockList = initializeFruitStockList()
+        self.menuList = initializeMenuList()
+    }
+    
+    private func initializeFruitStockList() -> [Fruit] {
+        var initialFruitStockList: [Fruit] = []
+        
+        initialFruitStockList.append(strawberry)
+        initialFruitStockList.append(banana)
+        initialFruitStockList.append(pineapple)
+        initialFruitStockList.append(kiwi)
+        initialFruitStockList.append(mango)
+        
+        return initialFruitStockList
+    }
+    
+    private func initializeMenuList() -> [JuiceMenu] {
+        var initialMenuList = [JuiceMenu]()
+
+        initialMenuList.append(.딸바쥬스)
+        initialMenuList.append(.망고쥬스)
+        initialMenuList.append(.망고키위쥬스)
+        initialMenuList.append(.키위쥬스)
+        initialMenuList.append(.파인애플쥬스)
+
+        return initialMenuList
+    }
+    
+    func checkAllStock() {
+        for fruitType in fruitStockList {
+            print("\(fruitType.fruitName) 재고가 \(fruitType.currentStock) 개 남아있습니다.")
+        }
+    }
+    
+    func checkStock(of fruitType: Fruit) -> Int {
+        return fruitType.currentStock
+    }
+    
+    func addStock(of fruitType: Fruit, addingAmount: Int) {
+        guard addingAmount > 0 else {
+            print("재고를 하나 이상 추가해주세요.")
+            return
+        }
+        
+        fruitType.currentStock += addingAmount
+    }
+    
+    func makeJuice(of order: JuiceMenu) {
+        switch order {
+        case .딸바쥬스:
+            guard checkStock(of: strawberry) >= 10,
+                  checkStock(of: banana) >= 1 else {
+                print("딸바쥬스를 만들 재고가 충분하지 않습니다.")
+                return
+            }
+            
+            updateStock(of: strawberry, used: 10)
+            updateStock(of: banana, used: 1)
+            
+        case .망고쥬스:
+            guard checkStock(of: mango) >= 3 else {
+                print("망고쥬스를 만들 재고가 충분하지 않습니다.")
+                return
+            }
+            
+            updateStock(of: mango, used: 3)
+            
+        case .망고키위쥬스:
+            guard checkStock(of: mango) >= 2,
+                  checkStock(of: kiwi) >= 1 else {
+                print("망고키위쥬스를 만들 재고가 충분하지 않습니다.")
+                return
+            }
+            
+            updateStock(of: mango, used: 2)
+            updateStock(of: kiwi, used: 1)
+            
+        case .키위쥬스:
+            guard checkStock(of: kiwi) >= 3 else {
+                print("키위쥬스를 만들 재고가 충분하지 않습니다.")
+                return
+            }
+            
+            updateStock(of: kiwi, used: 3)
+            
+        case .파인애플쥬스:
+            guard checkStock(of: kiwi) >= 2 else {
+                print("파인애플쥬스를 만들 재고가 충분하지 않습니다.")
+                return
+            }
+            
+            updateStock(of: pineapple, used: 2)
+            
+        }
+    }
+    
+    private func updateStock(of fruitType: Fruit, used amount: Int) {
+        fruitType.currentStock -= amount
+    }
+    
+
+}
+

--- a/JuiceMaker/JuiceMaker/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/JuiceMaker.swift
@@ -36,13 +36,13 @@ struct JuiceMaker {
     
     private func initializeMenuList() -> [JuiceMenu] {
         var initialMenuList = [JuiceMenu]()
-
+        
         initialMenuList.append(.딸바쥬스)
         initialMenuList.append(.망고쥬스)
         initialMenuList.append(.망고키위쥬스)
         initialMenuList.append(.키위쥬스)
         initialMenuList.append(.파인애플쥬스)
-
+        
         return initialMenuList
     }
     
@@ -117,7 +117,5 @@ struct JuiceMaker {
     private func updateStock(of fruitType: Fruit, used amount: Int) {
         fruitType.currentStock -= amount
     }
-    
-
 }
 

--- a/JuiceMaker/JuiceMaker/JuiceMenu.swift
+++ b/JuiceMaker/JuiceMaker/JuiceMenu.swift
@@ -1,0 +1,17 @@
+//
+//  JuiceMenu.swift
+//  JuiceMaker
+//
+//  Created by 강인희 on 2020/11/16.
+//
+
+import Foundation
+
+enum JuiceMenu {
+    case 딸바쥬스
+    case 망고쥬스
+    case 망고키위쥬스
+    case 키위쥬스
+    case 파인애플쥬스
+}
+

--- a/JuiceMaker/JuiceMaker/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/ViewController.swift
@@ -7,12 +7,9 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
     }
-
-
 }
 


### PR DESCRIPTION
- Fruit(Class), JuiceMenu(Enum), JuiceMaker(Struct) 타입 생성 및 요구함수 구현.

- JuiceMaker에서 재고관리,메뉴관리를 직접적으로 하는 것보다, Fruit 타입에 재고량을 속성으로 두고 JuiceMenu는 메뉴자체만을 만든 후JuiceMaker에 필요로 하는 Fruit와 JuiceMenu를 할당하여 제조작업에 더 초점을 맞출 수 있도록 구성했습니다.

- JuiceMaker에서 Fruit를 배열로 관리하여, 해당 과일의 현재재고량(Fruit의 속성)을 업데이트하기 위해 Fruit를 Struct가 아닌 Class로 구현해보았습니다. 해당 프로젝트에서 과일의 종류가 같다면 따로 해당 과일을 복사할 필요없이 하나의 과일로 묶어서 관리하고, 과일 하나 타입의 재고량 업데이트시에 Fruit의 배열 (fruitStockList)의 업데이트 작업 또한 필요했기에 Class로 구현했습니다.

- JuiceMaker에서 쥬스를 만드는 함수 makeJuice는 메뉴이름을 받으면 해당 메뉴에 따라 필요한 과일재료의 재고량을 확인한 후 재고량을 업데이트하는 방식을 case별로 반복하고 있는데 불필요하게 코드가 길어진 것인지 잘 모르겠습니다 ㅠㅠ .. 의견 부탁드려요 :)