### PR TITLE
쥬스메이커 [Step1]: namu, 호박

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
+		E9784636272156B0003A7ED2 /* FruitStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9784635272156B0003A7ED2 /* FruitStorage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C73DAF44255D0CDF00020D38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMaker.swift; sourceTree = "<group>"; };
+		E9784635272156B0003A7ED2 /* FruitStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStorage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,10 +70,11 @@
 		C71CD66F266C7B500038B9CB /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				E9784635272156B0003A7ED2 /* FruitStorage.swift */,
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
-				252F54D4272141DC00E3EC5C /* Fruit.swift */,
 				252F54D6272141EB00E3EC5C /* JuiceMenu.swift */,
+				252F54D4272141DC00E3EC5C /* Fruit.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -192,6 +195,7 @@
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 				252F54D32721414900E3EC5C /* FruitStoreError.swift in Sources */,
 				252F54D7272141EB00E3EC5C /* JuiceMenu.swift in Sources */,
+				E9784636272156B0003A7ED2 /* FruitStorage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
-		E9784636272156B0003A7ED2 /* FruitStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9784635272156B0003A7ED2 /* FruitStorage.swift */; };
+		E9784636272156B0003A7ED2 /* FruitStockManaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9784635272156B0003A7ED2 /* FruitStockManaging.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,7 +35,7 @@
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C73DAF44255D0CDF00020D38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMaker.swift; sourceTree = "<group>"; };
-		E9784635272156B0003A7ED2 /* FruitStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStorage.swift; sourceTree = "<group>"; };
+		E9784635272156B0003A7ED2 /* FruitStockManaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStockManaging.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,7 +70,7 @@
 		C71CD66F266C7B500038B9CB /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				E9784635272156B0003A7ED2 /* FruitStorage.swift */,
+				E9784635272156B0003A7ED2 /* FruitStockManaging.swift */,
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				252F54D6272141EB00E3EC5C /* JuiceMenu.swift */,
@@ -195,7 +195,7 @@
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 				252F54D32721414900E3EC5C /* FruitStoreError.swift in Sources */,
 				252F54D7272141EB00E3EC5C /* JuiceMenu.swift in Sources */,
-				E9784636272156B0003A7ED2 /* FruitStorage.swift in Sources */,
+				E9784636272156B0003A7ED2 /* FruitStockManaging.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		252F54D32721414900E3EC5C /* FruitStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252F54D22721414900E3EC5C /* FruitStoreError.swift */; };
+		252F54D5272141DC00E3EC5C /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252F54D4272141DC00E3EC5C /* Fruit.swift */; };
+		252F54D7272141EB00E3EC5C /* JuiceMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252F54D6272141EB00E3EC5C /* JuiceMenu.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -18,6 +21,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		252F54D22721414900E3EC5C /* FruitStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStoreError.swift; sourceTree = "<group>"; };
+		252F54D4272141DC00E3EC5C /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
+		252F54D6272141EB00E3EC5C /* JuiceMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMenu.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -41,6 +47,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		252F54D1272140F000E3EC5C /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				252F54D22721414900E3EC5C /* FruitStoreError.swift */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		C71CD66D266C7B470038B9CB /* Controller */ = {
 			isa = PBXGroup;
 			children = (
@@ -56,6 +70,8 @@
 			children = (
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
+				252F54D4272141DC00E3EC5C /* Fruit.swift */,
+				252F54D6272141EB00E3EC5C /* JuiceMenu.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -89,6 +105,7 @@
 		C73DAF35255D0CDD00020D38 /* JuiceMaker */ = {
 			isa = PBXGroup;
 			children = (
+				252F54D1272140F000E3EC5C /* Error */,
 				C71CD66D266C7B470038B9CB /* Controller */,
 				C71CD66F266C7B500038B9CB /* Model */,
 				C71CD671266C7B570038B9CB /* View */,
@@ -171,7 +188,10 @@
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
+				252F54D5272141DC00E3EC5C /* Fruit.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
+				252F54D32721414900E3EC5C /* FruitStoreError.swift in Sources */,
+				252F54D7272141EB00E3EC5C /* JuiceMenu.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -11,8 +11,11 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+        let juiceMaker = JuiceMaker()
+        
+        try! juiceMaker.makeJuice(menu: .banana)
+        try! juiceMaker.makeJuice(menu: .strawberryBanana)
+        print(juiceMaker.fruitStore.inventory)
     }
-
-
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -11,11 +11,6 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
-        let juiceMaker = JuiceMaker()
-        
-        try! juiceMaker.makeJuice(menu: .banana)
-        try! juiceMaker.makeJuice(menu: .strawberryBanana)
-        print(juiceMaker.fruitStore.inventory)
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Error/FruitStoreError.swift
+++ b/JuiceMaker/JuiceMaker/Error/FruitStoreError.swift
@@ -8,5 +8,5 @@
 
 enum FruitStoreError: Error {
     case stockShortage
-    case unexpectedNil
+    case stockDataMissing
 }

--- a/JuiceMaker/JuiceMaker/Error/FruitStoreError.swift
+++ b/JuiceMaker/JuiceMaker/Error/FruitStoreError.swift
@@ -1,0 +1,12 @@
+//
+//  FruitStoreError.swift
+//  JuiceMaker
+//
+//  Created by 박병호 on 2021/10/21.
+//
+
+
+enum FruitStoreError: Error {
+    case stockShortage
+    case unexpectedNil
+}

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -4,8 +4,6 @@
 //
 //  Created by 박병호 on 2021/10/21.
 //
-
-
 enum Fruit: CaseIterable {
     case strawberry, banana, kiwi, pineapple, mango
 }

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -1,0 +1,11 @@
+//
+//  Fruit.swift
+//  JuiceMaker
+//
+//  Created by 박병호 on 2021/10/21.
+//
+
+
+enum Fruit: CaseIterable {
+    case strawberry, banana, kiwi, pineapple, mango
+}

--- a/JuiceMaker/JuiceMaker/Model/FruitStockManaging.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStockManaging.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol FruitStorage {
+protocol FruitStockManaging {
     func changeFruitStock(of fruit: Fruit, by quantity: Int, calculate: (Int, Int) -> Int) throws
     func currentFruitStock(of fruit: Fruit) throws -> Int
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStorage.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStorage.swift
@@ -1,0 +1,13 @@
+//
+//  StoreProtocol.swift
+//  JuiceMaker
+//
+//  Created by Jae-hoon Sim on 2021/10/21.
+//
+
+import Foundation
+
+protocol FruitStorage {
+    func changeFruitStock(of fruit: Fruit, by quantity: Int, calculate: (Int, Int) -> Int) throws
+    func currentFruitStock(of fruit: Fruit) throws -> Int
+}

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,5 +8,17 @@ import Foundation
 
 // 과일 저장소 타입
 class FruitStore {
+    enum Fruit: CaseIterable {
+        case strawberry, banana, kiwi, pineapple, mango
+    }
+    
+    var inventory: Dictionary<Fruit, Int>
+    
+    init(defaultValue: Int = 10) {
+        self.inventory = [:]
+        Fruit.allCases.forEach {
+            inventory.updateValue(defaultValue, forKey: $0)
+        }
+    }
     
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -21,4 +21,18 @@ class FruitStore {
         }
     }
     
+    func increaseFruitStock(fruit: Fruit) {
+        guard let fruitStock = inventory[fruit] else {
+            return
+        }
+        inventory[fruit] = fruitStock + 1
+    }
+    
+    func decreaseFruitStock(fruit: Fruit, quantity: Int = 1) {
+        guard let fruitStock = inventory[fruit] else {
+            return
+        }
+        inventory[fruit] = fruitStock - quantity
+    }
+    
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -6,8 +6,7 @@
 
 import Foundation
 
-
-class FruitStore {
+class FruitStore: FruitStorage {
     private var inventory: [Fruit: Int] = [:]
     
     init(defaultValue: Int = 10) {
@@ -24,5 +23,12 @@ class FruitStore {
             throw FruitStoreError.stockShortage
         }
         inventory[fruit] = calculate(fruitStock, quantity)
+    }
+    
+    func currentFruitStock(of fruit: Fruit) throws -> Int {
+        guard let currentStock = inventory[fruit] else {
+            throw FruitStoreError.stockDataMissing
+        }
+        return currentStock
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -18,7 +18,7 @@ class FruitStore {
     
     func changeFruitStock(of fruit: Fruit, by quantity: Int = 1, calculate: (Int, Int) -> Int) throws {
         guard let fruitStock = inventory[fruit] else {
-            throw FruitStoreError.unexpectedNil
+            throw FruitStoreError.stockDataMissing
         }
         if calculate(fruitStock, quantity) < 0 {
             throw FruitStoreError.stockShortage

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -9,10 +9,14 @@ import Foundation
 class FruitStore: FruitStorage {
     private var inventory: [Fruit: Int] = [:]
     
-    init(defaultValue: Int = 10) {
-        Fruit.allCases.forEach {
-            inventory.updateValue(defaultValue, forKey: $0)
+    init(fruitQuantity: Int = 10) {
+        Fruit.allCases.forEach { fruit in
+            inventory.updateValue(fruitQuantity, forKey: fruit)
         }
+    }
+    
+    init(inventory: [Fruit: Int]) {
+        self.inventory = inventory
     }
     
     func changeFruitStock(of fruit: Fruit, by quantity: Int = 1, calculate: (Int, Int) -> Int) throws {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -6,10 +6,8 @@
 
 import Foundation
 
+
 class FruitStore {
-    enum Fruit: CaseIterable {
-        case strawberry, banana, kiwi, pineapple, mango
-    }
     
     private var inventory: [Fruit: Int]
     
@@ -29,9 +27,4 @@ class FruitStore {
         }
         inventory[fruit] = calculate(fruitStock, quantity)
     }
-}
-
-enum FruitStoreError: Error {
-    case stockShortage
-    case unexpectedNil
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -20,23 +20,15 @@ class FruitStore {
         }
     }
     
-    func increaseFruitStock(of fruit: Fruit, by quantity: Int = 1) {
-        guard let fruitStock = inventory[fruit] else {
-            return
-        }
-        inventory[fruit] = fruitStock + quantity
-    }
-    
-    func decreaseFruitStock(of fruit: Fruit, by quantity: Int = 1) throws {
+    func changeFruitStock(of fruit: Fruit, by quantity: Int = 1, calculate: (Int, Int) -> Int) throws {
         guard let fruitStock = inventory[fruit] else {
             throw FruitStoreError.unexpectedNil
         }
-        if fruitStock < quantity {
+        if calculate(fruitStock, quantity) < 0 {
             throw FruitStoreError.stockShortage
         }
-        inventory[fruit] = fruitStock - quantity
+        inventory[fruit] = calculate(fruitStock, quantity)
     }
-    
 }
 
 enum FruitStoreError: Error {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -23,10 +23,11 @@ class FruitStore: FruitStorage {
         guard let fruitStock = inventory[fruit] else {
             throw FruitStoreError.stockDataMissing
         }
-        if calculate(fruitStock, quantity) < 0 {
+        let changedFruitStock = calculate(fruitStock, quantity)
+        if changedFruitStock < 0 {
             throw FruitStoreError.stockShortage
         }
-        inventory[fruit] = calculate(fruitStock, quantity)
+        inventory[fruit] = changedFruitStock
     }
     
     func currentFruitStock(of fruit: Fruit) throws -> Int {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,11 +8,9 @@ import Foundation
 
 
 class FruitStore {
-    
-    private var inventory: [Fruit: Int]
+    private var inventory: [Fruit: Int] = [:]
     
     init(defaultValue: Int = 10) {
-        self.inventory = [:]
         Fruit.allCases.forEach {
             inventory.updateValue(defaultValue, forKey: $0)
         }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -28,11 +28,19 @@ class FruitStore {
         inventory[fruit] = fruitStock + 1
     }
     
-    func decreaseFruitStock(fruit: Fruit, quantity: Int = 1) {
+    func decreaseFruitStock(fruit: Fruit, quantity: Int = 1) throws {
         guard let fruitStock = inventory[fruit] else {
-            return
+            throw FruitStoreError.unexpectedNil
+        }
+        if fruitStock < quantity {
+            throw FruitStoreError.stockShortage
         }
         inventory[fruit] = fruitStock - quantity
     }
     
+}
+
+enum FruitStoreError: Error {
+    case stockShortage
+    case unexpectedNil
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -6,13 +6,12 @@
 
 import Foundation
 
-// 과일 저장소 타입
 class FruitStore {
     enum Fruit: CaseIterable {
         case strawberry, banana, kiwi, pineapple, mango
     }
     
-    var inventory: Dictionary<Fruit, Int>
+    private var inventory: [Fruit: Int]
     
     init(defaultValue: Int = 10) {
         self.inventory = [:]
@@ -21,14 +20,14 @@ class FruitStore {
         }
     }
     
-    func increaseFruitStock(fruit: Fruit) {
+    func increaseFruitStock(of fruit: Fruit, by quantity: Int = 1) {
         guard let fruitStock = inventory[fruit] else {
             return
         }
-        inventory[fruit] = fruitStock + 1
+        inventory[fruit] = fruitStock + quantity
     }
     
-    func decreaseFruitStock(fruit: Fruit, quantity: Int = 1) throws {
+    func decreaseFruitStock(of fruit: Fruit, by quantity: Int = 1) throws {
         guard let fruitStock = inventory[fruit] else {
             throw FruitStoreError.unexpectedNil
         }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-class FruitStore: FruitStorage {
+class FruitStore: FruitStockManaging {
     private var inventory: [Fruit: Int] = [:]
     
     init(fruitQuantity: Int = 10) {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,5 +8,30 @@ import Foundation
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
+    enum JuiceMenu {
+        case strawberry, banana, kiwi, pineapple, mango, strawberryBanana, mangoKiwi
+        
+        var recipe: Dictionary<FruitStore.Fruit, Int> {
+            switch self {
+            case .strawberry:
+                return [.strawberry: 16]
+            case .banana:
+                return [.banana: 2]
+            case.kiwi:
+                return [.kiwi: 3]
+            case .pineapple:
+                return [.pineapple: 2]
+            case .mango:
+                return [.mango: 3]
+            case .strawberryBanana:
+                return [.strawberry: 10, .banana: 1]
+            case .mangoKiwi:
+                return [.mango: 2, .kiwi: 1]
+            }
+        }
+    }
+    
+    let fruitStore = FruitStore()
+    
     
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -33,5 +33,10 @@ struct JuiceMaker {
     
     let fruitStore = FruitStore()
     
+    func makeJuice(menu: JuiceMenu) throws {
+        try menu.recipe.forEach {
+            try fruitStore.decreaseFruitStock(fruit: $0.key, quantity: $0.value)
+        }
+    }
     
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -6,12 +6,11 @@
 
 import Foundation
 
-// 쥬스 메이커 타입
 struct JuiceMaker {
     enum JuiceMenu {
         case strawberry, banana, kiwi, pineapple, mango, strawberryBanana, mangoKiwi
         
-        var recipe: Dictionary<FruitStore.Fruit, Int> {
+        fileprivate var recipe: [FruitStore.Fruit: Int] {
             switch self {
             case .strawberry:
                 return [.strawberry: 16]
@@ -31,12 +30,11 @@ struct JuiceMaker {
         }
     }
     
-    let fruitStore = FruitStore()
+    private let fruitStore = FruitStore()
     
     func makeJuice(menu: JuiceMenu) throws {
-        try menu.recipe.forEach {
-            try fruitStore.decreaseFruitStock(fruit: $0.key, quantity: $0.value)
+        for (fruit, quantity) in menu.recipe {
+            try fruitStore.decreaseFruitStock(of: fruit, by: quantity)
         }
     }
-    
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,28 +7,6 @@
 import Foundation
 
 struct JuiceMaker {
-    enum JuiceMenu {
-        case strawberry, banana, kiwi, pineapple, mango, strawberryBanana, mangoKiwi
-        
-        fileprivate var recipe: [FruitStore.Fruit: Int] {
-            switch self {
-            case .strawberry:
-                return [.strawberry: 16]
-            case .banana:
-                return [.banana: 2]
-            case.kiwi:
-                return [.kiwi: 3]
-            case .pineapple:
-                return [.pineapple: 2]
-            case .mango:
-                return [.mango: 3]
-            case .strawberryBanana:
-                return [.strawberry: 10, .banana: 1]
-            case .mangoKiwi:
-                return [.mango: 2, .kiwi: 1]
-            }
-        }
-    }
     
     private let fruitStore = FruitStore()
     
@@ -38,3 +16,4 @@ struct JuiceMaker {
         }
     }
 }
+

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,9 +8,9 @@ import Foundation
 
 struct JuiceMaker {
     
-    private let fruitStore: FruitStorage
+    private let fruitStore: FruitStockManaging
     
-    init(store: FruitStorage) {
+    init(store: FruitStockManaging) {
         self.fruitStore = store
     }
     

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,7 +8,11 @@ import Foundation
 
 struct JuiceMaker {
     
-    private let fruitStore = FruitStore()
+    private let fruitStore: FruitStorage
+    
+    init(store: FruitStorage) {
+        self.fruitStore = store
+    }
     
     func makeJuice(menu: JuiceMenu) throws {
         for (fruit, quantity) in menu.recipe {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -34,7 +34,7 @@ struct JuiceMaker {
     
     func makeJuice(menu: JuiceMenu) throws {
         for (fruit, quantity) in menu.recipe {
-            try fruitStore.decreaseFruitStock(of: fruit, by: quantity)
+            try fruitStore.changeFruitStock(of: fruit, by: quantity, calculate: -)
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMenu.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMenu.swift
@@ -4,9 +4,6 @@
 //
 //  Created by 박병호 on 2021/10/21.
 //
-
-
-
 enum JuiceMenu {
     case strawberry, banana, kiwi, pineapple, mango, strawberryBanana, mangoKiwi
     

--- a/JuiceMaker/JuiceMaker/Model/JuiceMenu.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMenu.swift
@@ -1,0 +1,31 @@
+//
+//  JuiceMenu.swift
+//  JuiceMaker
+//
+//  Created by 박병호 on 2021/10/21.
+//
+
+
+
+enum JuiceMenu {
+    case strawberry, banana, kiwi, pineapple, mango, strawberryBanana, mangoKiwi
+    
+    var recipe: [Fruit: Int] {
+        switch self {
+        case .strawberry:
+            return [.strawberry: 16]
+        case .banana:
+            return [.banana: 2]
+        case.kiwi:
+            return [.kiwi: 3]
+        case .pineapple:
+            return [.pineapple: 2]
+        case .mango:
+            return [.mango: 3]
+        case .strawberryBanana:
+            return [.strawberry: 10, .banana: 1]
+        case .mangoKiwi:
+            return [.mango: 2, .kiwi: 1]
+        }
+    }
+}

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -387,7 +387,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="901"/>
+            <point key="canvasLocation" x="1510" y="912"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="cAf-jL-tPK">
@@ -405,7 +405,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2s5-lS-967" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="21"/>
+            <point key="canvasLocation" x="1510" y="32"/>
         </scene>
     </scenes>
     <resources>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# ios-juice-maker
+iOS 쥬스 메이커 재고관리 시작 저장소
+
+## STEP1
+
+### 고려사항
+1. 코드의 의도
+    - 추후 Controller에서 과일의 재고를 알기 위해  `JuiceMaker` 인스턴스 내부의 `FruitStore` 인스턴스 프로퍼티인 `inventory`에 직접 접근하도록 하는 것 보다, 해당 재고정보를 Controller에게 전달할 수 있는 메서드를 구현하는 것이 캡슐화/은닉화에 더 적합한 것 같아서 `FruitStore` 인스턴스는 `private`로 설정함.
+    - 추후 과일 종류가 추가될 때 `Fruit` 열거형에 `case`로만 추가하면 자동으로 `FruitStore`에 초기화될 수 있도록 열거형에 `CaseIterable` 프로토콜을 채택하고 `FruitStore`의 이니셜라이저에서 `allCases`를 통해 모든 케이스를 딕셔너리 내부에 초기화할 수 있도록 구현함.
+    - 에러 상황들은 View에 `Alert`을 표시하는 방식이 될 것 같아서, 현재 모델에서는 `throw`만 해줬으며 `catch`하여 처리하는 기능은 구현하지 않음. 추후 Controller 구현 시 에러처리를 하게 될 것 같다.
+2. 고민한 것
+    - 딕셔너리로 과일을 관리하는 방법과 `Int`타입 프로퍼티로 관리하는 방법 중 어떤 것이 효율적일까
+    당장은 `Int`타입 프로퍼티로 `var strawberry = 10` 과 같이 쓰는 것이 편리할 것 같기는 하지만, 추후 과일의 종류가 추가되는 상황 등의 유지보수를 위하여 `Dictionary<Fruit, Int>` 타입으로 관리하도록 함.
+    - 과일의 재고를 `UInt`로 저장할지 `Int`로 저장할지 고민했는데, 
+    `UInt`를 쓰면 연산 시 매번 형변환 해야하는 어려움도 있고, 굳이 `UInt`를 쓰지 않아도 음수가 되지 않도록 조건을 걸어주면 되기에 `Int`를 사용하기로 함.
+
+### 구현내용
+#### 주요 타입
+1. FruitStore (class 타입)
+
+	1. 주요 프로퍼티
+		- inventory(Dictionary<Fruit, Int>): (key: 과일의 종류)-(value: 해당 과일의 재고)쌍을 원소로 갖는 딕셔너리.
+
+	1. 주요 메서드
+		- increaseFruitStock: inventory의 과일 재고를 추가하는 함수. 변경할 과일의 종류, 추가할 수량(기본값 = 1)을 매개변수로 전달받는다.
+		- decreaseFruitStock: inventory의 과일 재고를 감소하는 함수. 변경할 과일의 종류, 감소할 수량(기본값 = 1)을 매개변수로 전달받는다.
+
+	1. 중첩 타입
+		- Fruit (enum 타입, CaseIterable 채택): FruitStore에서 관리할 과일의 종류를 정의함. CaseIterable 프로토콜을 채택하여, case가 추가되더라도 inventory에 allCases를 통해 초기화되도록 구현. 
+
+1. JuiceMaker (struct 타입)
+
+	1. 주요 프로퍼티
+		- recipe(Dictionary<Fruit: Int>): 판매하는 주스들의 레시피를 switch 문을 통해 사용되는 과일과 개수를 리턴
+
+	1. 주요 메서드
+		- makeJuice: 주스를 만드는 함수. 만들어야 하는 메뉴를 전달 받아 사용되는 과일의 재고를 감소시킨다.
+
+	1. 중첩 타입
+		- JuiceMenu (enum타입): 주스 메뉴들을 case에 정의하고, 주스의 레시피를 recipe에 정의
+
+1. FruitStoreError (enum 타입, Error 채택) : FruitStore에서 발생할 수 있는 에러를 정의


### PR DESCRIPTION
안녕하세요 메이슨! @myssun0325 

쥬스메이커 STEP1 코드 작성하여 PR 보내드립니다!

## 코드의 의도

 1. 추후 Controller에서 과일의 재고를 알기 위해  `JuiceMaker` 인스턴스 내부의 `FruitStore` 인스턴스 프로퍼티인 `inventory`에 직접 접근하도록 하는 것 보다, 해당 재고정보를 Controller에게 전달할 수 있는 메서드를 구현하는 것이 캡슐화/은닉화에 더 적합한 것 같아서 `FruitStore` 인스턴스는 `private`로 설정함
 1. 추후 과일 종류가 추가될 때 `Fruit` 열거형에 `case`로만 추가하면 자동으로 `FruitStore`에 초기화될 수 있도록 열거형에 `CaseIterable` 프로토콜을 채택하고 `FruitStore`의 이니셜라이저에서 `allCases`를 통해 모든 케이스를 딕셔너리 내부에 초기화할 수 있도록 구현함.
 1. 에러 상황들은 View에 `Alert`을 표시하는 방식이 될 것 같아서, 현재 모델에서는 `throw`만 해줬으며 `catch`하여 처리하는 기능은 구현하지 않음. 추후 Controller 구현 시 에러처리를 하게 될 것 같다.


##  고민한 것

 1. 딕셔너리로 과일을 관리하는 방법과 `Int`타입 프로퍼티로 관리하는 방법 중 어떤 것이 효율적일까
    당장은 `Int`타입 프로퍼티로 `var strawberry = 10` 과 같이 쓰는 것이 편리할 것 같기는 하지만, 추후 과일의 종류가 추가되는 상황 등의 유지보수를 위하여 `Dictionary<Fruit, Int>` 타입으로 관리하도록 함.
 1. 과일의 재고를 `UInt`로 저장할지 `Int`로 저장할지 고민했는데, 
    `UInt`를 쓰면 연산 시 매번 형변환 해야하는 어려움도 있고, 굳이 `UInt`를 쓰지 않아도 음수가 되지 않도록 조건을 걸어주면 되기에 `Int`를 사용하기로 함.


## 질문할 것

 1. 각 타입에 필요한 열거형들을 `Nested`로 정의할지, 외부에 정의할지 결정하는 기준이 뭘까요?
 1. 왜 `FruitStore`는 class로 되어있고 `JuiceMaker`는 struct로 되어있을까요?
    → class와 struct의 용도는 어떻게 다를까?
    
    클래스만 가능한 것들
    - 구조체는 상속할 수 없습니다.
    - 타입캐스팅은 클래스의 인스턴스에만 허용됩니다.
    - 디이니셜라이저는 클래스의 인스턴스에만 활용할 수 있습니다.
    - 참조 횟수 계산(Reference Counting)은 클래스의 인스턴스에만 적용됩니다.

    FruitStore에서 위에 해당하는 항목은 현재까지는 없어보이는데 FruitStore가 class로 되어 있는 이유를 모르겠네요.. ㅠㅠ   
    메이슨은 어떻게 생각하시나요?!
  
