### PR TITLE
쥬스 메이커 [STEP3] 예거, Yohan

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		60B55976273115CC00843C72 /* NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B55975273115CC00843C72 /* NotificationCenter.swift */; };
 		60C298222728F96B00C3011D /* EditAmountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C298212728F96B00C3011D /* EditAmountViewController.swift */; };
 		C123AA112721617200296BE5 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C123AA102721617200296BE5 /* Fruit.swift */; };
 		C1ED7ED6271FF4EB003FA4AF /* JuiceMakerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1ED7ED5271FF4EB003FA4AF /* JuiceMakerError.swift */; };
@@ -21,6 +22,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		60B55975273115CC00843C72 /* NotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenter.swift; sourceTree = "<group>"; };
 		60C298212728F96B00C3011D /* EditAmountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAmountViewController.swift; sourceTree = "<group>"; };
 		C123AA102721617200296BE5 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		C1ED7ED5271FF4EB003FA4AF /* JuiceMakerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMakerError.swift; sourceTree = "<group>"; };
@@ -54,6 +56,7 @@
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
 				60C298212728F96B00C3011D /* EditAmountViewController.swift */,
+				60B55975273115CC00843C72 /* NotificationCenter.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -184,6 +187,7 @@
 				C123AA112721617200296BE5 /* Fruit.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
+				60B55976273115CC00843C72 /* NotificationCenter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
+		C73DAF3B255D0CDD00020D38 /* JuiceOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */; };
 		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
@@ -30,7 +30,7 @@
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C73DAF3A255D0CDD00020D38 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceOrderViewController.swift; sourceTree = "<group>"; };
 		C73DAF3D255D0CDD00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -54,7 +54,7 @@
 			children = (
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
-				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */,
 				60C298212728F96B00C3011D /* EditAmountViewController.swift */,
 				60B55975273115CC00843C72 /* NotificationCenter.swift */,
 			);
@@ -182,7 +182,7 @@
 				C1ED7ED6271FF4EB003FA4AF /* JuiceMakerError.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				60C298222728F96B00C3011D /* EditAmountViewController.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				C73DAF3B255D0CDD00020D38 /* JuiceOrderViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C123AA112721617200296BE5 /* Fruit.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
@@ -35,7 +35,7 @@ class EditAmountViewController: UIViewController {
         case pineappleAmountStepper:
             editFruitAmount(fruit: .pineapple, from: stepper)
         default:
-            fatalError("Undefined Error")
+            showAppTerminatingAlert()
         }
     }
 
@@ -50,10 +50,8 @@ class EditAmountViewController: UIViewController {
         do {
             try updateAllFruitAmountLabels()
             try initializeAllFruitAmountSteppers()
-        } catch JuiceMakerError.fruitNotFound {
-            fatalError("Fruit Not Found")
         } catch {
-            fatalError("Undefined Error")
+            showAppTerminatingAlert()
         }
     }
     
@@ -108,10 +106,23 @@ class EditAmountViewController: UIViewController {
         do {
             try updateFruitStoreInventory(fruit: fruit, from: stepper)
             try updateAllFruitAmountLabels()
-        } catch JuiceMakerError.fruitNotFound {
-            fatalError("Fruit Not Found")
         } catch {
-            fatalError("Undefined Error")
+            showAppTerminatingAlert()
+        }
+    }
+    
+    private func showAppTerminatingAlert() {
+        let title = "시스템 오류가 발생했습니다."
+        let message = "앱이 5초 뒤 종료됩니다...\n개발자에게 문의해주세요."
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let terminateAction = UIAlertAction(title: "지금 종료", style: .destructive) { _ in
+            exit(-1)
+        }
+        
+        alert.addAction(terminateAction)
+        present(alert, animated: true) {
+            sleep(5)
+            exit(-1)
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
@@ -8,6 +8,36 @@
 import UIKit
 
 class EditAmountViewController: UIViewController {
+    private let fruitStore = FruitStore.shared
+    
+    @IBOutlet private weak var strawberryAmountLabel: UILabel!
+    @IBOutlet private weak var bananaAmountLabel: UILabel!
+    @IBOutlet private weak var mangoAmountLabel: UILabel!
+    @IBOutlet private weak var kiwiAmountLabel: UILabel!
+    @IBOutlet private weak var pineappleAmountLabel: UILabel!
+    
+    @IBOutlet private weak var strawberryAmountStepper: UIStepper!
+    @IBOutlet private weak var bananaAmountStepper: UIStepper!
+    @IBOutlet private weak var mangoAmountStepper: UIStepper!
+    @IBOutlet private weak var kiwiAmountStepper: UIStepper!
+    @IBOutlet private weak var pineappleAmountStepper: UIStepper!
+    
+    @IBAction private func fruitAmountSteppersHandler(_ stepper: UIStepper) {
+        switch stepper {
+        case strawberryAmountStepper:
+            strawberryAmountLabel.text = String(Int(stepper.value))
+        case bananaAmountStepper:
+            bananaAmountLabel.text = String(Int(stepper.value))
+        case mangoAmountStepper:
+            mangoAmountLabel.text = String(Int(stepper.value))
+        case kiwiAmountStepper:
+            kiwiAmountLabel.text = String(Int(stepper.value))
+        case pineappleAmountStepper:
+            pineappleAmountLabel.text = String(Int(stepper.value))
+        default:
+            fatalError("Undefined Button")
+        }
+    }
 
     @IBAction func touchUpDismissButton(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true, completion: nil)
@@ -15,5 +45,46 @@ class EditAmountViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        do {
+            try updateFruitAmountLabels()
+            try updateFruitAmountSteppers()
+        } catch JuiceMakerError.fruitNotFound {
+            fatalError("Fruit Not Found")
+        } catch {
+            fatalError("Undefined Error")
+        }
+    }
+    
+    private func updateFruitAmountLabels() throws {
+        guard let strawberryAmount = fruitStore.inventory[.strawberry],
+              let bananaAmount = fruitStore.inventory[.banana],
+              let mangoAmount = fruitStore.inventory[.mango],
+              let kiwiAmount = fruitStore.inventory[.kiwi],
+              let pineappleAmount = fruitStore.inventory[.pineapple] else {
+                  throw JuiceMakerError.fruitNotFound
+              }
+        
+        strawberryAmountLabel.text = String(strawberryAmount)
+        bananaAmountLabel.text = String(bananaAmount)
+        mangoAmountLabel.text = String(mangoAmount)
+        kiwiAmountLabel.text = String(kiwiAmount)
+        pineappleAmountLabel.text = String(pineappleAmount)
+    }
+    
+    private func updateFruitAmountSteppers() throws {
+        guard let strawberryAmount = fruitStore.inventory[.strawberry],
+              let bananaAmount = fruitStore.inventory[.banana],
+              let mangoAmount = fruitStore.inventory[.mango],
+              let kiwiAmount = fruitStore.inventory[.kiwi],
+              let pineappleAmount = fruitStore.inventory[.pineapple] else {
+                  throw JuiceMakerError.fruitNotFound
+              }
+        
+        strawberryAmountStepper.value = Double(strawberryAmount)
+        bananaAmountStepper.value = Double(bananaAmount)
+        mangoAmountStepper.value = Double(mangoAmount)
+        kiwiAmountStepper.value = Double(kiwiAmount)
+        pineappleAmountStepper.value = Double(pineappleAmount)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
@@ -92,6 +92,7 @@ class EditAmountViewController: UIViewController {
     private func updateFruitStoreInventory(fruit: Fruit, from stepper: UIStepper) throws {
         let stepperValue = Int(stepper.value)
         
+        
         guard let inventoryValue = fruitStore.inventory[fruit] else {
             throw JuiceMakerError.fruitNotFound
         }

--- a/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
@@ -9,6 +9,10 @@ import UIKit
 
 class EditAmountViewController: UIViewController {
 
+    @IBAction func touchUpDismissButton(_ sender: UIBarButtonItem) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
@@ -49,8 +49,8 @@ class EditAmountViewController: UIViewController {
         super.viewDidLoad()
         
         do {
-            try updateFruitAmountLabels()
-            try updateFruitAmountSteppers()
+            try updateAllFruitAmountLabels()
+            try updateAllFruitAmountSteppers()
         } catch JuiceMakerError.fruitNotFound {
             fatalError("Fruit Not Found")
         } catch {
@@ -58,7 +58,7 @@ class EditAmountViewController: UIViewController {
         }
     }
     
-    private func updateFruitAmountLabels() throws {
+    private func updateAllFruitAmountLabels() throws {
         guard let strawberryAmount = fruitStore.inventory[.strawberry],
               let bananaAmount = fruitStore.inventory[.banana],
               let mangoAmount = fruitStore.inventory[.mango],
@@ -74,7 +74,7 @@ class EditAmountViewController: UIViewController {
         pineappleAmountLabel.text = String(pineappleAmount)
     }
     
-    private func updateFruitAmountSteppers() throws {
+    private func updateAllFruitAmountSteppers() throws {
         guard let strawberryAmount = fruitStore.inventory[.strawberry],
               let bananaAmount = fruitStore.inventory[.banana],
               let mangoAmount = fruitStore.inventory[.mango],

--- a/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
@@ -2,7 +2,7 @@
 //  EditAmountViewController.swift
 //  JuiceMaker
 //
-//  Created by 장영우 on 2021/10/27.
+//  Created by Yohan on 2021/10/27.
 //
 
 import UIKit
@@ -40,7 +40,9 @@ class EditAmountViewController: UIViewController {
     }
 
     @IBAction func touchUpDismissButton(_ sender: UIBarButtonItem) {
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true) {
+            notificationCenter.post(name: .didEditAmount, object: nil)
+        }
     }
     
     override func viewDidLoad() {

--- a/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/EditAmountViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class EditAmountViewController: UIViewController {
     private let fruitStore = FruitStore.shared
+    private let feedbackGenerator = UISelectionFeedbackGenerator()
     
     @IBOutlet private weak var strawberryAmountLabel: UILabel!
     @IBOutlet private weak var bananaAmountLabel: UILabel!
@@ -37,6 +38,8 @@ class EditAmountViewController: UIViewController {
         default:
             showAppTerminatingAlert()
         }
+        
+        feedbackGenerator.selectionChanged()
     }
 
     @IBAction func touchUpDismissButton(_ sender: UIBarButtonItem) {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -49,9 +49,14 @@ class JuiceOrderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        applyAutoFontSizeToAllButtonLabels()
+        notificationCenter.addObserver(self,
+                                    selector: #selector(updateAllFruitAmountLabels),
+                                    name: .didEditAmount,
+                                    object: nil)
+        
         do {
             try updateAllFruitAmountLabels()
-            notificationCenter.addObserver(self, selector: #selector(updateAllFruitAmountLabels), name: .didEditAmount, object: nil)
         } catch JuiceMakerError.fruitNotFound {
             fatalError("Fruit Not Found")
         } catch {
@@ -112,6 +117,16 @@ class JuiceOrderViewController: UIViewController {
         alert.addAction(cancelAction)
         alert.addAction(navigateAction)
         present(alert, animated: true, completion: nil)
+    }
+    
+    private func applyAutoFontSizeToAllButtonLabels() {
+        strawberryJuiceButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        bananaJuiceButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        pineappleJuiceButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        kiwiJuiceButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        mangoJuiceButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        strawberryBananaJuiceButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        mangoKiwiJuiceButton.titleLabel?.adjustsFontSizeToFitWidth = true
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 class JuiceOrderViewController: UIViewController {
     private let juiceMaker = JuiceMaker()
     private let fruitStore = FruitStore.shared
-    private var feedbackGenerator = UINotificationFeedbackGenerator()
+    private let feedbackGenerator = UINotificationFeedbackGenerator()
     
     @IBOutlet private weak var strawberryAmountLabel: UILabel!
     @IBOutlet private weak var bananaAmountLabel: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -42,7 +42,7 @@ class JuiceOrderViewController: UIViewController {
         case mangoKiwiJuiceButton:
             orderJuice(.mangoKiwiJuice)
         default:
-            fatalError("Undefined Button")
+            showAppTerminatingAlert()
         }
     }
     
@@ -57,10 +57,8 @@ class JuiceOrderViewController: UIViewController {
         
         do {
             try updateAllFruitAmountLabels()
-        } catch JuiceMakerError.fruitNotFound {
-            fatalError("Fruit Not Found")
         } catch {
-            fatalError("Undefined Error")
+            showAppTerminatingAlert()
         }
     }
     
@@ -89,10 +87,8 @@ class JuiceOrderViewController: UIViewController {
         } catch JuiceMakerError.notEnoughFruit {
             showNotEnoughFruitAlert()
             feedbackGenerator.notificationOccurred(.warning)
-        } catch JuiceMakerError.fruitNotFound {
-            fatalError("Fruit Not Found")
         } catch {
-            fatalError("Undefined Error")
+            showAppTerminatingAlert()
         }
     }
     
@@ -117,6 +113,21 @@ class JuiceOrderViewController: UIViewController {
         alert.addAction(cancelAction)
         alert.addAction(navigateAction)
         present(alert, animated: true, completion: nil)
+    }
+    
+    private func showAppTerminatingAlert() {
+        let title = "시스템 오류가 발생했습니다."
+        let message = "앱이 5초 뒤 종료됩니다...\n개발자에게 문의해주세요."
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let terminateAction = UIAlertAction(title: "지금 종료", style: .destructive) { _ in
+            exit(-1)
+        }
+        
+        alert.addAction(terminateAction)
+        present(alert, animated: true) {
+            sleep(5)
+            exit(-1)
+        }
     }
     
     private func applyAutoFontSizeToAllButtonLabels() {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -51,7 +51,7 @@ class JuiceOrderViewController: UIViewController {
         
         applyAutoFontSizeToAllButtonLabels()
         notificationCenter.addObserver(self,
-                                    selector: #selector(updateAllFruitAmountLabels),
+                                    selector: #selector(modalDismissCompletionHandler),
                                     name: .didEditAmount,
                                     object: nil)
         
@@ -62,7 +62,15 @@ class JuiceOrderViewController: UIViewController {
         }
     }
     
-    @objc private func updateAllFruitAmountLabels() throws {
+    @objc private func modalDismissCompletionHandler() {
+        do {
+            try updateAllFruitAmountLabels()
+        } catch {
+            showAppTerminatingAlert()
+        }
+    }
+    
+    private func updateAllFruitAmountLabels() throws {
         guard let strawberryAmount = fruitStore.inventory[.strawberry],
               let bananaAmount = fruitStore.inventory[.banana],
               let mangoAmount = fruitStore.inventory[.mango],

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class JuiceOrderViewController: UIViewController {
     private let juiceMaker = JuiceMaker()
     private let fruitStore = FruitStore.shared
     private var feedbackGenerator = UINotificationFeedbackGenerator()
@@ -50,8 +50,8 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         
         do {
-            try updateFruitAmountLabels()
-            notificationCenter.addObserver(self, selector: #selector(updateFruitAmountLabels), name: .didEditAmount, object: nil)
+            try updateAllFruitAmountLabels()
+            notificationCenter.addObserver(self, selector: #selector(updateAllFruitAmountLabels), name: .didEditAmount, object: nil)
         } catch JuiceMakerError.fruitNotFound {
             fatalError("Fruit Not Found")
         } catch {
@@ -59,7 +59,7 @@ class ViewController: UIViewController {
         }
     }
     
-    @objc private func updateFruitAmountLabels() throws {
+    @objc private func updateAllFruitAmountLabels() throws {
         guard let strawberryAmount = fruitStore.inventory[.strawberry],
               let bananaAmount = fruitStore.inventory[.banana],
               let mangoAmount = fruitStore.inventory[.mango],
@@ -78,7 +78,7 @@ class ViewController: UIViewController {
     private func orderJuice(_ juice: JuiceMaker.Juice) {
         do {
             try juiceMaker.make(juice)
-            try updateFruitAmountLabels()
+            try updateAllFruitAmountLabels()
             showJuiceWasMadeAlert(juice: juice)
             feedbackGenerator.notificationOccurred(.success)
         } catch JuiceMakerError.notEnoughFruit {

--- a/JuiceMaker/JuiceMaker/Controller/NotificationCenter.swift
+++ b/JuiceMaker/JuiceMaker/Controller/NotificationCenter.swift
@@ -1,0 +1,14 @@
+//
+//  NotificationCenter.swift
+//  JuiceMaker
+//
+//  Created by Yohan on 2021/11/02.
+//
+
+import Foundation
+
+let notificationCenter: NotificationCenter = NotificationCenter.default
+
+extension Notification.Name {
+    static let didEditAmount = Notification.Name("didEditAmount")
+}

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -51,6 +51,7 @@ class ViewController: UIViewController {
         
         do {
             try updateFruitAmountLabels()
+            notificationCenter.addObserver(self, selector: #selector(updateFruitAmountLabels), name: .didEditAmount, object: nil)
         } catch JuiceMakerError.fruitNotFound {
             fatalError("Fruit Not Found")
         } catch {
@@ -58,7 +59,7 @@ class ViewController: UIViewController {
         }
     }
     
-    private func updateFruitAmountLabels() throws {
+    @objc private func updateFruitAmountLabels() throws {
         guard let strawberryAmount = fruitStore.inventory[.strawberry],
               let bananaAmount = fruitStore.inventory[.banana],
               let mangoAmount = fruitStore.inventory[.mango],

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -2,7 +2,7 @@
 //  Fruit.swift
 //  JuiceMaker
 //
-//  Created by 유재호 on 2021/10/21.
+//  Created by 예거 on 2021/10/21.
 //
 
 enum Fruit: CaseIterable {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,6 +5,8 @@
 // 
 
 struct JuiceMaker {
+    private let fruitStore = FruitStore.shared
+    
     enum Juice: String {
         case strawberryJuice = "딸기 쥬스"
         case bananaJuice = "바나나 쥬스"
@@ -33,8 +35,6 @@ struct JuiceMaker {
             }
         }
     }
-    
-    private let fruitStore = FruitStore.shared
     
     private func hasIngredients(of juice: Juice) throws {
         let recipe = juice.recipe

--- a/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
@@ -2,7 +2,7 @@
 //  JuiceMakerError.swift
 //  JuiceMaker
 //
-//  Created by 유재호 on 2021/10/20.
+//  Created by 예거 on 2021/10/20.
 //
 
 enum JuiceMakerError: Error {

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -308,6 +309,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="fruitAmountSteppersHandler:" destination="Yu1-lM-nqp" eventType="valueChanged" id="tW1-Rr-6Ld"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -332,6 +336,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="fruitAmountSteppersHandler:" destination="Yu1-lM-nqp" eventType="valueChanged" id="oNk-xt-KDH"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -341,7 +348,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="4h5-48-yeJ">
                                         <rect key="frame" x="296" y="0.0" width="132" height="195"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
                                                 <rect key="frame" x="28.666666666666686" y="0.0" width="75" height="124"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
@@ -356,6 +363,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="fruitAmountSteppersHandler:" destination="Yu1-lM-nqp" eventType="valueChanged" id="LAd-R2-4ZN"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -380,6 +390,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="fruitAmountSteppersHandler:" destination="Yu1-lM-nqp" eventType="valueChanged" id="GPS-QT-Ljr"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -389,7 +402,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="u6n-tp-wCG">
                                         <rect key="frame" x="592" y="0.0" width="132" height="195"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
                                                 <rect key="frame" x="28.666666666666629" y="0.0" width="75" height="124"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
@@ -404,6 +417,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="fruitAmountSteppersHandler:" destination="Yu1-lM-nqp" eventType="valueChanged" id="0yD-Ax-kjB"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -436,6 +452,18 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <connections>
+                        <outlet property="bananaAmountLabel" destination="gKu-86-RhI" id="oVU-9C-cBF"/>
+                        <outlet property="bananaAmountStepper" destination="O5s-2N-3iP" id="cZV-7z-Ize"/>
+                        <outlet property="kiwiAmountLabel" destination="ZDv-1m-HBY" id="YYz-Rj-m4N"/>
+                        <outlet property="kiwiAmountStepper" destination="klA-59-Nu4" id="BMB-LP-obq"/>
+                        <outlet property="mangoAmountLabel" destination="MpT-VW-hCb" id="lk4-nC-Yen"/>
+                        <outlet property="mangoAmountStepper" destination="Rcr-xr-eqz" id="lpw-jf-WdY"/>
+                        <outlet property="pineappleAmountLabel" destination="YJI-ER-LJR" id="tsn-cm-qaX"/>
+                        <outlet property="pineappleAmountStepper" destination="xbn-6P-grO" id="isW-fc-bPw"/>
+                        <outlet property="strawberryAmountLabel" destination="0yV-kn-zaT" id="ZMM-JJ-k4L"/>
+                        <outlet property="strawberryAmountStepper" destination="ZQk-f4-zrz" id="wMi-Ac-p1B"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -239,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="show" identifier="SegueToEditAmountView" id="LGK-03-UAw"/>
+                                <segue destination="Yu1-lM-nqp" kind="presentation" identifier="SegueToEditAmountView" id="LGK-03-UAw"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -289,7 +288,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="D7X-vx-u60">
-                                <rect key="frame" x="60" y="63" width="724" height="195"/>
+                                <rect key="frame" x="60" y="50" width="724" height="195"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8wA-yN-4Dl">
                                         <rect key="frame" x="0.0" y="0.0" width="132" height="195"/>
@@ -413,6 +412,19 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c5h-cm-g7H">
+                                <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <items>
+                                    <navigationItem title="재고 추가" id="j2k-bC-cAw">
+                                        <barButtonItem key="rightBarButtonItem" title="닫기" id="vUY-Y9-zuN">
+                                            <connections>
+                                                <action selector="touchUpDismissButton:" destination="Yu1-lM-nqp" id="xt4-1P-X1m"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -239,7 +239,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" identifier="SegueToEditAmountView" id="LGK-03-UAw"/>
+                                <segue destination="PNp-2G-oVd" kind="presentation" identifier="SegueToEditAmountView" id="LGK-03-UAw"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -270,6 +270,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -280,7 +281,7 @@
             </objects>
             <point key="canvasLocation" x="896" y="45"/>
         </scene>
-        <!--Edit Amount View Controller-->
+        <!--재고 추가-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController id="Yu1-lM-nqp" customClass="EditAmountViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
@@ -289,7 +290,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="D7X-vx-u60">
-                                <rect key="frame" x="60" y="50" width="724" height="195"/>
+                                <rect key="frame" x="60" y="63" width="724" height="195"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8wA-yN-4Dl">
                                         <rect key="frame" x="0.0" y="0.0" width="132" height="195"/>
@@ -428,19 +429,6 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c5h-cm-g7H">
-                                <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <items>
-                                    <navigationItem title="재고 추가" id="j2k-bC-cAw">
-                                        <barButtonItem key="rightBarButtonItem" title="닫기" id="vUY-Y9-zuN">
-                                            <connections>
-                                                <action selector="touchUpDismissButton:" destination="Yu1-lM-nqp" id="xt4-1P-X1m"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -451,7 +439,13 @@
                             <constraint firstItem="D7X-vx-u60" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="16" id="qRC-6H-wIX"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <navigationItem key="navigationItem" title="재고 추가" id="g4W-fY-l7r">
+                        <barButtonItem key="rightBarButtonItem" title="닫기" id="s1W-P1-PoS">
+                            <connections>
+                                <action selector="touchUpDismissButton:" destination="Yu1-lM-nqp" id="Npr-4W-PJd"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="bananaAmountLabel" destination="gKu-86-RhI" id="oVU-9C-cBF"/>
                         <outlet property="bananaAmountStepper" destination="O5s-2N-3iP" id="cZV-7z-Ize"/>
@@ -467,7 +461,26 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="896" y="1806"/>
+            <point key="canvasLocation" x="1565" y="900"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="9By-Mr-uVW">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="PNp-2G-oVd" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="C84-mV-WVp">
+                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="Yu1-lM-nqp" kind="relationship" relationship="rootViewController" id="RW0-6f-eqi"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="BZB-HY-tDT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1565" y="45"/>
         </scene>
     </scenes>
     <resources>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -123,6 +122,7 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <inset key="titleEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
                                                 <state key="normal" title="딸바쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
@@ -134,6 +134,7 @@
                                                 <rect key="frame" x="296" y="0.0" width="280" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <inset key="titleEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
                                                 <state key="normal" title="망키쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
@@ -153,6 +154,7 @@
                                                         <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <inset key="titleEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
                                                         <state key="normal" title="딸기쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
@@ -164,6 +166,7 @@
                                                         <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <inset key="titleEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
                                                         <state key="normal" title="바나나쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
@@ -180,6 +183,7 @@
                                                         <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <inset key="titleEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
                                                         <state key="normal" title="망고쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
@@ -191,6 +195,7 @@
                                                         <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <inset key="titleEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
                                                         <state key="normal" title="키위쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
@@ -204,6 +209,7 @@
                                                 <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <inset key="titleEdgeInsets" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
                                                 <state key="normal" title="파인애플쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="JuiceOrderViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
@lina0322 @Jager-yoo)
안녕하세요 엘림~ 
벌써 마지막 STEP PR이네요!
이번 PR도 잘 부탁드려요ㅎㅎ 🙏🏻
(예거, 요한 9모둠입니다!)

이번에도 고민했던 점과 궁금한 점으로 정리해봤어요

---

## 🐶 고민했던 점 

### 1. Modal 전환임에도 Navigation Controller를 하나 더 추가한 이유
Modal로 전환되는 화면의 경우, Navigation Controller에 의해 자동으로 Navigation Bar가 생성되지 않으나, 프로젝트 구현 요구사항으로 첫 번째 화면과 (modal로 전환될)두 번째 화면이 동일한 디자인의 Navigation Bar를 가져야 했습니다

그래서, Navigation Bar를 수동으로 만드는 것보다, Navigation Controller를 하나 더 만들어 자동으로 만들어주는게, 유지보수나 확장성 측면에서 더 나은 것 같다고 판단했습니다!
<br>
### 2. KVO를 도입하려다 문제가 있어, NotificationCenter로 구현
app에는 두 개의 뷰컨이 존재하며 두 뷰컨은 하나의 Model(`FruitStore`)를 참조하여 Label 값을 display하고 있습니다.
거기에, 두 뷰컨 모두에서 Model의 값을 수정할 수 있으므로 동기화 작업도 필요하였습니다. (한 뷰컨이 Model을 수정하면 다른 뷰컨에서 이를 감지하고 자신의 View를 업데이트하도록)

이를 위해, 3가지 (노티센터 / KVO / 프로퍼티옵저버)를 고려해보았고, 가장 먼저 KVO를 적용시도해보았는데 문제가 있었습니다
값 변경 감시대상인 `FruitStore`의 과일 재고를 저장하는 `inventory`라는 프로퍼티가 dictionary인데 key의 타입이 `enum`이어서 `NSObject`를 상속할 수 없어 KVO 사용이 불가했습니다 😂😂

그래서 NotificationCenter로 구현하게 되었습니다.
(delegate 패턴은 배우면 하려고 아껴뒀습니다ㅎㅎ...)
<br>
### 3. 두번째 화면에서 재고 수정한 것을, 첫 화면의 view로 언제 update시킬 것인가? (modal이 종료될 때?)

우선, 두 번째 화면의 stepper의 값을 변경하면 실시간으로 Model의 값도 변경하도록 구현하였습니다 (+Label도)
그러므로, 첫 번째 화면의 Label이 정상적으로 업데이트되려면 단지 Model의 값을 읽어오기만 하면 됩니다
두 번째 화면을 dismiss 하는 버튼을 누르는 시점에, `post`를 보내어 첫 번째 화면이 변경된 Model을 읽어 Label을 업데이트하도록 구현하였습니다

사실 일반적으론 Modal을 dismiss하는 방법으로 버튼을 누르는 게 아닌 gesture도 있으므로 버튼 Action에 넣는게 적절하지 않지만, landscape only App이므로 gesture 사용이 불가해 버튼 Action이 유일한 dismiss 방법이므로 `post`를 구현하였습니다
<br>
### 4. Auto Layout 추가 적용
프로젝트 제약사항 중 오토레이아웃을 적용해보라는 사항이 있었습니다

이미 거의 적용되어 있었어서 다양한 device에서 테스트해봤을 때 대부분 문제가 없었습니다.
다만, 화면이 작은 device에서 버튼 title이 긴 경우, "..."으로 축약되어 보이지 않는 점이 있어 이를 개선해보았습니다

우선, `adjustFontSizeToFitWidth`를 true로 설정하여 축약되지 않게 설정하였습니다
그리고, 버튼 title이 버튼의 border와 너무 붙어있어서 스토리보드 Attribute Inspector에 있는 title-insets를 적용했어요
(그러고보니... 얘네는 오토 레이아웃의 범주가 맞나요..?)
<br>
### 기타
- ViewController 파일명과 타입이름을 명확하게 변경하였습니다
(`ViewController` -> `JuiceOrderViewController`)
- NotificationCenter는 `Foundation` Framework에 구현되어 있다!(import필요)
- 스토리보드 Attribute Inspector의 'Line Break'의 `Truncate Options`는 text가 길어져서 생략되어야 할 때, 그 생략 지점을 의미한다
- viewDidLoad가 끝나지 않으면, viewWillAppear가 실행되지 않는다는 사실 발견 (유저가 View를 볼 수 없다)

---

## 🤔  궁금한 점

### 1. NotificationCenter.addObserver 메서드에서 #selector에 throws 메서드를 try없이 사용할 수 있는 이유가 궁금해요

아래 예제에서 selector 함수로 지정해준 `updateAllFruitAmountLabels`는 에러를 던지는 메서드인데 `try`가 없어도 잘 동작하는 이유가 궁금합니다!
```swift
notificationCenter.addObserver(self,
                                    selector: #selector(updateAllFruitAmountLabels),
                                    name: .didEditAmount,
                                    object: nil)
```
<br>
### 2. Notification.Name 인스턴스를 생성하는 방식
원래는 전역변수로 생성하여 사용했는데 블로그 예제들을 보니 죄다 extension으로 구현을 해놓아서 어떤 장점이 있길래 extension으로 구현하는걸까 고민해보았습니다

```swift
// 원래 사용하던 전역변수 방식
let notiName = Notification.Name("value was changed")

// extension방식
extension Notification.Name {
    static let notiName = Notification.Name("value was changed")
}
```

저희가 생각해본 바로는, 이렇게 extension을 활용하여 타입 프로퍼티로 정의하면 `addObserver`에서 사용할 때, dot만 입력해도 사용가능한 Name의 목록이 나오므로 여기저기 코드가 흩어져있는 NotificationCenter의 특성 상, 사용하기 편해서이지 않을까하고 생각해봤어요!
(왜 다들 extension을 쓰는걸까요? 어떤 장점이 있길래🤔)

현업에서나 엘림은 이런식으로 extension 방식을 사용하는지 궁금해요!

---

## 🦊 추가로 해보고 싶은 것
1. STEP2 PR에서 fatalError에 대해 피드백주셨었는데 이를 Alert로 유저에게 알리고 3초 후에 app이 종료되도록 구현해볼까 싶어요 (Alert -> sleep 3초 후 fatalError)

2. Stepper에도 selection스타일 햅틱을 넣어줄까 싶습니다! 유저 interaction 차원에서 Stepper는 피드백이 없으면 많이 허전한 것 같아요
