### PR TITLE
쥬스 메이커 [STEP3] 아샌, 애플사이다

### DIFF
--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -28,14 +28,14 @@ class EditStockViewController: UIViewController {
         fruitStockLabels[indexOfFruit].text = "\(store.inventory[indexOfFruit].count)"
     }
 
-    private func initializeStocktepper(at indexOfFruit: Int) {
+    private func initializeStockStepper(at indexOfFruit: Int) {
         fruitstockSteppers[indexOfFruit].value = Double(store.inventory[indexOfFruit].count)
     }
     
     private func initializeUIElements() {
         for indexOfFruit in 0..<fruitStockLabels.count {
             initializeStockLabel(at: indexOfFruit)
-            initializeStocktepper(at: indexOfFruit)
+            initializeStockStepper(at: indexOfFruit)
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -39,11 +39,32 @@ class EditStockViewController: UIViewController {
         }
     }
     
-    func EditStock(changedStock: Int, fruit: FruitName) {
+    func editStock(changedStock: Int, fruit: FruitName) {
         let indexOfFruit = store.findIndexFromInventory(with: fruit)
         let currentStock = store.inventory[indexOfFruit].count
         let stockDifference = changedStock - currentStock
         store.addStock(count: stockDifference, to: fruit)
+    }
+    
+    @IBAction func strawberryStockStepperValueChanged(_ sender: UIStepper) {
+        strawberryStockLabel.text = Int(sender.value).description
+        editStock(changedStock: Int(sender.value), fruit: .strawberry)
+    }
+    @IBAction func bananaStockStepperValueChanged(_ sender: UIStepper) {
+        bananaStockLabel.text = Int(sender.value).description
+        editStock(changedStock: Int(sender.value), fruit: .banana)
+    }
+    @IBAction func pineappleStockStepperValueChanged(_ sender: UIStepper) {
+        pineappleStockLabel.text = Int(sender.value).description
+        editStock(changedStock: Int(sender.value), fruit: .pineapple)
+    }
+    @IBAction func kiwiStockStepperValueChanged(_ sender: UIStepper) {
+        kiwiStockLabel.text = Int(sender.value).description
+        editStock(changedStock: Int(sender.value), fruit: .kiwi)
+    }
+    @IBAction func mangoStockStepperValueChanged(_ sender: UIStepper) {
+        mangoStockLabel.text = Int(sender.value).description
+        editStock(changedStock: Int(sender.value), fruit: .mango)
     }
     
     @IBAction func tapDoneButton(_ sender: UIBarButtonItem) {

--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -2,6 +2,18 @@ import UIKit
 
 class EditStockViewController: UIViewController {
 
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var mangoStockLabel: UILabel!
+    
+    @IBOutlet weak var strawberryStockStepper: UIStepper!
+    @IBOutlet weak var bananaStockStepper: UIStepper!
+    @IBOutlet weak var pineappleStockStepper: UIStepper!
+    @IBOutlet weak var kiwiStockStepper: UIStepper!
+    @IBOutlet weak var mangoStockStepper: UIStepper!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -16,6 +16,8 @@ class EditStockViewController: UIViewController {
     @IBOutlet weak var mangoStockStepper: UIStepper!
     @IBOutlet var fruitstockSteppers: [UIStepper]!
     
+    let store = FruitStore.shared
+
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -39,6 +39,13 @@ class EditStockViewController: UIViewController {
         }
     }
     
+    func EditStock(changedStock: Int, fruit: FruitName) {
+        let indexOfFruit = store.findIndexFromInventory(with: fruit)
+        let currentStock = store.inventory[indexOfFruit].count
+        let stockDifference = changedStock - currentStock
+        store.addStock(count: stockDifference, to: fruit)
+    }
+    
     @IBAction func tapDoneButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true)
     }

--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -22,6 +22,14 @@ class EditStockViewController: UIViewController {
         super.viewDidLoad()
     }
     
+    func initializeStockLabel(at indexOfFruit: Int) {
+        fruitStockLabels[indexOfFruit].text = "\(store.inventory[indexOfFruit].count)"
+    }
+
+    func initializeStocktepper(at indexOfFruit: Int) {
+        fruitstockSteppers[indexOfFruit].value = Double(store.inventory[indexOfFruit].count)
+    }
+    
     @IBAction func tapDoneButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true)
     }

--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -7,12 +7,14 @@ class EditStockViewController: UIViewController {
     @IBOutlet weak var pineappleStockLabel: UILabel!
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
+    @IBOutlet var fruitStockLabels: [UILabel]!
     
     @IBOutlet weak var strawberryStockStepper: UIStepper!
     @IBOutlet weak var bananaStockStepper: UIStepper!
     @IBOutlet weak var pineappleStockStepper: UIStepper!
     @IBOutlet weak var kiwiStockStepper: UIStepper!
     @IBOutlet weak var mangoStockStepper: UIStepper!
+    @IBOutlet var fruitstockSteppers: [UIStepper]!
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -2,21 +2,21 @@ import UIKit
 
 class EditStockViewController: UIViewController {
 
-    @IBOutlet weak var strawberryStockLabel: UILabel!
-    @IBOutlet weak var bananaStockLabel: UILabel!
-    @IBOutlet weak var pineappleStockLabel: UILabel!
-    @IBOutlet weak var kiwiStockLabel: UILabel!
-    @IBOutlet weak var mangoStockLabel: UILabel!
-    @IBOutlet var fruitStockLabels: [UILabel]!
+    @IBOutlet private weak var strawberryStockLabel: UILabel!
+    @IBOutlet private weak var bananaStockLabel: UILabel!
+    @IBOutlet private weak var pineappleStockLabel: UILabel!
+    @IBOutlet private weak var kiwiStockLabel: UILabel!
+    @IBOutlet private weak var mangoStockLabel: UILabel!
+    @IBOutlet private var fruitStockLabels: [UILabel]!
     
-    @IBOutlet weak var strawberryStockStepper: UIStepper!
-    @IBOutlet weak var bananaStockStepper: UIStepper!
-    @IBOutlet weak var pineappleStockStepper: UIStepper!
-    @IBOutlet weak var kiwiStockStepper: UIStepper!
-    @IBOutlet weak var mangoStockStepper: UIStepper!
-    @IBOutlet var fruitstockSteppers: [UIStepper]!
+    @IBOutlet private weak var strawberryStockStepper: UIStepper!
+    @IBOutlet private weak var bananaStockStepper: UIStepper!
+    @IBOutlet private weak var pineappleStockStepper: UIStepper!
+    @IBOutlet private weak var kiwiStockStepper: UIStepper!
+    @IBOutlet private weak var mangoStockStepper: UIStepper!
+    @IBOutlet private var fruitstockSteppers: [UIStepper]!
     
-    let store = FruitStore.shared
+    private let store = FruitStore.shared
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -45,28 +45,28 @@ class EditStockViewController: UIViewController {
         store.addStock(count: stockDifference, to: fruit)
     }
     
-    @IBAction func strawberryStockStepperValueChanged(_ sender: UIStepper) {
+    @IBAction private func strawberryStockStepperValueChanged(_ sender: UIStepper) {
         strawberryStockLabel.text = Int(sender.value).description
         editStock(changedStock: Int(sender.value), fruit: .strawberry)
     }
-    @IBAction func bananaStockStepperValueChanged(_ sender: UIStepper) {
+    @IBAction private func bananaStockStepperValueChanged(_ sender: UIStepper) {
         bananaStockLabel.text = Int(sender.value).description
         editStock(changedStock: Int(sender.value), fruit: .banana)
     }
-    @IBAction func pineappleStockStepperValueChanged(_ sender: UIStepper) {
+    @IBAction private func pineappleStockStepperValueChanged(_ sender: UIStepper) {
         pineappleStockLabel.text = Int(sender.value).description
         editStock(changedStock: Int(sender.value), fruit: .pineapple)
     }
-    @IBAction func kiwiStockStepperValueChanged(_ sender: UIStepper) {
+    @IBAction private func kiwiStockStepperValueChanged(_ sender: UIStepper) {
         kiwiStockLabel.text = Int(sender.value).description
         editStock(changedStock: Int(sender.value), fruit: .kiwi)
     }
-    @IBAction func mangoStockStepperValueChanged(_ sender: UIStepper) {
+    @IBAction private func mangoStockStepperValueChanged(_ sender: UIStepper) {
         mangoStockLabel.text = Int(sender.value).description
         editStock(changedStock: Int(sender.value), fruit: .mango)
     }
     
-    @IBAction func tapDoneButton(_ sender: UIBarButtonItem) {
+    @IBAction private func tapDoneButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -20,6 +20,8 @@ class EditStockViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        initializeUIElements()
     }
     
     func initializeStockLabel(at indexOfFruit: Int) {
@@ -28,6 +30,13 @@ class EditStockViewController: UIViewController {
 
     func initializeStocktepper(at indexOfFruit: Int) {
         fruitstockSteppers[indexOfFruit].value = Double(store.inventory[indexOfFruit].count)
+    }
+    
+    func initializeUIElements() {
+        for indexOfFruit in 0..<fruitStockLabels.count {
+            initializeStockLabel(at: indexOfFruit)
+            initializeStocktepper(at: indexOfFruit)
+        }
     }
     
     @IBAction func tapDoneButton(_ sender: UIBarButtonItem) {

--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -24,22 +24,22 @@ class EditStockViewController: UIViewController {
         initializeUIElements()
     }
     
-    func initializeStockLabel(at indexOfFruit: Int) {
+    private func initializeStockLabel(at indexOfFruit: Int) {
         fruitStockLabels[indexOfFruit].text = "\(store.inventory[indexOfFruit].count)"
     }
 
-    func initializeStocktepper(at indexOfFruit: Int) {
+    private func initializeStocktepper(at indexOfFruit: Int) {
         fruitstockSteppers[indexOfFruit].value = Double(store.inventory[indexOfFruit].count)
     }
     
-    func initializeUIElements() {
+    private func initializeUIElements() {
         for indexOfFruit in 0..<fruitStockLabels.count {
             initializeStockLabel(at: indexOfFruit)
             initializeStocktepper(at: indexOfFruit)
         }
     }
     
-    func editStock(changedStock: Int, fruit: FruitName) {
+    private func editStock(changedStock: Int, fruit: FruitName) {
         let currentStock = store.inventory[fruit.indexOfInventory].count
         let stockDifference = changedStock - currentStock
         store.addStock(count: stockDifference, to: fruit)

--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -14,7 +14,7 @@ class EditStockViewController: UIViewController {
     @IBOutlet private weak var pineappleStockStepper: UIStepper!
     @IBOutlet private weak var kiwiStockStepper: UIStepper!
     @IBOutlet private weak var mangoStockStepper: UIStepper!
-    @IBOutlet private var fruitstockSteppers: [UIStepper]!
+    @IBOutlet private var fruitStockSteppers: [UIStepper]!
     
     private let store = FruitStore.shared
 
@@ -29,7 +29,7 @@ class EditStockViewController: UIViewController {
     }
 
     private func initializeStockStepper(at indexOfFruit: Int) {
-        fruitstockSteppers[indexOfFruit].value = Double(store.inventory[indexOfFruit].count)
+        fruitStockSteppers[indexOfFruit].value = Double(store.inventory[indexOfFruit].count)
     }
     
     private func initializeUIElements() {

--- a/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditStockViewController.swift
@@ -40,8 +40,7 @@ class EditStockViewController: UIViewController {
     }
     
     func editStock(changedStock: Int, fruit: FruitName) {
-        let indexOfFruit = store.findIndexFromInventory(with: fruit)
-        let currentStock = store.inventory[indexOfFruit].count
+        let currentStock = store.inventory[fruit.indexOfInventory].count
         let stockDifference = changedStock - currentStock
         store.addStock(count: stockDifference, to: fruit)
     }

--- a/JuiceMaker/JuiceMaker/Controller/OrderJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderJuiceViewController.swift
@@ -83,8 +83,8 @@ class OrderJuiceViewController: UIViewController {
         do {
             try juiceMaker.make(juiceName: juiceName)
             showSuccessAlert(message: "\(juiceName.kor) 나왔습니다! 맛있게 드세요!")
-        } catch FruitStoreError.lackOfStock(let count) {
-            let description = FruitStoreError.lackOfStock(neededStock: count).description
+        } catch FruitStoreError.lackOfStock(let fruit, let count) {
+            let description = FruitStoreError.lackOfStock(fruitName: fruit, neededStock: count).description
             showLackOfStockAlert(message: description)
         } catch {
             print(error)

--- a/JuiceMaker/JuiceMaker/Controller/OrderJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderJuiceViewController.swift
@@ -7,6 +7,7 @@ class OrderJuiceViewController: UIViewController {
     @IBOutlet private weak var pineappleStockLabel: UILabel!
     @IBOutlet private weak var kiwiStockLabel: UILabel!
     @IBOutlet private weak var mangoStockLabel: UILabel!
+    @IBOutlet var fruitStockLabels: [UILabel]!
     
     private let juiceMaker = JuiceMaker()
     
@@ -20,18 +21,7 @@ class OrderJuiceViewController: UIViewController {
     }
     
     private func refreshSelectedStockLabel(of fruit: FruitName) {
-        switch fruit {
-        case .strawberry:
-            strawberryStockLabel.text = "\(juiceMaker.store.inventory[0].count)"
-        case .banana:
-            bananaStockLabel.text = "\(juiceMaker.store.inventory[1].count)"
-        case .pineapple:
-            pineappleStockLabel.text = "\(juiceMaker.store.inventory[2].count)"
-        case .kiwi:
-            kiwiStockLabel.text = "\(juiceMaker.store.inventory[3].count)"
-        case .mango:
-            mangoStockLabel.text = "\(juiceMaker.store.inventory[4].count)"
-        }
+        fruitStockLabels[fruit.indexOfInventory].text = "\(juiceMaker.store.inventory[fruit.indexOfInventory].count)"
     }
     
     @objc private func refreshStockLabel(_ notifacation: Notification) {

--- a/JuiceMaker/JuiceMaker/Controller/OrderJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderJuiceViewController.swift
@@ -2,11 +2,11 @@ import UIKit
 
 class OrderJuiceViewController: UIViewController {
     
-    @IBOutlet weak var strawberryStockLabel: UILabel!
-    @IBOutlet weak var bananaStockLabel: UILabel!
-    @IBOutlet weak var pineappleStockLabel: UILabel!
-    @IBOutlet weak var kiwiStockLabel: UILabel!
-    @IBOutlet weak var mangoStockLabel: UILabel!
+    @IBOutlet private weak var strawberryStockLabel: UILabel!
+    @IBOutlet private weak var bananaStockLabel: UILabel!
+    @IBOutlet private weak var pineappleStockLabel: UILabel!
+    @IBOutlet private weak var kiwiStockLabel: UILabel!
+    @IBOutlet private weak var mangoStockLabel: UILabel!
     
     private let juiceMaker = JuiceMaker()
     
@@ -91,25 +91,25 @@ class OrderJuiceViewController: UIViewController {
         }
     }
     
-    @IBAction func tapStrawberryBananaJuiceButton(_ sender: UIButton) {
+    @IBAction private func tapStrawberryBananaJuiceButton(_ sender: UIButton) {
         receiveJuiceOrder(juiceName: .strawberryBananaJuice)
     }
-    @IBAction func tapMangoKiwiJuiceButton(_ sender: UIButton) {
+    @IBAction private func tapMangoKiwiJuiceButton(_ sender: UIButton) {
         receiveJuiceOrder(juiceName: .mangoKiwiJuice)
     }
-    @IBAction func tapStrawberryJuiceButton(_ sender: UIButton) {
+    @IBAction private func tapStrawberryJuiceButton(_ sender: UIButton) {
         receiveJuiceOrder(juiceName: .strawberryJuice)
     }
-    @IBAction func tapBananaJuiceButton(_ sender: UIButton) {
+    @IBAction private func tapBananaJuiceButton(_ sender: UIButton) {
         receiveJuiceOrder(juiceName: .bananaJuice)
     }
-    @IBAction func tapPineappleJuiceButton(_ sender: UIButton) {
+    @IBAction private func tapPineappleJuiceButton(_ sender: UIButton) {
         receiveJuiceOrder(juiceName: .pineappleJuice)
     }
-    @IBAction func tapKiwiJuiceButton(_ sender: UIButton) {
+    @IBAction private func tapKiwiJuiceButton(_ sender: UIButton) {
         receiveJuiceOrder(juiceName: .kiwiJuice)
     }
-    @IBAction func tapMangoJuiceButton(_ sender: UIButton) {
+    @IBAction private func tapMangoJuiceButton(_ sender: UIButton) {
         receiveJuiceOrder(juiceName: .mangoJuice)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/OrderJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderJuiceViewController.swift
@@ -56,7 +56,7 @@ class OrderJuiceViewController: UIViewController {
         let alert = UIAlertController(title: nil,
                                       message: message,
                                       preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "재고 수정",
+        let okAction = UIAlertAction(title: "재고 수정⚒",
                                      style: .default) { (action) in
             self.present(editStockViewController, animated: true)
         }

--- a/JuiceMaker/JuiceMaker/Controller/OrderJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/OrderJuiceViewController.swift
@@ -36,11 +36,11 @@ class OrderJuiceViewController: UIViewController {
         }
     }
     
-    private func showSuccessAlert(message: String) {
+    private func showSuccessAlert(message: String, btnTitle: String) {
         let alert = UIAlertController(title: nil,
                                       message: message,
                                       preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "OK",
+        let okAction = UIAlertAction(title: "\(btnTitle) OK",
                                      style: .default,
                                      handler: nil)
         
@@ -72,7 +72,7 @@ class OrderJuiceViewController: UIViewController {
     private func receiveJuiceOrder(juiceName: JuiceName) {
         do {
             try juiceMaker.make(juiceName: juiceName)
-            showSuccessAlert(message: "\(juiceName.kor) 나왔습니다! 맛있게 드세요!")
+            showSuccessAlert(message: "\(juiceName.kor) 나왔습니다! 맛있게 드세요!", btnTitle: juiceName.imoji)
         } catch FruitStoreError.lackOfStock(let fruit, let count) {
             let description = FruitStoreError.lackOfStock(fruitName: fruit, neededStock: count).description
             showLackOfStockAlert(message: description)

--- a/JuiceMaker/JuiceMaker/Model/Errors.swift
+++ b/JuiceMaker/JuiceMaker/Model/Errors.swift
@@ -2,14 +2,14 @@ import Foundation
 
 enum FruitStoreError: LocalizedError {
     case invalidFruitChoice
-    case lackOfStock(neededStock: Int)
+    case lackOfStock(fruitName: String, neededStock: Int)
     
     var description: String {
         switch self {
         case .invalidFruitChoice:
             return "유효하지 않은 선택입니다."
-        case .lackOfStock(let neededStock):
-            return "재료가 \(neededStock)개 부족합니다. 재고를 확인해주세요."
+        case .lackOfStock(let fruitName, let neededStock):
+            return "\(fruitName)(이)가 \(neededStock)개 부족합니다. 재고를 확인해주세요."
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/Errors.swift
+++ b/JuiceMaker/JuiceMaker/Model/Errors.swift
@@ -2,14 +2,14 @@ import Foundation
 
 enum FruitStoreError: LocalizedError {
     case invalidFruitChoice
-    case lackOfStock(fruitName: String, neededStock: Int)
+    case lackOfStock(fruitName: FruitName, neededStock: Int)
     
     var description: String {
         switch self {
         case .invalidFruitChoice:
             return "유효하지 않은 선택입니다."
         case .lackOfStock(let fruitName, let neededStock):
-            return "\(fruitName)(이)가 \(neededStock)개 부족합니다. 재고를 확인해주세요."
+            return "\(fruitName.kor)\(fruitName.imoji)(이)가 \(neededStock)개 부족합니다. 재고를 확인해주세요."
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -37,9 +37,9 @@ class FruitStore {
         switch fruit {
         case .strawberry: return 0
         case .banana: return 1
-        case .kiwi: return 2
-        case .mango: return 3
-        case .pineapple: return 4
+        case .pineapple: return 2
+        case .kiwi: return 3
+        case .mango: return 4
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -33,15 +33,18 @@ class FruitStore {
         initializeInventory()
     }
     
-    private func findIndexFromInventory(with fruit: FruitName) throws -> Int {
-        guard let indexOfFruit = inventory.firstIndex(where: { $0.name == fruit }) else {
-            throw FruitStoreError.invalidFruitChoice
+    func findIndexFromInventory(with fruit: FruitName) -> Int {
+        switch fruit {
+        case .strawberry: return 0
+        case .banana: return 1
+        case .kiwi: return 2
+        case .mango: return 3
+        case .pineapple: return 4
         }
-        return indexOfFruit
     }
     
-    func addStock(count: Int, to fruit: FruitName) throws {
-        let indexOfFruit = try findIndexFromInventory(with: fruit)
+    func addStock(count: Int, to fruit: FruitName) {
+        let indexOfFruit = findIndexFromInventory(with: fruit)
         inventory[indexOfFruit].count += count
         NotificationCenter.default.post(name: .didChangeStock, object: nil, userInfo: ["changedFruit": fruit])
     }
@@ -53,7 +56,7 @@ class FruitStore {
     }
     
     func subtractStock(count: Int, from fruit: FruitName) throws {
-        let indexOfFruit = try findIndexFromInventory(with: fruit)
+        let indexOfFruit = findIndexFromInventory(with: fruit)
         try checkEnoughStock(from: indexOfFruit, for: count)
         inventory[indexOfFruit].count -= count
         NotificationCenter.default.post(name: .didChangeStock, object: nil, userInfo: ["changedFruit": fruit])

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -20,6 +20,16 @@ enum FruitName: CaseIterable {
         case .mango: return 4
         }
     }
+    
+    var kor: String {
+        switch self {
+        case .strawberry: return "딸기"
+        case .banana: return "바나나"
+        case .pineapple: return "파인애플"
+        case .kiwi: return "키위"
+        case .mango: return "망고"
+        }
+    }
 }
 
 struct Fruit {
@@ -50,7 +60,7 @@ class FruitStore {
     
     func checkEnoughStock(of fruit: FruitName, for count: Int) throws {
         guard inventory[fruit.indexOfInventory].count >= count else {
-            throw FruitStoreError.lackOfStock(neededStock: count - inventory[fruit.indexOfInventory].count)
+            throw FruitStoreError.lackOfStock(fruitName: fruit.kor, neededStock: count - inventory[fruit.indexOfInventory].count)
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -10,6 +10,16 @@ enum FruitName: CaseIterable {
     case pineapple
     case kiwi
     case mango
+    
+    var indexOfInventory: Int {
+        switch self {
+        case .strawberry: return 0
+        case .banana: return 1
+        case .pineapple: return 2
+        case .kiwi: return 3
+        case .mango: return 4
+        }
+    }
 }
 
 struct Fruit {
@@ -33,32 +43,19 @@ class FruitStore {
         initializeInventory()
     }
     
-    func findIndexFromInventory(with fruit: FruitName) -> Int {
-        switch fruit {
-        case .strawberry: return 0
-        case .banana: return 1
-        case .pineapple: return 2
-        case .kiwi: return 3
-        case .mango: return 4
-        }
-    }
-    
     func addStock(count: Int, to fruit: FruitName) {
-        let indexOfFruit = findIndexFromInventory(with: fruit)
-        inventory[indexOfFruit].count += count
+        inventory[fruit.indexOfInventory].count += count
         NotificationCenter.default.post(name: .didChangeStock, object: nil, userInfo: ["changedFruit": fruit])
     }
     
-    private func checkEnoughStock(from index: Int, for count: Int) throws {
-        guard inventory[index].count >= count else {
-            throw FruitStoreError.lackOfStock(neededStock: count - inventory[index].count)
+    func checkEnoughStock(of fruit: FruitName, for count: Int) throws {
+        guard inventory[fruit.indexOfInventory].count >= count else {
+            throw FruitStoreError.lackOfStock(neededStock: count - inventory[fruit.indexOfInventory].count)
         }
     }
     
-    func subtractStock(count: Int, from fruit: FruitName) throws {
-        let indexOfFruit = findIndexFromInventory(with: fruit)
-        try checkEnoughStock(from: indexOfFruit, for: count)
-        inventory[indexOfFruit].count -= count
+    func subtractStock(count: Int, from fruit: FruitName) {
+        inventory[fruit.indexOfInventory].count -= count
         NotificationCenter.default.post(name: .didChangeStock, object: nil, userInfo: ["changedFruit": fruit])
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -30,6 +30,16 @@ enum FruitName: CaseIterable {
         case .mango: return "망고"
         }
     }
+    
+    var imoji: String {
+        switch self {
+        case .strawberry: return "🍓"
+        case .banana: return "🍌"
+        case .pineapple: return "🍍"
+        case .kiwi: return "🥝"
+        case .mango: return "🥭"
+        }
+    }
 }
 
 struct Fruit {
@@ -60,7 +70,7 @@ class FruitStore {
     
     func checkEnoughStock(of fruit: FruitName, for count: Int) throws {
         guard inventory[fruit.indexOfInventory].count >= count else {
-            throw FruitStoreError.lackOfStock(fruitName: fruit.kor, neededStock: count - inventory[fruit.indexOfInventory].count)
+            throw FruitStoreError.lackOfStock(fruitName: fruit, neededStock: count - inventory[fruit.indexOfInventory].count)
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -12,19 +12,31 @@ enum JuiceName: CaseIterable {
     var kor: String {
         switch self {
         case .strawberryJuice:
-            return "딸기 쥬스"
+            return "딸기 쥬스🍓"
         case .bananaJuice:
-            return "바나나 쥬스"
+            return "바나나 쥬스🍌"
         case .kiwiJuice:
-            return "키위 쥬스"
+            return "키위 쥬스🥝"
         case .pineappleJuice:
-            return "파인애플 쥬스"
+            return "파인애플 쥬스🍍"
         case .strawberryBananaJuice:
-            return "딸바 쥬스"
+            return "🍓딸바 쥬스🍌"
         case .mangoJuice:
-            return "망고 쥬스"
+            return "망고 쥬스🥭"
         case .mangoKiwiJuice:
-            return "망키 쥬스"
+            return "🥭망키 쥬스🥝"
+        }
+    }
+
+    var imoji: String {
+        switch self {
+        case .strawberryJuice: return "🍓"
+        case .bananaJuice: return "🍌"
+        case .kiwiJuice: return "🥝"
+        case .pineappleJuice: return "🍍"
+        case .strawberryBananaJuice: return "🍓🍌"
+        case .mangoJuice: return "🥭"
+        case .mangoKiwiJuice: return "🥭🥝"
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -80,14 +80,21 @@ struct JuiceMaker {
         return foundRecipe
     }
     
-    private func blendIngredient(by recipe: [ingredient]) throws {
+    private func checkIngredient(of recipe: [ingredient]) throws {
         for ingredient in recipe {
-            try store.subtractStock(count: ingredient.count, from: ingredient.fruit)
+            try store.checkEnoughStock(of: ingredient.fruit, for: ingredient.count)
+        }
+    }
+    
+    private func blendIngredient(by recipe: [ingredient]) {
+        for ingredient in recipe {
+            store.subtractStock(count: ingredient.count, from: ingredient.fruit)
         }
     }
     
     func make(juiceName: JuiceName) throws {
         let foundRecipe = try findRecipe(of: juiceName)
-        try blendIngredient(by: foundRecipe)
+        try checkIngredient(of: foundRecipe)
+        blendIngredient(by: foundRecipe)
     }
 }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -433,6 +433,16 @@
                         <outlet property="pineappleStockStepper" destination="Rcr-xr-eqz" id="kdO-be-KDz"/>
                         <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="yuj-3w-iba"/>
                         <outlet property="strawberryStockStepper" destination="ZQk-f4-zrz" id="F9u-2i-VJi"/>
+                        <outletCollection property="fruitStockLabels" destination="0yV-kn-zaT" collectionClass="NSMutableArray" id="XLV-WT-vKA"/>
+                        <outletCollection property="fruitStockLabels" destination="gKu-86-RhI" collectionClass="NSMutableArray" id="6yh-Sd-aFL"/>
+                        <outletCollection property="fruitStockLabels" destination="MpT-VW-hCb" collectionClass="NSMutableArray" id="aQz-jC-H27"/>
+                        <outletCollection property="fruitStockLabels" destination="ZDv-1m-HBY" collectionClass="NSMutableArray" id="4Po-Yk-5ft"/>
+                        <outletCollection property="fruitStockLabels" destination="YJI-ER-LJR" collectionClass="NSMutableArray" id="l4R-tn-HfW"/>
+                        <outletCollection property="fruitstockSteppers" destination="ZQk-f4-zrz" collectionClass="NSMutableArray" id="uUV-ai-PZC"/>
+                        <outletCollection property="fruitstockSteppers" destination="O5s-2N-3iP" collectionClass="NSMutableArray" id="klI-31-gkH"/>
+                        <outletCollection property="fruitstockSteppers" destination="Rcr-xr-eqz" collectionClass="NSMutableArray" id="38x-FO-bpL"/>
+                        <outletCollection property="fruitstockSteppers" destination="klA-59-Nu4" collectionClass="NSMutableArray" id="0Ae-k3-S13"/>
+                        <outletCollection property="fruitstockSteppers" destination="xbn-6P-grO" collectionClass="NSMutableArray" id="rmI-Mg-l8Z"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
-    <device id="retina4_0" orientation="landscape" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+    <device id="retina6_1" orientation="landscape" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
@@ -15,23 +16,23 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="OrderJuiceViewController" customModule="JuiceMaker" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="16" y="52" width="536" height="112"/>
+                                <rect key="frame" x="60" y="64" width="776" height="145"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="94.5" height="112"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="142.5" height="145"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="84"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="92" width="94.5" height="20"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +41,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="110.5" y="0.0" width="94.5" height="112"/>
+                                        <rect key="frame" x="158.5" y="0.0" width="142.5" height="145"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="81"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="89" width="94.5" height="23"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +59,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="221" y="0.0" width="94" height="112"/>
+                                        <rect key="frame" x="317" y="0.0" width="142" height="145"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="81"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
+                                                <rect key="frame" x="0.0" y="0.0" width="142" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="89" width="94" height="23"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
+                                                <rect key="frame" x="0.0" y="122" width="142" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +77,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="331" y="0.0" width="94.5" height="112"/>
+                                        <rect key="frame" x="475" y="0.0" width="142.5" height="145"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="81"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="89" width="94.5" height="23"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +95,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="441.5" y="0.0" width="94.5" height="112"/>
+                                        <rect key="frame" x="633.5" y="0.0" width="142.5" height="145"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="81"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="89" width="94.5" height="23"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,37 +115,22 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="16" y="184" width="536" height="116"/>
+                                <rect key="frame" x="60" y="229" width="776" height="144"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="536" height="54"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="776" height="68"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="205" height="54"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="301" height="68"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <state key="normal">
                                                     <attributedString key="attributedTitle">
-                                                        <fragment content="딸바쥬스">
-                                                            <attributes>
-                                                                <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
-                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                            </attributes>
-                                                        </fragment>
                                                         <fragment>
-                                                            <string key="content" base64-UTF8="YES">
-Cg
-</string>
+                                                            <string key="content">딸바쥬스
+주문</string>
                                                             <attributes>
                                                                 <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <font key="NSFont" metaFont="system" size="15"/>
-                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                            </attributes>
-                                                        </fragment>
-                                                        <fragment content="주문">
-                                                            <attributes>
-                                                                <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
                                                                 <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                             </attributes>
                                                         </fragment>
@@ -155,33 +141,18 @@ Cg
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="331" y="0.0" width="205" height="54"/>
+                                                <rect key="frame" x="475" y="0.0" width="301" height="68"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <state key="normal">
                                                     <string key="title">망키쥬스 
 주문</string>
                                                     <attributedString key="attributedTitle">
-                                                        <fragment content="망키쥬스">
-                                                            <attributes>
-                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
-                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                            </attributes>
-                                                        </fragment>
                                                         <fragment>
-                                                            <string key="content" base64-UTF8="YES">
-IAo
-</string>
+                                                            <string key="content">망키쥬스 
+주문</string>
                                                             <attributes>
                                                                 <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <font key="NSFont" metaFont="system" size="15"/>
-                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                            </attributes>
-                                                        </fragment>
-                                                        <fragment content="주문">
-                                                            <attributes>
-                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
                                                                 <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                             </attributes>
                                                         </fragment>
@@ -194,37 +165,22 @@ IAo
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="62" width="536" height="54"/>
+                                        <rect key="frame" x="0.0" y="76" width="776" height="68"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="536" height="54"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="776" height="68"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="94.5" height="54"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <state key="normal">
                                                             <attributedString key="attributedTitle">
-                                                                <fragment content="딸기쥬스">
-                                                                    <attributes>
-                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
-                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                                    </attributes>
-                                                                </fragment>
                                                                 <fragment>
-                                                                    <string key="content" base64-UTF8="YES">
-IAo
-</string>
+                                                                    <string key="content">딸기쥬스 
+주문</string>
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                                                                         <font key="NSFont" metaFont="system" size="15"/>
-                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                                    </attributes>
-                                                                </fragment>
-                                                                <fragment content="주문">
-                                                                    <attributes>
-                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
                                                                 </fragment>
@@ -235,14 +191,14 @@ IAo
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="110.5" y="0.0" width="94.5" height="54"/>
+                                                        <rect key="frame" x="158.5" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <state key="normal">
                                                             <attributedString key="attributedTitle">
                                                                 <fragment content="바나나쥬스">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -260,7 +216,7 @@ IAo
                                                                 <fragment content="주문">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -272,14 +228,14 @@ IAo
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="221" y="0.0" width="94" height="54"/>
+                                                        <rect key="frame" x="317" y="0.0" width="142" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <state key="normal">
                                                             <attributedString key="attributedTitle">
                                                                 <fragment content="파인애플쥬스">
                                                                     <attributes>
                                                                         <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -297,7 +253,7 @@ IAo
                                                                 <fragment content="주문">
                                                                     <attributes>
                                                                         <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -310,14 +266,14 @@ IAo
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="331" y="0.0" width="94.5" height="54"/>
+                                                        <rect key="frame" x="475" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <state key="normal">
                                                             <attributedString key="attributedTitle">
                                                                 <fragment content="키위쥬스">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -335,7 +291,7 @@ IAo
                                                                 <fragment content="주문">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -347,14 +303,14 @@ IAo
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="441.5" y="0.0" width="94.5" height="54"/>
+                                                        <rect key="frame" x="633.5" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <state key="normal">
                                                             <attributedString key="attributedTitle">
                                                                 <fragment content="망고쥬스">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -372,7 +328,7 @@ IAo
                                                                 <fragment content="주문">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -416,11 +372,10 @@ IAo
                     </navigationItem>
                     <connections>
                         <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="b0M-X4-n8h"/>
-                        <outlet property="btn" destination="BFb-ka-wGA" id="8LJ-wH-jRo"/>
                         <outlet property="kiwiStockLabel" destination="FZq-de-TJG" id="tV1-r7-NZh"/>
                         <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="9lt-1c-E7g"/>
                         <outlet property="pineappleStockLabel" destination="ccQ-Dk-PuY" id="aIi-zU-1Sv"/>
-                        <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="6Nc-tJ-tRS"/>
+                        <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="T3Q-xS-gFE"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -433,7 +388,7 @@ IAo
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="568" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -450,30 +405,30 @@ IAo
             <objects>
                 <viewController id="Yu1-lM-nqp" customClass="EditStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="D7X-vx-u60">
-                                <rect key="frame" x="16" y="61" width="536" height="160"/>
+                                <rect key="frame" x="60" y="71.5" width="776" height="207"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8wA-yN-4Dl">
-                                        <rect key="frame" x="0.0" y="0.0" width="94.5" height="160"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="142.5" height="207"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.5" y="0.0" width="75" height="89"/>
+                                                <rect key="frame" x="33.5" y="0.0" width="75" height="136"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="0.0" y="97" width="94.5" height="23"/>
+                                                <rect key="frame" x="0.0" y="144" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="0.0" y="128" width="94" height="32"/>
+                                                <rect key="frame" x="24" y="175" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="strawberryStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="rZZ-31-fXK"/>
                                                 </connections>
@@ -484,23 +439,23 @@ IAo
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="KVg-wK-Pg5">
-                                        <rect key="frame" x="110.5" y="0.0" width="94.5" height="160"/>
+                                        <rect key="frame" x="158.5" y="0.0" width="142.5" height="207"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="9.5" y="0.0" width="75" height="89"/>
+                                                <rect key="frame" x="33.5" y="0.0" width="75" height="136"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="0.0" y="97" width="94.5" height="23"/>
+                                                <rect key="frame" x="0.0" y="144" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="0.0" y="128" width="94" height="32"/>
+                                                <rect key="frame" x="24" y="175" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="bananaStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="T15-2O-6Qz"/>
                                                 </connections>
@@ -511,23 +466,23 @@ IAo
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="4h5-48-yeJ">
-                                        <rect key="frame" x="221" y="0.0" width="94" height="160"/>
+                                        <rect key="frame" x="317" y="0.0" width="142" height="207"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="9.5" y="0.0" width="75" height="89"/>
+                                                <rect key="frame" x="33.5" y="0.0" width="75" height="136"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="0.0" y="97" width="94" height="23"/>
+                                                <rect key="frame" x="0.0" y="144" width="142" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="0.0" y="128" width="94" height="32"/>
+                                                <rect key="frame" x="24" y="175" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="pineappleStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="VTh-fY-guR"/>
                                                 </connections>
@@ -538,23 +493,23 @@ IAo
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Lco-jm-bk9">
-                                        <rect key="frame" x="331" y="0.0" width="94.5" height="160"/>
+                                        <rect key="frame" x="475" y="0.0" width="142.5" height="207"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="10" y="0.0" width="75" height="89"/>
+                                                <rect key="frame" x="34" y="0.0" width="75" height="136"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="0.0" y="97" width="94.5" height="23"/>
+                                                <rect key="frame" x="0.0" y="144" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="0.5" y="128" width="94" height="32"/>
+                                                <rect key="frame" x="24.5" y="175" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="kiwiStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="qPz-VR-6ad"/>
                                                 </connections>
@@ -565,23 +520,23 @@ IAo
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="u6n-tp-wCG">
-                                        <rect key="frame" x="441.5" y="0.0" width="94.5" height="160"/>
+                                        <rect key="frame" x="633.5" y="0.0" width="142.5" height="207"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="10" y="0.0" width="75" height="89"/>
+                                                <rect key="frame" x="34" y="0.0" width="75" height="136"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="0.0" y="97" width="94.5" height="23"/>
+                                                <rect key="frame" x="0.0" y="144" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="0.5" y="128" width="94" height="32"/>
+                                                <rect key="frame" x="24.5" y="175" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="mangoStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="84n-X6-5Js"/>
                                                 </connections>
@@ -643,7 +598,7 @@ IAo
                 <navigationController storyboardIdentifier="EditStockNavigation" automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
-                        <rect key="frame" x="0.0" y="0.0" width="568" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -422,6 +422,18 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="GuK-qf-bkt"/>
+                        <outlet property="bananaStockStepper" destination="O5s-2N-3iP" id="RYz-Jd-XdM"/>
+                        <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="mFF-h7-rAe"/>
+                        <outlet property="kiwiStockStepper" destination="klA-59-Nu4" id="Rr4-tm-Of8"/>
+                        <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="u84-3u-ZbL"/>
+                        <outlet property="mangoStockStepper" destination="xbn-6P-grO" id="9dz-UY-nh4"/>
+                        <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="IC4-cu-hcq"/>
+                        <outlet property="pineappleStockStepper" destination="Rcr-xr-eqz" id="kdO-be-KDz"/>
+                        <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="yuj-3w-iba"/>
+                        <outlet property="strawberryStockStepper" destination="ZQk-f4-zrz" id="F9u-2i-VJi"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -431,7 +431,7 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="재고 추가" id="g4W-fY-l7r">
-                        <barButtonItem key="rightBarButtonItem" title="완료" id="CMs-vd-cPP">
+                        <barButtonItem key="rightBarButtonItem" title="닫기" id="CMs-vd-cPP">
                             <connections>
                                 <action selector="tapDoneButton:" destination="Yu1-lM-nqp" id="AIq-Y9-LiN"/>
                             </connections>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_1" orientation="landscape" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
@@ -376,6 +375,11 @@ IAo
                         <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="9lt-1c-E7g"/>
                         <outlet property="pineappleStockLabel" destination="ccQ-Dk-PuY" id="aIi-zU-1Sv"/>
                         <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="T3Q-xS-gFE"/>
+                        <outletCollection property="fruitStockLabels" destination="Qas-vP-td6" collectionClass="NSMutableArray" id="N2B-6z-5zn"/>
+                        <outletCollection property="fruitStockLabels" destination="gvk-pA-Lw5" collectionClass="NSMutableArray" id="HJl-1n-jrO"/>
+                        <outletCollection property="fruitStockLabels" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="gq1-6y-k7D"/>
+                        <outletCollection property="fruitStockLabels" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="oho-XC-DLw"/>
+                        <outletCollection property="fruitStockLabels" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="kAL-F2-asa"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -581,11 +585,11 @@ IAo
                         <outletCollection property="fruitStockLabels" destination="MpT-VW-hCb" collectionClass="NSMutableArray" id="aQz-jC-H27"/>
                         <outletCollection property="fruitStockLabels" destination="ZDv-1m-HBY" collectionClass="NSMutableArray" id="4Po-Yk-5ft"/>
                         <outletCollection property="fruitStockLabels" destination="YJI-ER-LJR" collectionClass="NSMutableArray" id="l4R-tn-HfW"/>
-                        <outletCollection property="fruitstockSteppers" destination="ZQk-f4-zrz" collectionClass="NSMutableArray" id="uUV-ai-PZC"/>
-                        <outletCollection property="fruitstockSteppers" destination="O5s-2N-3iP" collectionClass="NSMutableArray" id="klI-31-gkH"/>
-                        <outletCollection property="fruitstockSteppers" destination="Rcr-xr-eqz" collectionClass="NSMutableArray" id="38x-FO-bpL"/>
-                        <outletCollection property="fruitstockSteppers" destination="klA-59-Nu4" collectionClass="NSMutableArray" id="0Ae-k3-S13"/>
-                        <outletCollection property="fruitstockSteppers" destination="xbn-6P-grO" collectionClass="NSMutableArray" id="rmI-Mg-l8Z"/>
+                        <outletCollection property="fruitStockSteppers" destination="ZQk-f4-zrz" collectionClass="NSMutableArray" id="uUV-ai-PZC"/>
+                        <outletCollection property="fruitStockSteppers" destination="O5s-2N-3iP" collectionClass="NSMutableArray" id="klI-31-gkH"/>
+                        <outletCollection property="fruitStockSteppers" destination="Rcr-xr-eqz" collectionClass="NSMutableArray" id="38x-FO-bpL"/>
+                        <outletCollection property="fruitStockSteppers" destination="klA-59-Nu4" collectionClass="NSMutableArray" id="0Ae-k3-S13"/>
+                        <outletCollection property="fruitStockSteppers" destination="xbn-6P-grO" collectionClass="NSMutableArray" id="rmI-Mg-l8Z"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
-    <device id="retina6_0" orientation="landscape" appearance="light"/>
+    <device id="retina4_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,23 +15,23 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="OrderJuiceViewController" customModule="JuiceMaker" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="60" y="52" width="724" height="136.66666666666666"/>
+                                <rect key="frame" x="16" y="52" width="536" height="112"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="94.5" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
+                                                <rect key="frame" x="0.0" y="92" width="94.5" height="20"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -39,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="148" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="110.5" y="0.0" width="94.5" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="81"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
+                                                <rect key="frame" x="0.0" y="89" width="94.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -57,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="296" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="221" y="0.0" width="94" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="81"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
+                                                <rect key="frame" x="0.0" y="89" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -75,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="444" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="331" y="0.0" width="94.5" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="81"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
+                                                <rect key="frame" x="0.0" y="89" width="94.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -93,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="592" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="441.5" y="0.0" width="94.5" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="81"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
+                                                <rect key="frame" x="0.0" y="89" width="94.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -113,28 +114,78 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="60" y="208.66666666666663" width="724" height="140.33333333333337"/>
+                                <rect key="frame" x="16" y="184" width="536" height="116"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="576" height="66"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
+                                        <rect key="frame" x="0.0" y="0.0" width="536" height="54"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                                <rect key="frame" x="0.0" y="0.0" width="205" height="54"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <state key="normal" title="딸바쥬스 주문">
-                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <state key="normal">
+                                                    <attributedString key="attributedTitle">
+                                                        <fragment content="딸바쥬스">
+                                                            <attributes>
+                                                                <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                        <fragment>
+                                                            <string key="content" base64-UTF8="YES">
+Cg
+</string>
+                                                            <attributes>
+                                                                <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <font key="NSFont" metaFont="system" size="15"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                        <fragment content="주문">
+                                                            <attributes>
+                                                                <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                    </attributedString>
                                                 </state>
                                                 <connections>
                                                     <action selector="tapStrawberryBananaJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="q3f-Td-LPl"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="296" y="0.0" width="280" height="66"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                                <rect key="frame" x="331" y="0.0" width="205" height="54"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <state key="normal" title="망키쥬스 주문">
-                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <state key="normal">
+                                                    <string key="title">망키쥬스 
+주문</string>
+                                                    <attributedString key="attributedTitle">
+                                                        <fragment content="망키쥬스">
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                        <fragment>
+                                                            <string key="content" base64-UTF8="YES">
+IAo
+</string>
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" metaFont="system" size="15"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                        <fragment content="주문">
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                    </attributedString>
                                                 </state>
                                                 <connections>
                                                     <action selector="tapMangoKiwiJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="3s0-cc-gpF"/>
@@ -143,95 +194,216 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="74.000000000000028" width="724" height="66.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="62" width="536" height="54"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="280" height="66.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="536" height="54"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
+                                                        <rect key="frame" x="0.0" y="0.0" width="94.5" height="54"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="딸기쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="딸기쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment>
+                                                                    <string key="content" base64-UTF8="YES">
+IAo
+</string>
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="tapStrawberryJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wYt-jm-zRT"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                        <rect key="frame" x="110.5" y="0.0" width="94.5" height="54"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="바나나쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="바나나쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment>
+                                                                    <string key="content" base64-UTF8="YES">
+IAo
+</string>
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="tapBananaJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Y1d-zN-X05"/>
                                                         </connections>
                                                     </button>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="f2d-aY-X4s">
-                                                <rect key="frame" x="296" y="0.0" width="280" height="66.333333333333329"/>
-                                                <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                        <rect key="frame" x="221" y="0.0" width="94" height="54"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="파인애플쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="파인애플쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment>
+                                                                    <string key="content" base64-UTF8="YES">
+IAo
+</string>
+                                                                    <attributes>
+                                                                        <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
+                                                            <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="17" scale="default"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="tapPineappleJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qcq-Ve-ewQ"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                        <rect key="frame" x="331" y="0.0" width="94.5" height="54"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="키위쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="키위쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment>
+                                                                    <string key="content" base64-UTF8="YES">
+IAo
+</string>
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="tapKiwiJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="VEG-h1-ov3"/>
                                                         </connections>
                                                     </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                        <rect key="frame" x="441.5" y="0.0" width="94.5" height="54"/>
+                                                        <color key="backgroundColor" name="AccentColor"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="망고쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment>
+                                                                    <string key="content" base64-UTF8="YES">
+IAo
+</string>
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
+                                                        </state>
+                                                        <connections>
+                                                            <action selector="tapMangoJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="DT4-ww-DCi"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
                                             </stackView>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
-                                                <color key="backgroundColor" name="AccentColor"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <state key="normal" title="망고쥬스 주문">
-                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                </state>
-                                                <connections>
-                                                    <action selector="tapMangoJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="DT4-ww-DCi"/>
-                                                </connections>
-                                            </button>
                                         </subviews>
                                     </stackView>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="y2A-PH-DJY" firstAttribute="trailing" secondItem="hrc-2F-fzl" secondAttribute="trailing" id="Fu0-qW-GJ8"/>
-                                    <constraint firstItem="wcW-7H-RXw" firstAttribute="trailing" secondItem="ngP-kF-Yii" secondAttribute="trailing" id="cB0-NH-HNJ"/>
-                                </constraints>
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="ngP-kF-Yii" firstAttribute="leading" secondItem="FZq-de-TJG" secondAttribute="leading" id="1na-EV-OQh"/>
                             <constraint firstItem="vaj-6k-c2D" firstAttribute="leading" secondItem="zaq-m5-IIF" secondAttribute="leading" id="4Ki-Xs-fjI"/>
                             <constraint firstItem="zaq-m5-IIF" firstAttribute="height" secondItem="8bC-Xf-vdC" secondAttribute="height" multiplier="35%" id="5ly-0F-l0U"/>
                             <constraint firstItem="Pnn-0B-qbM" firstAttribute="trailing" secondItem="dgU-OE-25m" secondAttribute="trailing" id="6U9-bI-g7g"/>
-                            <constraint firstItem="ngP-kF-Yii" firstAttribute="trailing" secondItem="fKd-3d-9vz" secondAttribute="trailing" id="CVb-4a-jr7"/>
-                            <constraint firstItem="hrc-2F-fzl" firstAttribute="trailing" secondItem="G4B-kp-2Jo" secondAttribute="trailing" id="JP9-5g-NDg"/>
+                            <constraint firstItem="hrc-2F-fzl" firstAttribute="trailing" secondItem="gvk-pA-Lw5" secondAttribute="trailing" id="HvY-ao-Pmj"/>
                             <constraint firstItem="zaq-m5-IIF" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="Vlw-OR-dfY"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="vaj-6k-c2D" secondAttribute="bottom" constant="20" id="ea1-Np-zdi"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="zaq-m5-IIF" secondAttribute="trailing" constant="16" id="f8U-FF-gSK"/>
                             <constraint firstItem="vaj-6k-c2D" firstAttribute="trailing" secondItem="zaq-m5-IIF" secondAttribute="trailing" id="fHg-kF-51g"/>
                             <constraint firstItem="vaj-6k-c2D" firstAttribute="top" secondItem="zaq-m5-IIF" secondAttribute="bottom" constant="20" id="lUh-rF-xWP"/>
+                            <constraint firstItem="ngP-kF-Yii" firstAttribute="trailing" secondItem="3Ce-SU-JeH" secondAttribute="trailing" id="sST-Yw-c3h"/>
                             <constraint firstItem="zaq-m5-IIF" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="wst-Au-sZB"/>
                         </constraints>
                     </view>
@@ -244,6 +416,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="b0M-X4-n8h"/>
+                        <outlet property="btn" destination="BFb-ka-wGA" id="8LJ-wH-jRo"/>
                         <outlet property="kiwiStockLabel" destination="FZq-de-TJG" id="tV1-r7-NZh"/>
                         <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="9lt-1c-E7g"/>
                         <outlet property="pineappleStockLabel" destination="ccQ-Dk-PuY" id="aIi-zU-1Sv"/>
@@ -260,7 +433,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -277,30 +450,30 @@
             <objects>
                 <viewController id="Yu1-lM-nqp" customClass="EditStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="D7X-vx-u60">
-                                <rect key="frame" x="60" y="63" width="724" height="195"/>
+                                <rect key="frame" x="16" y="61" width="536" height="160"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8wA-yN-4Dl">
-                                        <rect key="frame" x="0.0" y="0.0" width="132" height="195"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="94.5" height="160"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="28.666666666666671" y="0.0" width="75" height="124"/>
+                                                <rect key="frame" x="9.5" y="0.0" width="75" height="89"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="0.0" y="132" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="97" width="94.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="128" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="strawberryStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="rZZ-31-fXK"/>
                                                 </connections>
@@ -311,23 +484,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="KVg-wK-Pg5">
-                                        <rect key="frame" x="148" y="0.0" width="132" height="195"/>
+                                        <rect key="frame" x="110.5" y="0.0" width="94.5" height="160"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="28.666666666666657" y="0.0" width="75" height="124"/>
+                                                <rect key="frame" x="9.5" y="0.0" width="75" height="89"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="0.0" y="132" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="97" width="94.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="128" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="bananaStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="T15-2O-6Qz"/>
                                                 </connections>
@@ -338,23 +511,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="4h5-48-yeJ">
-                                        <rect key="frame" x="296" y="0.0" width="132" height="195"/>
+                                        <rect key="frame" x="221" y="0.0" width="94" height="160"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="28.666666666666686" y="0.0" width="75" height="124"/>
+                                                <rect key="frame" x="9.5" y="0.0" width="75" height="89"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="0.0" y="132" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="97" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="128" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="pineappleStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="VTh-fY-guR"/>
                                                 </connections>
@@ -365,23 +538,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Lco-jm-bk9">
-                                        <rect key="frame" x="444" y="0.0" width="132" height="195"/>
+                                        <rect key="frame" x="331" y="0.0" width="94.5" height="160"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="28.666666666666629" y="0.0" width="75" height="124"/>
+                                                <rect key="frame" x="10" y="0.0" width="75" height="89"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="0.0" y="132" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="97" width="94.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <rect key="frame" x="0.5" y="128" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="kiwiStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="qPz-VR-6ad"/>
                                                 </connections>
@@ -392,23 +565,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="u6n-tp-wCG">
-                                        <rect key="frame" x="592" y="0.0" width="132" height="195"/>
+                                        <rect key="frame" x="441.5" y="0.0" width="94.5" height="160"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="28.666666666666629" y="0.0" width="75" height="124"/>
+                                                <rect key="frame" x="10" y="0.0" width="75" height="89"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="0.0" y="132" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="97" width="94.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <rect key="frame" x="0.5" y="128" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="mangoStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="84n-X6-5Js"/>
                                                 </connections>
@@ -470,7 +643,7 @@
                 <navigationController storyboardIdentifier="EditStockNavigation" automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -301,6 +301,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="strawberryStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="rZZ-31-fXK"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -325,6 +328,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="bananaStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="T15-2O-6Qz"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -349,6 +355,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="pineappleStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="VTh-fY-guR"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -373,6 +382,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="kiwiStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="qPz-VR-6ad"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -397,6 +409,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="mangoStockStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="84n-X6-5Js"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@
    - addStock 및 subtractStock : 유효한 선택인지 확인하고, 유효하면 n개의 재고 수량을 변경함 (subtractStock 메서드에서 재고가 부족할 경우, 오류가 발생함)
    - make : 사용자가 원하는 종류의 쥬스를 레시피에 따라 제조함. 유효한 메뉴가 아니면 오류가 발생함
 
+### 키워드 
+   - Class/Structure/Enum, Access Control, Computed Property, LocalizedError, Dictionary/Array, Initializer
+
 ## STEP2
 ### 구현 내용
    - "쥬스 주문" View에서 "재고 수정" 버튼을 탭하면 "재고 추가" View로 이동

--- a/README.md
+++ b/README.md
@@ -3,13 +3,12 @@
 ## 프로젝트 소개
 1. 과일을 관리하는 FruitStore와 해당 과일로 레시피에 따라 과일쥬스를 제조하는 JuiceMaker가 있습니다.
 1. FruitStore의 관리 대상 과일의 종류는 딸기, 바나나, 파인애플, 키위, 망고입니다. 초기 재고는 모두 10개입니다.
-1. 각 과일의 수량을 n개씩 변경할 수 있습니다.
-1. 과일 재고가 부족하면 JuiceMaker에서 쥬스를 제조할 수 없습니다.
-1. '재고 수정'버튼 탭하면 '쥬스 주문'View -> '재고 추가'View로 이동(Modal 적용)
-1. 각 쥬스 주문 버튼 탭하면 현재 과일의 재고에 따라 Alert 표시
-1. 과일 재고 부족시 Alert의 버튼을 통해 '재고 추가'View로 이동(Modal 적용)
-1. 과일 재고량이 변경되면 label에 반영
-- (STEP3 확인 후 작성 예정)
+1. '쥬스 주문' View에서 '재고 수정' 버튼을 탭하면, '재고 추가' View로 이동 (Modal 적용)합니다.
+1. '쥬스 주문' View에서 '쥬스 주문' 버튼을 탭하면, 현재 과일의 재고에 따라 Alert를 표시합니다.
+1. 만약 과일 재고가 부족하면 JuiceMaker에서 쥬스를 제조할 수 없습니다. 과일 재고 부족 시 표시되는 Alert의 버튼을 통해 '재고 추가'View로 이동 (Modal 적용)합니다.
+1. '재고 추가' View에서 Stepper를 통해 각 과일의 수량을 변경할 수 있습니다. 변경된 재고량은 Label에 반영합니다.
+1. '재고 추가' View에서 '닫기' 버튼을 탭하면, '쥬스 주문' View로 이동 (Modal 적용)합니다.
+1. Auto Layout을 통해 여러 기기에서 사용이 가능합니다.
 
 ### 그라운드 룰
    - 공식문서 읽기 : 매일 10시~12시
@@ -18,16 +17,23 @@
    - 커밋 메시지 컨벤션 : 카르마 스타일 
    - Git 커밋 템플릿 및 Git Issue 활용
 
+### 프로젝트 참여자
+   - 팀원 : 아샌 @ICS-Asan, 애플사이다 @just1103
+   - 리뷰어 : 그린 @GREENOVER
+
 ### 프로젝트 일정
-1) 1주차 - STEP1
+* 1주차 - STEP1
    - 10/18 (월) 스크럼, 프로젝트 확인, 진행 이전 세부사항 설정
    - 10/19 (화) 스크럼, 짝 프로그래밍
    - 10/20 (수) 스크럼, 짝 프로그래밍, PR 요청
-2) 2주차 - STEP2
+* 2주차 - STEP2
    - 10/25 (월) 스크럼, 프로젝트 확인, Alert 및 ViewController 공식문서 읽기
    - 10/26 (화) 스크럼, 화면 전환 구현, Xcode 오류 해결
    - 10/27 (수) 스크럼, Label/Alert 구현
    - 10/28 (목) 스크럼, 최종 수정 및 PR 요청
+* 3주차 - STEP3
+   - 11/01 (월) 스크럼, Stepper 적용, Label에 재고 반영
+   - 11/02 (화) 스크럼, 최종 수정 및 PR 요청
 
 ## STEP1
 ### 구현 내용
@@ -77,3 +83,34 @@
 
 ### 키워드
    - UIAlert, UILabel, Modality, Navigation Bar/Bar Button, Error Handling, Storyboard Unrecognized selector 오류 해결, Singleton Pattern, NotificationCenter
+
+## STEP3
+### 구현 내용
+   - '재고 추가' View에서 Stepper를 통해 각 과일의 수량을 변경
+   - 변경된 재고량은 Label에 반영함
+   - IBOutlet Collection을 사용하여 여러 개의 UI요소에 동일한 효과 (과일 재고를 Label에 일괄 반영, Stepper의 value 프로퍼티 값을 일괄 변경)를 적용
+   - 추가로 구현한 기능 : 재고 수정 Alert 메시지에서 부족한 재고량 및 과일 종류를 보여줌 
+
+### 고려사항
+* 기능
+   - FruitStoreError의 lackOfStock case에 연관값을 2개 (fruitName, neededStock) 지정하여, Alert 메시지를 보다 명확하게 표현함 (ex. "딸기"(이)가 10개 부족합니다. 재고를 확인해주세요.")
+   - Stepper의 minimumValue 프로퍼티 값을 0으로 설정하여 과일 재고가 0 미만의 값이 되지 않도록 방지함
+   - Steppper의 value 프로퍼티 값을 현재 과일 재고로 초기화하고, @IBAction 함수를 통해 사용자가 Stepper를 탭할 때마다 valueChange 이벤트를 발생시켜 변경된 재고량을 Label에 즉각 반영함
+
+* EditStockViewController의 주요 프로퍼티
+   - 스토리보드의 UILabel을 제어하기 위해 @IBOutlet 변수 생성
+   - 스토리보드의 UIStepper를 제어하기 위해 @IBOutlet 변수 생성
+   - 여러 개의 UI요소에 동일한 효과를 적용하기 위해 @IBOutlet Collection 변수 생성
+
+* EditStockViewController의 주요 메서드
+   - 각각의 Stepper에 연결된 @IBAction 함수 생성
+   - initializeUIElements : 현재 과일 재고를 Label의 텍스트 및 Stepper의 value 프로퍼티에 반영
+   - editStock : Stepper에서 valueChange 이벤트가 발생했을 때, 변경된 Stepper의 value 프로퍼티의 값 (changedStock)에서 기존 과일 재고 (currentStock)를 뺀 값을 구함 (stockDifference). 그리고 이 값을 addStock 메서드의 매개변수로 전달하여 최종적으로 과일 재고를 수정함
+
+* 디버깅
+   - 2개의 재료를 사용하는 경우 (딸바 쥬스, 망키 쥬스), 레시피 상 2개의 재고 중 두번째 재고가 부족하더라도 첫번째 재고가 소모되는 버그가 발생하여 디버깅함
+		 1) 재고의 갯수를 확인하는 함수와 재료를 사용하는 함수 분리
+	   1) 함수의 간결성을 위해 함수로 되어 있던 부분을 연산 프로퍼티로 선언
+
+### 키워드 
+   - Outlet Collection, UIStepper, Auto Layout, Enum Associate Value


### PR DESCRIPTION
안녕하세요. 그린 @GREENOVER 
아샌, 애플사이다 입니다. @ICS-Asan @just1103

STEP3 PR 요청 드립니다. 부족한 부분이 많을텐데 마지막 STEP3 리뷰도 잘 부탁드려요 :)

1. 주요 구현 내용
   - IBOutlet Collection을 사용하여 여러 개의 UI요소에 동일한 효과 (과일 재고를 Label에 일괄 반영, Stepper의 value 프로퍼티 값을 일괄 변경)를 적용해봤습니다.
   - StepperValueChanged IBAction 함수에서 Label에 Int 타입의 수를 출력하기 위해 `Int(sender.value).description`을 적용했습니다.
   - Auto Layout은 기존에 적용이 되어 있는 상태입니다. 그래서 PR 요청을 드린 후에 따로 Auto Layout 정복하기 강의를 들으면서 천천히 적용해보는 연습을 하려고 합니다.
   - 추가로 구현한 기능 : Error 열거형에서 연관값을 사용했습니다. 재고 수정 Alert 메시지에서 부족한 재고량 및 과일 종류를 보여주도록 했습니다.
```swift
enum FruitStoreError: LocalizedError {
    case invalidFruitChoice
    case lackOfStock(fruitName: String, neededStock: Int)
    
    var description: String {
        switch self {
        case .invalidFruitChoice:
            return "유효하지 않은 선택입니다."
        case .lackOfStock(let fruitName, let neededStock):
            return "\(fruitName)(이)가 \(neededStock)개 부족합니다. 재고를 확인해주세요."
        }
    }
}
```

2. 조언받고 싶은 내용
   - 2개의 재료를 사용하는 경우 (딸바 쥬스, 망키 쥬스), 레시피 상 2개의 재고 중 두번째 재고가 부족하더라도 첫번째 재고가 소모되는 버그가 발생하였습니다.
		 이 버그를 해결하기 위해 재료가 충분한지 확인하는 함수, 재료를 사용하는 함수 2개로 분리하여 구현했습니다.
		 아래 코드처럼 for-in 구문을 사용하여 모두 확인 후에 재료를 사용하도록 구현하였는데 비슷한 로직이 반복되는 것이 불편하게 느껴졌습니다.
		 이러한 부분을 개선할 방법이 있는지 조언을 얻고 싶습니다.

``` swift
private func checkIngredient(of recipe: [ingredient]) throws {
        for ingredient in recipe {
            try store.checkEnoughStock(of: ingredient.fruit, for: ingredient.count)
        }
    }
  
private func blendIngredient(by recipe: [ingredient]) {
    for ingredient in recipe {
        store.subtractStock(count: ingredient.count, from: ingredient.fruit)
	    }
	}

func make(juiceName: JuiceName) throws {
        let foundRecipe = try findRecipe(of: juiceName)
        try checkIngredient(of: foundRecipe)
        blendIngredient(by: foundRecipe)
  }
```