### PR TITLE
쥬스 메이커 [STEP 1] 제이티, Ari

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9A757554271D599A00108EB8 /* RequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A757553271D599A00108EB8 /* RequestError.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		9A757553271D599A00108EB8 /* RequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestError.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -56,6 +58,7 @@
 			children = (
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
+				9A757553271D599A00108EB8 /* RequestError.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -169,6 +172,7 @@
 			files = (
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				9A757554271D599A00108EB8 /* RequestError.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -15,7 +15,7 @@ class FruitStore {
         case mango
     }
     
-    var fruitBasket: [Fruit: Int]
+    private var fruitBasket: [Fruit: Int]
     
     init(count: Int = 10) {
         let allFruits = Fruit.allCases

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -6,6 +6,8 @@
 
 import Foundation
 
+private let defaultFruitCount = 10
+
 class FruitStore {
     enum Fruit: CaseIterable {
         case strawberry
@@ -17,14 +19,22 @@ class FruitStore {
     
     private var fruitBasket: [Fruit: Int]
     
-    init(count: Int = 10) {
+    init(count: Int = defaultFruitCount) {
         let allFruits = Fruit.allCases
         let fruitscount = Array(repeating: count, count: allFruits.count)
         
         self.fruitBasket = Dictionary(uniqueKeysWithValues: zip(allFruits, fruitscount))
     }
     
-    func changeAmount(count: Int, of fruit: Fruit, by calculator: (Int, Int) -> Int) throws {
+    func addFruitStock(fruit: Fruit, count: Int) throws {
+        try changeAmount(count: count, of: fruit, by: +)
+    }
+    
+    func subFruitStock(fruit: Fruit, count: Int) throws {
+        try changeAmount(count: count, of: fruit, by: -)
+    }
+    
+    private func changeAmount(count: Int, of fruit: Fruit, by calculator: (Int, Int) -> Int) throws {
         guard count > 0 else {
             throw RequestError.wrongCount
         }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -6,7 +6,40 @@
 
 import Foundation
 
-// 과일 저장소 타입
 class FruitStore {
+    enum Fruit: CaseIterable {
+        case strawberry
+        case banana
+        case pineapple
+        case kiwi
+        case mango
+    }
     
+    var fruitBasket: [Fruit: Int]
+    
+    init(count: Int = 10) {
+        let allFruits = Fruit.allCases
+        let fruitscount = Array(repeating: count, count: allFruits.count)
+        
+        self.fruitBasket = Dictionary(uniqueKeysWithValues: zip(allFruits, fruitscount))
+    }
+    
+    func changeAmount(count: Int, of fruit: Fruit, by calculator: (Int, Int) -> Int) {
+        guard count > 0 else {
+            print("수량을 잘못 입력하였습니다.")
+            return
+        }
+        guard let oldFruitCount = fruitBasket[fruit] else {
+            print("선택한 과일이 존재하지 않습니다.")
+            return
+        }
+        let newFruitCount = calculator(oldFruitCount, count)
+        guard newFruitCount >= 0 else {
+            print("과일의 재고가 부족합니다.")
+            return
+        }
+        fruitBasket[fruit] = newFruitCount
+    }
 }
+
+

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -31,10 +31,10 @@ class FruitStore {
         guard let oldFruitCount = fruitBasket[fruit] else {
             throw RequestError.fruitNotFound
         }
-        let newFruitCount = calculator(oldFruitCount, count)
-        guard newFruitCount >= 0 else {
+        guard count <= oldFruitCount else {
             throw RequestError.fruitStockOut
         }
+        let newFruitCount = calculator(oldFruitCount, count)
         fruitBasket[fruit] = newFruitCount
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -37,6 +37,11 @@ class FruitStore {
         let newFruitCount = calculator(oldFruitCount, count)
         fruitBasket[fruit] = newFruitCount
     }
+    
+    func hasFruitStock(of fruit: Fruit, count fruitCountSubtracted: Int) -> Bool {
+        guard let currentFruitAmount = fruitBasket[fruit] else { return false }
+        return currentFruitAmount >= fruitCountSubtracted
+    }
 }
 
 

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -24,19 +24,16 @@ class FruitStore {
         self.fruitBasket = Dictionary(uniqueKeysWithValues: zip(allFruits, fruitscount))
     }
     
-    func changeAmount(count: Int, of fruit: Fruit, by calculator: (Int, Int) -> Int) {
+    func changeAmount(count: Int, of fruit: Fruit, by calculator: (Int, Int) -> Int) throws {
         guard count > 0 else {
-            print("수량을 잘못 입력하였습니다.")
-            return
+            throw RequestError.wrongCount
         }
         guard let oldFruitCount = fruitBasket[fruit] else {
-            print("선택한 과일이 존재하지 않습니다.")
-            return
+            throw RequestError.fruitNotFound
         }
         let newFruitCount = calculator(oldFruitCount, count)
         guard newFruitCount >= 0 else {
-            print("과일의 재고가 부족합니다.")
-            return
+            throw RequestError.fruitStockOut
         }
         fruitBasket[fruit] = newFruitCount
     }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -6,7 +6,8 @@
 
 import Foundation
 
-// 쥬스 메이커 타입
 struct JuiceMaker {
     
 }
+
+

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -6,9 +6,10 @@
 
 import Foundation
 
-typealias Recipe = [FruitStore.Fruit: Int]
 
 struct JuiceMaker {
+    typealias Recipe = [FruitStore.Fruit: Int]
+
     enum Juice {
         case strawberry
         case banana

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -20,15 +20,14 @@ struct JuiceMaker {
     }
     
     let fruitStore = FruitStore()
-    
     let juiceRecipes: [Juice: Recipe] = [
-        .strawberry: [.strawberry: 16],
-        .banana: [.banana: 2],
-        .kiwi: [.kiwi: 3],
-        .pineapple: [.pineapple: 2],
-        .strawberryBanana: [.strawberry: 10, .banana: 1],
-        .mango: [.mango: 3],
-        .mangoKiwi: [.mango: 2, .kiwi: 1]
+        Juice.strawberry: [.strawberry: 16],
+        Juice.banana: [.banana: 2],
+        Juice.kiwi: [.kiwi: 3],
+        Juice.pineapple: [.pineapple: 2],
+        Juice.strawberryBanana: [.strawberry: 10, .banana: 1],
+        Juice.mango: [.mango: 3],
+        Juice.mangoKiwi: [.mango: 2, .kiwi: 1]
     ]
     
     func fruitsMixer(juice: Juice) throws {
@@ -40,8 +39,6 @@ struct JuiceMaker {
             try fruitStore.changeAmount(count: count, of: fruit, by: -)
             print("fruit: \(fruit) count: \(count)")
         }
-        
-        print("주스가 완성되었습니다")
     }
     
     func canMakeJuice(recipe: Recipe) -> Bool {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -33,12 +33,23 @@ struct JuiceMaker {
     
     func fruitsMixer(juice: Juice) throws {
         guard let recipe = juiceRecipes[juice] else { return }
+        guard canMakeJuice(recipe: recipe) else {
+            throw RequestError.fruitStockOut
+        }
         try recipe.forEach { (fruit, count) in
             try fruitStore.changeAmount(count: count, of: fruit, by: -)
             print("fruit: \(fruit) count: \(count)")
         }
         
         print("주스가 완성되었습니다")
+    }
+    
+    func canMakeJuice(recipe: Recipe) -> Bool {
+        return recipe.reduce(true) {
+            let fruit = $1.key
+            let count = $1.value
+            return $0 && fruitStore.hasFruitStock(of: fruit, count: count)
+        }
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -36,7 +36,7 @@ struct JuiceMaker {
             throw RequestError.fruitStockOut
         }
         try juiceRecipe.forEach { (fruit, count) in
-            try fruitStore.changeAmount(count: count, of: fruit, by: -)
+            try fruitStore.subFruitStock(fruit: fruit, count: count)
             print("fruit: \(fruit) count: \(count)")
         }
     }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,7 +7,17 @@
 import Foundation
 
 struct JuiceMaker {
+    enum Juice {
+        case strawberry
+        case banana
+        case kiwi
+        case pineapple
+        case strawberryBanana
+        case mango
+        case mangoKiwi
+    }
     
+    let fruitStore = FruitStore()
 }
 
 

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -6,6 +6,8 @@
 
 import Foundation
 
+typealias Recipe = [FruitStore.Fruit: Int]
+
 struct JuiceMaker {
     enum Juice {
         case strawberry
@@ -18,6 +20,26 @@ struct JuiceMaker {
     }
     
     let fruitStore = FruitStore()
+    
+    let juiceRecipes: [Juice: Recipe] = [
+        .strawberry: [.strawberry: 16],
+        .banana: [.banana: 2],
+        .kiwi: [.kiwi: 3],
+        .pineapple: [.pineapple: 2],
+        .strawberryBanana: [.strawberry: 10, .banana: 1],
+        .mango: [.mango: 3],
+        .mangoKiwi: [.mango: 2, .kiwi: 1]
+    ]
+    
+    func fruitsMixer(juice: Juice) throws {
+        guard let recipe = juiceRecipes[juice] else { return }
+        try recipe.forEach { (fruit, count) in
+            try fruitStore.changeAmount(count: count, of: fruit, by: -)
+            print("fruit: \(fruit) count: \(count)")
+        }
+        
+        print("주스가 완성되었습니다")
+    }
 }
 
 

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -31,11 +31,11 @@ struct JuiceMaker {
     ]
     
     func fruitsMixer(juice: Juice) throws {
-        guard let recipe = juiceRecipes[juice] else { return }
-        guard canMakeJuice(recipe: recipe) else {
+        guard let juiceRecipe = juiceRecipes[juice] else { return }
+        guard canMakeJuice(recipe: juiceRecipe) else {
             throw RequestError.fruitStockOut
         }
-        try recipe.forEach { (fruit, count) in
+        try juiceRecipe.forEach { (fruit, count) in
             try fruitStore.changeAmount(count: count, of: fruit, by: -)
             print("fruit: \(fruit) count: \(count)")
         }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -19,8 +19,8 @@ struct JuiceMaker {
         case mangoKiwi
     }
     
-    let fruitStore = FruitStore()
-    let juiceRecipes: [Juice: Recipe] = [
+    private let fruitStore = FruitStore()
+    private let juiceRecipes: [Juice: Recipe] = [
         Juice.strawberry: [.strawberry: 16],
         Juice.banana: [.banana: 2],
         Juice.kiwi: [.kiwi: 3],
@@ -41,7 +41,7 @@ struct JuiceMaker {
         }
     }
     
-    func canMakeJuice(recipe: Recipe) -> Bool {
+    private func canMakeJuice(recipe: Recipe) -> Bool {
         return recipe.reduce(true) {
             let fruit = $1.key
             let count = $1.value
@@ -49,5 +49,3 @@ struct JuiceMaker {
         }
     }
 }
-
-

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -37,7 +37,6 @@ struct JuiceMaker {
         }
         try juiceRecipe.forEach { (fruit, count) in
             try fruitStore.subFruitStock(fruit: fruit, count: count)
-            print("fruit: \(fruit) count: \(count)")
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Model/RequestError.swift
+++ b/JuiceMaker/JuiceMaker/Model/RequestError.swift
@@ -1,0 +1,25 @@
+//
+//  RequestError.swift
+//  JuiceMaker
+//
+//  Created by 이아리 on 2021/10/18.
+//
+
+import Foundation
+
+enum RequestError: Error {
+    case wrongCount
+    case fruitNotFound
+    case fruitStockOut
+    
+    func printErrorMessage() {
+        switch self {
+        case RequestError.wrongCount:
+            print("수량을 잘못 입력하였습니다.")
+        case RequestError.fruitNotFound:
+            print("선택한 과일이 존재하지 않습니다.")
+        case RequestError.fruitStockOut:
+            print("과일의 재고가 부족합니다.")
+        }
+    }
+}

--- a/JuiceMaker/JuiceMaker/Model/RequestError.swift
+++ b/JuiceMaker/JuiceMaker/Model/RequestError.swift
@@ -7,19 +7,19 @@
 
 import Foundation
 
-enum RequestError: Error {
+enum RequestError: Error, LocalizedError {
     case wrongCount
     case fruitNotFound
     case fruitStockOut
     
-    func printErrorMessage() {
+    var errorDescription: String {
         switch self {
         case RequestError.wrongCount:
-            print("수량을 잘못 입력하였습니다.")
+            return "수량을 잘못 입력하였습니다."
         case RequestError.fruitNotFound:
-            print("선택한 과일이 존재하지 않습니다.")
+            return "선택한 과일이 존재하지 않습니다."
         case RequestError.fruitStockOut:
-            print("과일의 재고가 부족합니다.")
+            return "과일의 재고가 부족합니다."
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -24,13 +25,13 @@
                                         <rect key="frame" x="0.0" y="0.0" width="132" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="132" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -42,13 +43,13 @@
                                         <rect key="frame" x="148" y="0.0" width="132" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="132" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -60,13 +61,13 @@
                                         <rect key="frame" x="296" y="0.0" width="132" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="132" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -78,13 +79,13 @@
                                         <rect key="frame" x="444" y="0.0" width="132" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="132" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -96,13 +97,13 @@
                                         <rect key="frame" x="592" y="0.0" width="132" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="132" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -255,13 +256,13 @@
                                         <rect key="frame" x="0.0" y="0.0" width="132" height="195"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="28.666666666666671" y="0.0" width="75" height="120.66666666666667"/>
+                                                <rect key="frame" x="28.666666666666671" y="0.0" width="75" height="124"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="0.0" y="128.66666666666666" width="132" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="132" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -279,13 +280,13 @@
                                         <rect key="frame" x="148" y="0.0" width="132" height="195"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="28.666666666666657" y="0.0" width="75" height="120.66666666666667"/>
+                                                <rect key="frame" x="28.666666666666657" y="0.0" width="75" height="124"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="0.0" y="128.66666666666666" width="132" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="132" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -303,13 +304,13 @@
                                         <rect key="frame" x="296" y="0.0" width="132" height="195"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="28.666666666666686" y="0.0" width="75" height="120.66666666666667"/>
+                                                <rect key="frame" x="28.666666666666686" y="0.0" width="75" height="124"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="0.0" y="128.66666666666666" width="132" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="132" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -327,13 +328,13 @@
                                         <rect key="frame" x="444" y="0.0" width="132" height="195"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="28.666666666666629" y="0.0" width="75" height="120.66666666666667"/>
+                                                <rect key="frame" x="28.666666666666629" y="0.0" width="75" height="124"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="0.0" y="128.66666666666666" width="132" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="132" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -351,13 +352,13 @@
                                         <rect key="frame" x="592" y="0.0" width="132" height="195"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="28.666666666666629" y="0.0" width="75" height="120.66666666666667"/>
+                                                <rect key="frame" x="28.666666666666629" y="0.0" width="75" height="124"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="0.0" y="128.66666666666666" width="132" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="132" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,202 @@
+# 목차
+- [📝 동기화 메모장](#---------)
+- [키워드](#키워드)
+- [Contributors](#Contributors)
+- [Reviewers](#Reviewers)
+- [STEP 1 : 쥬스 메이커 타입 정의](#STEP-1--쥬스-메이커-타입-정의)
+    + [고민했던 것](#1-1-고민했던-것)
+    + [의문점](#1-2-의문점)
+    + [Trouble Shooting](#1-3-Trouble-Shooting)
+    + [배운 개념](#1-4-배운-개념)
+
+# 📝 동기화 메모장
+
+1. 프로젝트 기간: 2021.10.18 - 2021.11.05
+2. Grounds Rules
+    - Time Rule
+        - 아침: 10시
+        - 점심시간: 12시~ 1시
+        - 저녁시간: 6시~7시
+        - 프로젝트 최대 제한시간: 저녁 9시 ~ 최대 9시 30분 까지!
+3. 커밋 규칙
+    - 단위 : 기능 단위로
+    - Convention: Karma Style
+
+# 키워드
+
+- `struct`, `class`, `enum`
+- `Initialization`
+- `Nested Types`
+- `Dictionary`
+- `zip`
+- `typealias`
+- `Function Types as Parameter Types`
+- `Type Casting`
+- `Error Handling`
+- `Access Control`
+
+# Contributors
+
+@CodingJT @leeari95
+
+# Reviewers
+
+@daheenallwhite
+
+# STEP 1 : **쥬스 메이커 타입 정의**
+
+- 쥬스메이커 타입을 정의합니다.
+
+## 1-1. 고민했던 것
+
+- 과일과 주스를 사용자 정의 타입 `enum`으로 구현하는 것
+- 초기 재고 10개를 어떻게 기본값으로 초기화 해줄 것인지에 대한 고민
+    - `Dictionary`의 `init(uniqueKeysWithValues:)`, `zip`
+    - 코드 가독성을 위하여 전역변수 `defaultFruitCount`를 생성
+- 각 주스 제조에 필요한 과일의 갯수를 저장하는 방법에 대한 고민
+    - 코드 내부 가독성을 위해 `typealias`를 활용하여 `Recipe` 를 정의해준 부분
+    - `Dictionary` 를 활용하여 `key`에는 주스, `value`에는 재료가 들어가게 구성
+- `Juice` 타입을 파라미터로 받아서 레시피를 조회하여, 필요한 과일의 갯수를 재고에서 차감해주는 방법에 대한 고민
+    - 레시피 내부에 **과일 종류**와 **과일 갯수**를 받아서 과일의 재고가 있는지 확인하는 것
+    - 재고가 부족하다면 **예외처리**를 하도록 구현
+
+## 1-2. 의문점
+
+- `Nested Type`을 이용하여 `JuiceMaker` 타입 내부에 `Juice` 타입을 작성하는 것이 좋은 방법인지 의문이 들었다. 내부에 타입을 작성을 해준 이유는 `Juice`타입을 타입 내부에서만 사용하고 있기 때문인데, 이게 적절한 방법인지 의문이 들었다. `Juice` 타입의 값을 사용하고자 할 때에 `JuiceMaker.Juice.strawberry`와 같은 형태로 길게 작성을 해야하는데, 그렇다면 바깥에 타입을 생성하는게 좋은걸까? 가독성 측면에서 어떤 것이 좋은 방법인지 의문이 들었다.
+- 예외처리를 해주었는데 `do-catch`를 활용하여 에러를 처리해주는 부분은 구현하지 않았다. 이유는 나중에 `Controller`에서 사용할 때 처리해주어야 한다고 생각했기 때문인데, `Model`에서 미리 구현을 해놔야하는건지 헷갈린다.
+- `JuiceMaker` 타입에 구현한 메소드 `fruitsMixer(juice:)` 코드를 아래와 같이 구현해주었다.
+    
+    ```swift
+    // JuiceMaker 타입 내부의 메소드 fruitsMixer
+    func fruitsMixer(juice: Juice) throws {
+        guard let juiceRecipe = juiceRecipes[juice] else { return }
+        guard canMakeJuice(recipe: juiceRecipe) else {
+            throw RequestError.fruitStockOut
+        }
+        try juiceRecipe.forEach { (fruit, count) in
+            try fruitStore.subFruitStock(fruit: fruit, count: count)
+        }
+    }
+    ```
+    
+    `canMakeJuice(recipe:)`를 이용해 주스를 만들 수 있는지 미리 검증해주고 있고, 해당 코드의 아래에서 사용하는 `FruitStore` 타입의 `subFruitStock(fruit:count:)` 메소드에서도 주스를 만들 수 있는지 검증해주고 있다. 즉 이중으로 검증하고 있는 것인데 불필요한 작업이 아닌가 의문이 든다.
+    
+
+## 1-3. Trouble Shooting
+
+- `Error` 메세지를 출력하려고 코드를 작성하면서 알아냈던 방법들
+    1. `enum`안에 `static` 키워드를 활용하여 메서드 작성
+    2. `static` 키워드를 없애고 `as`로 다운캐스팅하여 사용
+    
+    ```swift
+    enum RequestError: Error {
+        case wrongInput
+        case notFound
+        case fruitStockOut
+        
+        func printErrorMessage() {
+            switch self {
+            case RequestError.wrongInput:
+                print("수량을 잘못 입력하였습니다.")
+            case RequestError.notFound:
+                print("선택한 과일이 존재하지 않습니다.")
+            case RequestError.fruitStockOut:
+                print("과일의 재고가 부족합니다.")
+            }
+        }
+    }
+    do {
+        try maker.fruitsMixer(juice: .strawberryBanana)
+    } catch let error as RequestError {
+        error.printErrorMessage()
+    }
+    ```
+    
+    1. `LocalizedError` 프로토콜을 채택하여 `errorDescription` 프로퍼티 작성하여 활용 (현재)
+    
+    ```swift
+    enum RequestError: Error, LocalizedError {
+        case wrongCount
+        case fruitNotFound
+        case fruitStockOut
+        
+        var errorDescription: String {
+            switch self {
+            case RequestError.wrongCount:
+                return "수량을 잘못 입력하였습니다."
+            case RequestError.fruitNotFound:
+                return "선택한 과일이 존재하지 않습니다."
+            case RequestError.fruitStockOut:
+                return "과일의 재고가 부족합니다."
+            }
+        }
+    }
+    ```
+    
+
+- `Dictionary(uniqueKeysWithValues:)`와 `zip` 사용하면서 Sequence의 대한 정확한 개념에 대해서 알아보았다.
+    - `Sequence`는 원소들을 순서대로 하나씩 순회할 수 있는 타입을 의미한다.
+    - `Sequence`에는 `range`만 들어가는 줄 알았는데 `Array`도 넣을 수 있었다.
+    - `Array`는 `Sequence` 프로토콜을 기반으로 작성되었다는 사실을 알았다. `Array` 타입을 사용할 때 `Sequence`의 대부분의 기능을 제공해준다. `map`, `filter`뿐만 아니라 `Sequence` 안에서 특정 조건을 만족하는 첫번째 요소를 찾는 기능 까지 모두 다 `Sequence` 프로토콜 안에 정의되어 있다.
+    - `Sequence`는 두가지 중요한 특징이 있는데 무한하거나, 유한하다. 그리고 한번만 이터레이트(`iterate`)할 수 있다.
+    
+- 각 주스를 만드는 데에 필요한 과일의 수를 저장하는 방법에 대해 고민해보았다.
+    - 초기에 작성한 코드는 아래와 같은 형태로 `switch문`을 이용해 만들어줄 주스에 따라 하드코딩으로 필요한 과일의 수를 넣어주었다.
+        
+        ```swift
+        func fruitsMixer(juice: Juice) {
+            switch juice {
+            case .strawberry:
+                ...
+            case .banana:
+                ...
+            case .kiwi:
+                ...
+            case .pineapple:
+                ...
+            case .strawberryBanana:
+                ...
+            case .mango:
+                ...
+            case .mangoKiwi:
+                ...
+            }
+        }
+        ```
+        
+    - 위에서 작성한 `fruitsMixer(juice:)`의 코드를 더 간결하게 작성하고 싶었고 `Dictionary`를 이용하여 해당 문제를 해결하였다.
+        
+        ```swift
+        typealias Recipe = [FruitStore.Fruit: Int]
+        
+        private let juiceRecipes: [Juice: Recipe] = [
+            Juice.strawberry: [.strawberry: 16],
+            Juice.banana: [.banana: 2],
+            Juice.kiwi: [.kiwi: 3],
+            Juice.pineapple: [.pineapple: 2],
+            Juice.strawberryBanana: [.strawberry: 10, .banana: 1],
+            Juice.mango: [.mango: 3],
+            Juice.mangoKiwi: [.mango: 2, .kiwi: 1]
+        ]
+        
+        func fruitsMixer(juice: Juice) throws {
+            guard let juiceRecipe = juiceRecipes[juice] else { return }
+          ...
+          try juiceRecipe.forEach { (fruit, count) in
+              try fruitStore.subFruitStock(fruit: fruit, count: count)
+          }
+        }
+        ```
+        
+
+## 1-4. 배운 개념
+
+- 에러 메세지를 출력할 때 사용할 수 있는 다양한 방법
+- `Nested Type`을 적절하게 활용하는 방법
+- `typealias`를 활용하여 가독성을 높이는 방법
+- 함수 내에서 클로저를 파라미터로 받아  +, - 등 연산자 기호를 해당 함수에 전달하여 사용하는 방법
+    - 연산자(+, -)도 하나의 함수였다.
+    `static func + (lhs: Int, rhs: Int) -> Int`
+    - 연산자 기호를 파라미터로 전달할 수 있다.
+    `changeAmount(count: count, of: fruit, by: -)`
+- `Sequence`의 대한 개념


### PR DESCRIPTION
@daheenallwhite 
@CodingJT @leeari95

안녕하세요 흰! 
생각보다 STEP 1을 빨리 구현해서 코드에 허점이 많지 않을까 걱정이 들지만, 저희끼리 충분히 고민해서 고쳐볼 수 있는 부분을 고민하고 고쳐서 PR 보내드립니다. 
저희가 놓친 부분이 있다면 번거롭더라도 한 번만 더 짚어주신다면 감사드리겠습니다.

잘 부탁드립니다...! 😁

## 고민했던 것

- 과일과 주스를 사용자 정의 타입 `enum`으로 구현하는 것
- 초기 재고 10개를 어떻게 기본값으로 초기화 해줄 것인지에 대한 고민
    - `Dictionary`의 `init(uniqueKeysWithValues:)`, `zip`
- 각 주스 제조에 필요한 과일의 갯수를 저장하는 방법에 대한 고민 (레시피)
    - typealias `Recipe`
    - `Dictionary` 활용
- `Juice` 타입을 파라미터로 받아서 레시피에 있는 과일의 갯수를 차감해주는 방법에 대한 고민
    - 레시피 내부에 **과일 종류**와 **과일 갯수**를 받아서 과일의 재고가 있는지 확인하는 것
    - 재고가 부족하다면 **예외처리**를 하도록 구현

## 궁금했던 것 / 조언을 얻고 싶은 부분

- 전체적으로 네이밍을 잘 하였는지 궁금합니다.
- 에러처리를 해주었는데, **do-catch**를 활용하여 에러를 처리해주는 부분은 구현하지 않았습니다. 나중에 **Controller**에서 사용할 때 처리해주어야 한다고 생각이 들었기 때문인데 맞는거겠죠? 아니면 Model에서 미리 구현을 해놔야하는 건지.. 헷갈립니다.
- **Nested Type**을 잘 활용하였는지에 관해 궁금합니다.
    - 현재 구현한 코드에서는 `FruitStore` 내부에 `Fruit` 타입을, `JuiceMaker` 내부에 `Juice` 타입을 구현해주었습니다. 둘다 연관된 타입이라고 생각해서 내부에 구현을 해줬는데요.
    - 해당 코드대로면 예시로 `Controller`에서 `Juice` 타입의 값을 활용하고 싶을 때 `JuiceMaker.Juice.strawberry`와 같은 형태로 작성해야 하는데, 이게 가독성 측면에서 적절한 구현인지 궁금합니다.
- `init(count:)` 코드에서 기본값을 명확하게 적어주기 위해 전역 변수  `defaultFruitCount`를 정의해주었습니다. `private` 접근 제어자를 이용해 전역 변수지만 외부에서 접근할 수 없도록 구현하였는데, 전역 변수를 사용하는 게 적절한지, 아니면 `FruitStore` 내부에서 `static parameter`로 정의하여 사용하는 게 좋을지(또는 그 외의 방법이 있는지) 궁금합니다!
- 저희가 `typealias` 키워드를 사용해서 `Recipe`라는 것을 정의 해줬는데요. `Recipe`라는 타입을 `JuiceMaker` 타입 내부에서만 사용한다는 이유로 내부에 정의를 해줬습니다. 이 부분에 대한 흰의 의견을 듣고싶습니다!
- 맨 처음 `changeAmount` 라는 메서드를 통해서 과일의 재고를 관리해주었는데요. 생각해보니 뭔가 `changeAmount` 메서드가 **더하기, 빼기, 곱하기**를 다 할 수 있어서 하는 일을 **명확하게 해주기 위해** `addFruitStock, subFruitStock` 메서드를 별도로 구현해서 `changeAmount`를 활용하는 방식으로 변경해주었어요. 변경해준 이 방식이 적절한건지 판단이 잘 안서서 이 부분에 대한 흰의 의견을 듣고 싶습니다.
- `JuiceMaker` 타입에 구현한 메소드 `fruitsMixer(juice:)` 코드를 아래와 같이 구현해주었습니다.
    
    ```swift
    // JuiceMaker 타입 내부의 메소드 fruitsMixer
    func fruitsMixer(juice: Juice) throws {
        guard let juiceRecipe = juiceRecipes[juice] else { return }
        guard canMakeJuice(recipe: juiceRecipe) else {
            throw RequestError.fruitStockOut
        }
        try juiceRecipe.forEach { (fruit, count) in
            try fruitStore.subFruitStock(fruit: fruit, count: count)
        }
    }
    ```
    
    `canMakeJuice(recipe:)`메서드 내부에서 
    `hasFruitStock`를 호출하여 `fruitBasket[fruit]`을 옵셔널 바인딩 (currentFruitAmount)
    `changeAmount` 내부에서 `fruitBasket[fruit]`을 옵셔널 바인딩 (oldFruitCount)
    이렇게 동일한 값을 서로 다른 메서드에서 옵셔널 바인딩을 해주고 있는데요. 즉, 이중으로 검증을 하고 있는 것처럼 보여져서 이것을 개선할 수 있을지에 대한 조언을 듣고 싶습니다.