### PR TITLE
쥬스메이커 [STEP 3] 제인, 허황

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
+		EACB96672730F35400A3166B /* StockModifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EACB96662730F35400A3166B /* StockModifyViewController.swift */; };
 		EAFED735272A46EF00A169B7 /* StockModifyNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAFED734272A46EF00A169B7 /* StockModifyNavController.swift */; };
 /* End PBXBuildFile section */
 
@@ -31,6 +32,7 @@
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C73DAF44255D0CDF00020D38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMaker.swift; sourceTree = "<group>"; };
+		EACB96662730F35400A3166B /* StockModifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockModifyViewController.swift; sourceTree = "<group>"; };
 		EAFED734272A46EF00A169B7 /* StockModifyNavController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockModifyNavController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -52,6 +54,7 @@
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */,
 				EAFED734272A46EF00A169B7 /* StockModifyNavController.swift */,
+				EACB96662730F35400A3166B /* StockModifyViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -178,6 +181,7 @@
 				EAFED735272A46EF00A169B7 /* StockModifyNavController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
+				EACB96672730F35400A3166B /* StockModifyViewController.swift in Sources */,
 				08A2A451272A72A2006A7CCC /* DataFormatConverter.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 			);

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -14,11 +14,10 @@ class JuiceMakerViewController: UIViewController {
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
     
-    let juiceMaker = JuiceMaker()
+    private let juiceMaker = JuiceMaker()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
         
         initJuiceMakerViewController()
     }
@@ -45,6 +44,8 @@ class JuiceMakerViewController: UIViewController {
         do {
             try juiceMaker.make(juice: juice)
             showCompletedOrderAlert(of: order)
+        } catch JuiceMakerError.invalidSelection {
+            showInvalidOrderAlert()
         } catch FruitStoreError.outOfStock(let neededFruit) {
             showFailedOrderAlert(fruitAndQuantity: neededFruit)
         } catch {
@@ -63,6 +64,16 @@ class JuiceMakerViewController: UIViewController {
         let stockModifyNC = storyboard.instantiateViewController(identifier: stockModifyNavController.storyboardID)
         
         present(stockModifyNC, animated: true, completion: nil)
+    }
+    
+    func showInvalidOrderAlert() {
+        let message = "메뉴에 없는 주문입니다. 다시 확인해 주세요."
+        
+        let alert = UIAlertController(title: "주문 실패", message: message, preferredStyle: .alert)
+        let close = UIAlertAction(title: "닫기", style: .default)
+        alert.addAction(close)
+        
+        present(alert, animated: true, completion: nil)
     }
     
     func showCompletedOrderAlert(of order: String) {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -36,10 +36,6 @@ class JuiceMakerViewController: UIViewController {
         mangoStockLabel.text =  FruitStore.shared.showStock(of: .mango)
     }
     
-    func currentStock() {
-        
-    }
-    
     @IBAction func touchUpOrderButton(_ sender: UIButton) {
         let order = sender.currentTitle?.components(separatedBy: " ").first ?? ""
         

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -99,7 +99,7 @@ class JuiceMakerViewController: UIViewController {
         let message = "\(DataFormatConverter().convert(using: fruitAndQuantity))가 모자라요. 재고를 수정할까요?"
         
         let alert = UIAlertController(title: "재고 부족", message: message, preferredStyle: .alert)
-        let ok = UIAlertAction(title: "재고 수정하기", style: .default) { _ in self.presentStockModifyView() }
+        let ok = UIAlertAction(title: "재고 수정하기", style: .default) { [weak self] _ in self?.presentStockModifyView() }
         let close = UIAlertAction(title: "아니오", style: .default)
         alert.addAction(close)
         alert.addAction(ok)

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -89,10 +89,10 @@ class JuiceMakerViewController: UIViewController {
         let message = "\(DataFormatConverter().convert(using: fruitAndQuantity))가 모자라요. 재고를 수정할까요?"
         
         let alert = UIAlertController(title: "재고 부족", message: message, preferredStyle: .alert)
-        let ok = UIAlertAction(title: "재고 수정하기", style: .default)
+        let ok = UIAlertAction(title: "재고 수정하기", style: .default) { _ in self.presentStockModifyView() }
         let close = UIAlertAction(title: "아니오", style: .default)
-        alert.addAction(ok)
         alert.addAction(close)
+        alert.addAction(ok)
         
         present(alert, animated: true, completion: nil)
     }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -14,15 +14,25 @@ class JuiceMakerViewController: UIViewController {
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
     
+    @IBOutlet weak var strawberryBananaJuiceOrderButton: UIButton!
+    @IBOutlet weak var mangoKiwiJuiceOrderButton: UIButton!
+    @IBOutlet weak var strawberryJuiceOrderButton: UIButton!
+    @IBOutlet weak var bananaJuiceOrderButton: UIButton!
+    @IBOutlet weak var pineappleJuiceOrderButton: UIButton!
+    @IBOutlet weak var kiwiJuiceOrderButton: UIButton!
+    @IBOutlet weak var mangoJuiceOrderButton: UIButton!
+    
     private let juiceMaker = JuiceMaker()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         initJuiceMakerViewController()
     }
     
     func initJuiceMakerViewController() {
         changeStockLabel()
+        adjustOrderButtonTitle()
         
         NotificationCenter.default.addObserver(self, selector: #selector(changeStockLabel), name: FruitStore.shared.didChangeStock, object: nil)
     }
@@ -34,6 +44,16 @@ class JuiceMakerViewController: UIViewController {
         pineappleStockLabel.text =  FruitStore.shared.showStock(of: .pineapple)
         kiwiStockLabel.text =  FruitStore.shared.showStock(of: .kiwi)
         mangoStockLabel.text =  FruitStore.shared.showStock(of: .mango)
+    }
+    
+    func adjustOrderButtonTitle() {
+        strawberryBananaJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        mangoKiwiJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        strawberryJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        bananaJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        pineappleJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        kiwiJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        mangoJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
     }
     
     @IBAction func touchUpOrderButton(_ sender: UIButton) {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -8,19 +8,13 @@ import UIKit
 
 class JuiceMakerViewController: UIViewController {
 
-    @IBOutlet weak var strawberryStockLabel: UILabel!
-    @IBOutlet weak var bananaStockLabel: UILabel!
-    @IBOutlet weak var pineappleStockLabel: UILabel!
-    @IBOutlet weak var kiwiStockLabel: UILabel!
-    @IBOutlet weak var mangoStockLabel: UILabel!
-    
-    @IBOutlet weak var strawberryBananaJuiceOrderButton: UIButton!
-    @IBOutlet weak var mangoKiwiJuiceOrderButton: UIButton!
-    @IBOutlet weak var strawberryJuiceOrderButton: UIButton!
-    @IBOutlet weak var bananaJuiceOrderButton: UIButton!
-    @IBOutlet weak var pineappleJuiceOrderButton: UIButton!
-    @IBOutlet weak var kiwiJuiceOrderButton: UIButton!
-    @IBOutlet weak var mangoJuiceOrderButton: UIButton!
+    @IBOutlet weak private var strawberryStockLabel: UILabel!
+    @IBOutlet weak private var bananaStockLabel: UILabel!
+    @IBOutlet weak private var pineappleStockLabel: UILabel!
+    @IBOutlet weak private var kiwiStockLabel: UILabel!
+    @IBOutlet weak private var mangoStockLabel: UILabel!
+        
+    @IBOutlet private var juiceOrderButtons: [UIButton]!
     
     private let juiceMaker = JuiceMaker()
     
@@ -30,7 +24,7 @@ class JuiceMakerViewController: UIViewController {
         initJuiceMakerViewController()
     }
     
-    func initJuiceMakerViewController() {
+    private func initJuiceMakerViewController() {
         changeStockLabel()
         adjustOrderButtonTitle()
         
@@ -38,7 +32,7 @@ class JuiceMakerViewController: UIViewController {
     }
 
     @objc
-    func changeStockLabel() {
+    private func changeStockLabel() {
         strawberryStockLabel.text =  FruitStore.shared.showStock(of: .strawberry)
         bananaStockLabel.text =  FruitStore.shared.showStock(of: .banana)
         pineappleStockLabel.text =  FruitStore.shared.showStock(of: .pineapple)
@@ -46,17 +40,13 @@ class JuiceMakerViewController: UIViewController {
         mangoStockLabel.text =  FruitStore.shared.showStock(of: .mango)
     }
     
-    func adjustOrderButtonTitle() {
-        strawberryBananaJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
-        mangoKiwiJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
-        strawberryJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
-        bananaJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
-        pineappleJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
-        kiwiJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
-        mangoJuiceOrderButton.titleLabel?.adjustsFontSizeToFitWidth = true
+    private func adjustOrderButtonTitle() {
+        for button in juiceOrderButtons {
+            button.titleLabel?.adjustsFontSizeToFitWidth = true
+        }
     }
     
-    @IBAction func touchUpOrderButton(_ sender: UIButton) {
+    @IBAction private func touchUpOrderButton(_ sender: UIButton) {
         let order = sender.currentTitle?.components(separatedBy: " ").first ?? ""
         
         let juice = Juice(rawValue: order)
@@ -72,11 +62,11 @@ class JuiceMakerViewController: UIViewController {
         }
     }
     
-    @IBAction func tapStockModifyButton(_ sender: UIBarButtonItem) {
+    @IBAction private func tapStockModifyButton(_ sender: UIBarButtonItem) {
         presentStockModifyView()
     }
     
-    func presentStockModifyView() {
+    private func presentStockModifyView() {
         let stockModifyNavController = StockModifyNavController()
 
         let storyboard = UIStoryboard(name: stockModifyNavController.storyboardName, bundle: nil)
@@ -85,7 +75,7 @@ class JuiceMakerViewController: UIViewController {
         present(stockModifyNC, animated: true, completion: nil)
     }
     
-    func showInvalidOrderAlert() {
+    private func showInvalidOrderAlert() {
         let message = "메뉴에 없는 주문입니다. 다시 확인해 주세요."
         
         let alert = UIAlertController(title: "주문 실패", message: message, preferredStyle: .alert)
@@ -95,7 +85,7 @@ class JuiceMakerViewController: UIViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    func showCompletedOrderAlert(of order: String) {
+    private func showCompletedOrderAlert(of order: String) {
         let message = "\(order) 나왔습니다! 맛있게 드세요!"
         
         let alert = UIAlertController(title: "쥬스 완성", message: message, preferredStyle: .alert)
@@ -105,7 +95,7 @@ class JuiceMakerViewController: UIViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    func showFailedOrderAlert(fruitAndQuantity: [Fruit: Int]) {
+    private func showFailedOrderAlert(fruitAndQuantity: [Fruit: Int]) {
         let message = "\(DataFormatConverter().convert(using: fruitAndQuantity))가 모자라요. 재고를 수정할까요?"
         
         let alert = UIAlertController(title: "재고 부족", message: message, preferredStyle: .alert)

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -89,10 +89,11 @@ class JuiceMakerViewController: UIViewController {
         let message = "\(DataFormatConverter().convert(using: fruitAndQuantity))가 모자라요. 재고를 수정할까요?"
         
         let alert = UIAlertController(title: "재고 부족", message: message, preferredStyle: .alert)
-        let ok = UIAlertAction(title: "재고 수정하기", style: .default) { _ in self.presentStockModifyView() }
+        let ok = UIAlertAction(title: "재고 수정하기", style: .default)
         let close = UIAlertAction(title: "아니오", style: .default)
-        alert.addAction(close)
         alert.addAction(ok)
+        alert.addAction(close)
+        
         present(alert, animated: true, completion: nil)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -36,6 +36,10 @@ class JuiceMakerViewController: UIViewController {
         mangoStockLabel.text =  FruitStore.shared.showStock(of: .mango)
     }
     
+    func currentStock() {
+        
+    }
+    
     @IBAction func touchUpOrderButton(_ sender: UIButton) {
         let order = sender.currentTitle?.components(separatedBy: " ").first ?? ""
         
@@ -57,11 +61,10 @@ class JuiceMakerViewController: UIViewController {
     }
     
     func presentStockModifyView() {
-        let stockModifyNavController = StockModifyNavController()
-        
-        let storyboard = UIStoryboard(name: stockModifyNavController.storyboardName, bundle: nil)
-        let stockModifyNC = storyboard.instantiateViewController(identifier: stockModifyNavController.storyboardID)
-        
+        guard let stockModifyNC = storyboard?.instantiateViewController(withIdentifier: "StockModifyNavController") else { return }
+        let stockModifyVC = stockModifyNC.children.first as? StockModifyViewController
+        stockModifyVC?.loadViewIfNeeded()
+        stockModifyVC?.changeStockLabel()
         present(stockModifyNC, animated: true, completion: nil)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -57,10 +57,11 @@ class JuiceMakerViewController: UIViewController {
     }
     
     func presentStockModifyView() {
-        guard let stockModifyNC = storyboard?.instantiateViewController(withIdentifier: "StockModifyNavController") else { return }
-        let stockModifyVC = stockModifyNC.children.first as? StockModifyViewController
-        stockModifyVC?.loadViewIfNeeded()
-        stockModifyVC?.changeStockLabel()
+        let stockModifyNavController = StockModifyNavController()
+
+        let storyboard = UIStoryboard(name: stockModifyNavController.storyboardName, bundle: nil)
+        let stockModifyNC = storyboard.instantiateViewController(identifier: stockModifyNavController.storyboardID)
+            
         present(stockModifyNC, animated: true, completion: nil)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -18,7 +18,6 @@ class JuiceMakerViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         initJuiceMakerViewController()
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -89,11 +89,10 @@ class JuiceMakerViewController: UIViewController {
         let message = "\(DataFormatConverter().convert(using: fruitAndQuantity))가 모자라요. 재고를 수정할까요?"
         
         let alert = UIAlertController(title: "재고 부족", message: message, preferredStyle: .alert)
-        let ok = UIAlertAction(title: "재고 수정하기", style: .default)
+        let ok = UIAlertAction(title: "재고 수정하기", style: .default) { _ in self.presentStockModifyView() }
         let close = UIAlertAction(title: "아니오", style: .default)
-        alert.addAction(ok)
         alert.addAction(close)
-        
+        alert.addAction(ok)
         present(alert, animated: true, completion: nil)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
@@ -15,10 +15,15 @@ class StockModifyViewController: UIViewController {
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
     
+    @IBOutlet weak var strawberryStepper: UIStepper!
+    @IBOutlet weak var bananaStepper: UIStepper!
+    @IBOutlet weak var pineappleStepper: UIStepper!
+    @IBOutlet weak var kiwiStepper: UIStepper!
+    @IBOutlet weak var mangoStepper: UIStepper!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         initJuiceMakerViewController()
-
     }
     
     func initJuiceMakerViewController() {
@@ -38,6 +43,26 @@ class StockModifyViewController: UIViewController {
     
     @IBAction func dismissButton(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true, completion: nil)
-        
     }
+
+    @IBAction func strawberryStepperValueChanged(_ sender: UIStepper) {
+        FruitStore.shared.add(fruit: .strawberry)
+    }
+    
+    @IBAction func bananaStepperValueChanged(_ sender: UIStepper) {
+        FruitStore.shared.add(fruit: .banana)
+    }
+    
+    @IBAction func pineappleStepperValueChanged(_ sender: UIStepper) {
+        FruitStore.shared.add(fruit: .pineapple)
+    }
+    
+    @IBAction func kiwiStepperValueChanged(_ sender: UIStepper) {
+        FruitStore.shared.add(fruit: .kiwi)
+    }
+    
+    @IBAction func mangoStepperValueChanged(_ sender: UIStepper) {
+        FruitStore.shared.add(fruit: .mango)
+    }
+
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
@@ -9,24 +9,24 @@ import UIKit
 
 class StockModifyViewController: UIViewController {
 
-    @IBOutlet weak var strawberryStockLabel: UILabel!
-    @IBOutlet weak var bananaStockLabel: UILabel!
-    @IBOutlet weak var pineappleStockLabel: UILabel!
-    @IBOutlet weak var kiwiStockLabel: UILabel!
-    @IBOutlet weak var mangoStockLabel: UILabel!
+    @IBOutlet weak private var strawberryStockLabel: UILabel!
+    @IBOutlet weak private var bananaStockLabel: UILabel!
+    @IBOutlet weak private var pineappleStockLabel: UILabel!
+    @IBOutlet weak private var kiwiStockLabel: UILabel!
+    @IBOutlet weak private var mangoStockLabel: UILabel!
     
-    @IBOutlet weak var strawberryStepper: UIStepper!
-    @IBOutlet weak var bananaStepper: UIStepper!
-    @IBOutlet weak var pineappleStepper: UIStepper!
-    @IBOutlet weak var kiwiStepper: UIStepper!
-    @IBOutlet weak var mangoStepper: UIStepper!
+    @IBOutlet weak private var strawberryStepper: UIStepper!
+    @IBOutlet weak private var bananaStepper: UIStepper!
+    @IBOutlet weak private var pineappleStepper: UIStepper!
+    @IBOutlet weak private var kiwiStepper: UIStepper!
+    @IBOutlet weak private var mangoStepper: UIStepper!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         initStockModifyViewController()
     }
     
-    func initStockModifyViewController() {
+    private func initStockModifyViewController() {
         NotificationCenter.default.addObserver(self, selector: #selector(changeStockLabel), name: FruitStore.shared.didChangeStock, object: nil)
         
         changeStockLabel()
@@ -34,7 +34,7 @@ class StockModifyViewController: UIViewController {
     }
 
     @objc
-    func changeStockLabel() {
+    private func changeStockLabel() {
         strawberryStockLabel.text =  FruitStore.shared.showStock(of: .strawberry)
         bananaStockLabel.text =  FruitStore.shared.showStock(of: .banana)
         pineappleStockLabel.text =  FruitStore.shared.showStock(of: .pineapple)
@@ -42,7 +42,7 @@ class StockModifyViewController: UIViewController {
         mangoStockLabel.text =  FruitStore.shared.showStock(of: .mango)
     }
     
-    func initializeStepper() {
+    private func initializeStepper() {
         strawberryStepper.restorationIdentifier = "딸기"
         bananaStepper.restorationIdentifier = "바나나"
         pineappleStepper.restorationIdentifier = "파인애플"
@@ -56,11 +56,11 @@ class StockModifyViewController: UIViewController {
         mangoStepper.value = Double(FruitStore.shared.showStock(of: .mango)) ?? 0.0
     }
     
-    @IBAction func dismissButton(_ sender: UIBarButtonItem) {
+    @IBAction private func dismissButton(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true, completion: nil)
     }
 
-    @IBAction func stepperValueChanged(_ sender: UIStepper) {
+    @IBAction private func stepperValueChanged(_ sender: UIStepper) {
         guard let stepperIdentifier = sender.restorationIdentifier,
               let fruit = Fruit(rawValue: stepperIdentifier) else {
                   return

--- a/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
@@ -28,6 +28,9 @@ class StockModifyViewController: UIViewController {
     
     func initStockModifyViewController() {
         NotificationCenter.default.addObserver(self, selector: #selector(changeStockLabel), name: FruitStore.shared.didChangeStock, object: nil)
+        
+        changeStockLabel()
+        initializeStepper()
     }
 
     @objc
@@ -37,6 +40,14 @@ class StockModifyViewController: UIViewController {
         pineappleStockLabel.text =  FruitStore.shared.showStock(of: .pineapple)
         kiwiStockLabel.text =  FruitStore.shared.showStock(of: .kiwi)
         mangoStockLabel.text =  FruitStore.shared.showStock(of: .mango)
+    }
+    
+    func initializeStepper() {
+        strawberryStepper.value = Double(FruitStore.shared.showStock(of: .strawberry)) ?? 0.0
+        bananaStepper.value = Double(FruitStore.shared.showStock(of: .banana)) ?? 0.0
+        pineappleStepper.value = Double(FruitStore.shared.showStock(of: .pineapple)) ?? 0.0
+        kiwiStepper.value = Double(FruitStore.shared.showStock(of: .kiwi)) ?? 0.0
+        mangoStepper.value = Double(FruitStore.shared.showStock(of: .mango)) ?? 0.0
     }
     
     @IBAction func dismissButton(_ sender: UIBarButtonItem) {

--- a/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
@@ -9,9 +9,31 @@ import UIKit
 
 class StockModifyViewController: UIViewController {
 
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var mangoStockLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        initJuiceMakerViewController()
 
+    }
+    
+    func initJuiceMakerViewController() {
+        changeStockLabel()
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(changeStockLabel), name: FruitStore.shared.didChangeStock, object: nil)
+    }
+
+    @objc
+    func changeStockLabel() {
+        strawberryStockLabel.text =  FruitStore.shared.showStock(of: .strawberry)
+        bananaStockLabel.text =  FruitStore.shared.showStock(of: .banana)
+        pineappleStockLabel.text =  FruitStore.shared.showStock(of: .pineapple)
+        kiwiStockLabel.text =  FruitStore.shared.showStock(of: .kiwi)
+        mangoStockLabel.text =  FruitStore.shared.showStock(of: .mango)
     }
     
     @IBAction func dismissButton(_ sender: UIBarButtonItem) {

--- a/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
@@ -27,8 +27,6 @@ class StockModifyViewController: UIViewController {
     }
     
     func initJuiceMakerViewController() {
-        changeStockLabel()
-        
         NotificationCenter.default.addObserver(self, selector: #selector(changeStockLabel), name: FruitStore.shared.didChangeStock, object: nil)
     }
 

--- a/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
@@ -2,7 +2,7 @@
 //  StockModifyViewController.swift
 //  JuiceMaker
 //
-//  Created by si won kim on 2021/10/26.
+//  Created by si won kim on 2021/11/02.
 //
 
 import UIKit
@@ -12,7 +12,10 @@ class StockModifyViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
     }
-
+    
+    @IBAction func dismissButton(_ sender: UIBarButtonItem) {
+        self.dismiss(animated: true, completion: nil)
+        
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
@@ -43,6 +43,12 @@ class StockModifyViewController: UIViewController {
     }
     
     func initializeStepper() {
+        strawberryStepper.restorationIdentifier = "딸기"
+        bananaStepper.restorationIdentifier = "바나나"
+        pineappleStepper.restorationIdentifier = "파인애플"
+        kiwiStepper.restorationIdentifier = "키위"
+        mangoStepper.restorationIdentifier = "망고"
+        
         strawberryStepper.value = Double(FruitStore.shared.showStock(of: .strawberry)) ?? 0.0
         bananaStepper.value = Double(FruitStore.shared.showStock(of: .banana)) ?? 0.0
         pineappleStepper.value = Double(FruitStore.shared.showStock(of: .pineapple)) ?? 0.0
@@ -54,24 +60,12 @@ class StockModifyViewController: UIViewController {
         self.dismiss(animated: true, completion: nil)
     }
 
-    @IBAction func strawberryStepperValueChanged(_ sender: UIStepper) {
-        FruitStore.shared.updateStock(fruit: .strawberry, quantity: Int(sender.value))
+    @IBAction func stepperValueChanged(_ sender: UIStepper) {
+        guard let stepperIdentifier = sender.restorationIdentifier,
+              let fruit = Fruit(rawValue: stepperIdentifier) else {
+                  return
+              }
+        let quantity = Int(sender.value)
+        FruitStore.shared.updateStock(fruit: fruit, quantity: quantity)
     }
-    
-    @IBAction func bananaStepperValueChanged(_ sender: UIStepper) {
-        FruitStore.shared.updateStock(fruit: .banana, quantity: Int(sender.value))
-    }
-    
-    @IBAction func pineappleStepperValueChanged(_ sender: UIStepper) {
-        FruitStore.shared.updateStock(fruit: .pineapple, quantity: Int(sender.value))
-    }
-    
-    @IBAction func kiwiStepperValueChanged(_ sender: UIStepper) {
-        FruitStore.shared.updateStock(fruit: .kiwi, quantity: Int(sender.value))
-    }
-    
-    @IBAction func mangoStepperValueChanged(_ sender: UIStepper) {
-        FruitStore.shared.updateStock(fruit: .mango, quantity: Int(sender.value))
-    }
-
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockModifyViewController.swift
@@ -23,10 +23,10 @@ class StockModifyViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        initJuiceMakerViewController()
+        initStockModifyViewController()
     }
     
-    func initJuiceMakerViewController() {
+    func initStockModifyViewController() {
         NotificationCenter.default.addObserver(self, selector: #selector(changeStockLabel), name: FruitStore.shared.didChangeStock, object: nil)
     }
 
@@ -44,23 +44,23 @@ class StockModifyViewController: UIViewController {
     }
 
     @IBAction func strawberryStepperValueChanged(_ sender: UIStepper) {
-        FruitStore.shared.add(fruit: .strawberry)
+        FruitStore.shared.updateStock(fruit: .strawberry, quantity: Int(sender.value))
     }
     
     @IBAction func bananaStepperValueChanged(_ sender: UIStepper) {
-        FruitStore.shared.add(fruit: .banana)
+        FruitStore.shared.updateStock(fruit: .banana, quantity: Int(sender.value))
     }
     
     @IBAction func pineappleStepperValueChanged(_ sender: UIStepper) {
-        FruitStore.shared.add(fruit: .pineapple)
+        FruitStore.shared.updateStock(fruit: .pineapple, quantity: Int(sender.value))
     }
     
     @IBAction func kiwiStepperValueChanged(_ sender: UIStepper) {
-        FruitStore.shared.add(fruit: .kiwi)
+        FruitStore.shared.updateStock(fruit: .kiwi, quantity: Int(sender.value))
     }
     
     @IBAction func mangoStepperValueChanged(_ sender: UIStepper) {
-        FruitStore.shared.add(fruit: .mango)
+        FruitStore.shared.updateStock(fruit: .mango, quantity: Int(sender.value))
     }
 
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -64,10 +64,8 @@ class FruitStore {
         stock = calculatedStock
     }
     
-    func add(fruit: Fruit, quantity: Int = 1) {
-        if let fruitCount = stock[fruit] {
-            stock.updateValue(fruitCount + quantity, forKey: fruit)
-        }
+    func updateStock(fruit: Fruit, quantity: Int) {
+        stock.updateValue(quantity, forKey: fruit)
     }
         
     private func checkOutOfStock(_ calculatedStock: [Fruit: Int]) throws {

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -244,10 +244,17 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="bananaJuiceOrderButton" destination="y2A-PH-DJY" id="3ci-nn-pKM"/>
                         <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="ek4-8Z-blD"/>
+                        <outlet property="kiwiJuiceOrderButton" destination="wcW-7H-RXw" id="kwY-vz-Yok"/>
                         <outlet property="kiwiStockLabel" destination="FZq-de-TJG" id="HNi-8f-eq9"/>
+                        <outlet property="mangoJuiceOrderButton" destination="q6G-4X-bVm" id="KgX-nm-FFb"/>
+                        <outlet property="mangoKiwiJuiceOrderButton" destination="ngP-kF-Yii" id="w0b-Nj-uuf"/>
                         <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="2h5-3A-Bpx"/>
+                        <outlet property="pineappleJuiceOrderButton" destination="BFb-ka-wGA" id="nYq-eD-EcA"/>
                         <outlet property="pineappleStockLabel" destination="ccQ-Dk-PuY" id="Joh-T7-tuM"/>
+                        <outlet property="strawberryBananaJuiceOrderButton" destination="hrc-2F-fzl" id="MKs-6r-T4E"/>
+                        <outlet property="strawberryJuiceOrderButton" destination="avd-o5-3JM" id="4AW-4J-ZaZ"/>
                         <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="VdA-IS-ZXe"/>
                     </connections>
                 </viewController>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -253,7 +253,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="762.72321428571422" y="92.753623188405811"/>
+            <point key="canvasLocation" x="911" y="1111"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="LzN-aE-P5w">
@@ -272,7 +272,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="66L-FI-VI3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
+            <point key="canvasLocation" x="911" y="25"/>
         </scene>
         <!--재고 추가-->
         <scene sceneID="fkG-vv-hpE">
@@ -303,6 +303,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="strawberryStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="qqJ-yE-8Sd"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -327,6 +330,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="bananaStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="LYo-Eg-Edu"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -351,6 +357,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="pineappleStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="bnK-Ia-I51"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -375,6 +384,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="kiwiStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="tYX-MP-KGK"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -399,6 +411,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="mangoStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="6YT-jy-b11"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -425,10 +440,15 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="jA6-n5-q5B"/>
                         <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="KQy-PO-3BP"/>
+                        <outlet property="kiwiStepper" destination="klA-59-Nu4" id="2U8-OE-rC9"/>
                         <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="cx3-vj-N7B"/>
+                        <outlet property="mangoStepper" destination="xbn-6P-grO" id="HwQ-4d-xPh"/>
                         <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="rhT-fE-gvR"/>
+                        <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="HTr-BV-IGS"/>
                         <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="jJa-Pd-x2d"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="BJZ-Bc-A8N"/>
                         <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="hXs-9p-Xfs"/>
                     </connections>
                 </viewController>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -263,6 +263,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" systemColor="systemGray5Color"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -273,10 +274,10 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--View Controller-->
+        <!--재고 추가-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" sceneMemberID="viewController">
+                <viewController id="Yu1-lM-nqp" customClass="StockModifyViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -416,7 +417,13 @@
                             <constraint firstItem="D7X-vx-u60" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="16" id="qRC-6H-wIX"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <navigationItem key="navigationItem" title="재고 추가" largeTitleDisplayMode="always" id="g4W-fY-l7r">
+                        <barButtonItem key="rightBarButtonItem" title="닫기" id="MQT-1Q-gkb">
+                            <connections>
+                                <action selector="dismissButton:" destination="Yu1-lM-nqp" id="hgS-Yq-5hk"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
@@ -430,8 +437,12 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" systemColor="systemGray4Color"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
+                    <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Inp-oR-2RQ">
+                        <autoresizingMask key="autoresizingMask"/>
+                    </toolbar>
                     <connections>
                         <segue destination="Yu1-lM-nqp" kind="relationship" relationship="rootViewController" id="wH1-3A-cBm"/>
                     </connections>
@@ -447,6 +458,9 @@
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray4Color">
+            <color red="0.81960784313725488" green="0.81960784313725488" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGray5Color">
             <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -424,6 +424,13 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="KQy-PO-3BP"/>
+                        <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="cx3-vj-N7B"/>
+                        <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="rhT-fE-gvR"/>
+                        <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="jJa-Pd-x2d"/>
+                        <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="hXs-9p-Xfs"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -244,18 +244,18 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="bananaJuiceOrderButton" destination="y2A-PH-DJY" id="3ci-nn-pKM"/>
                         <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="ek4-8Z-blD"/>
-                        <outlet property="kiwiJuiceOrderButton" destination="wcW-7H-RXw" id="kwY-vz-Yok"/>
                         <outlet property="kiwiStockLabel" destination="FZq-de-TJG" id="HNi-8f-eq9"/>
-                        <outlet property="mangoJuiceOrderButton" destination="q6G-4X-bVm" id="KgX-nm-FFb"/>
-                        <outlet property="mangoKiwiJuiceOrderButton" destination="ngP-kF-Yii" id="w0b-Nj-uuf"/>
                         <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="2h5-3A-Bpx"/>
-                        <outlet property="pineappleJuiceOrderButton" destination="BFb-ka-wGA" id="nYq-eD-EcA"/>
                         <outlet property="pineappleStockLabel" destination="ccQ-Dk-PuY" id="Joh-T7-tuM"/>
-                        <outlet property="strawberryBananaJuiceOrderButton" destination="hrc-2F-fzl" id="MKs-6r-T4E"/>
-                        <outlet property="strawberryJuiceOrderButton" destination="avd-o5-3JM" id="4AW-4J-ZaZ"/>
                         <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="VdA-IS-ZXe"/>
+                        <outletCollection property="juiceOrderButtons" destination="hrc-2F-fzl" collectionClass="NSMutableArray" id="GcY-xV-sEW"/>
+                        <outletCollection property="juiceOrderButtons" destination="ngP-kF-Yii" collectionClass="NSMutableArray" id="CMV-Om-Fnv"/>
+                        <outletCollection property="juiceOrderButtons" destination="avd-o5-3JM" collectionClass="NSMutableArray" id="9Du-V3-oeX"/>
+                        <outletCollection property="juiceOrderButtons" destination="y2A-PH-DJY" collectionClass="NSMutableArray" id="nue-au-zyz"/>
+                        <outletCollection property="juiceOrderButtons" destination="BFb-ka-wGA" collectionClass="NSMutableArray" id="bLo-4y-Vh2"/>
+                        <outletCollection property="juiceOrderButtons" destination="wcW-7H-RXw" collectionClass="NSMutableArray" id="Vew-1V-DSR"/>
+                        <outletCollection property="juiceOrderButtons" destination="q6G-4X-bVm" collectionClass="NSMutableArray" id="WtP-B3-rxU"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -304,7 +304,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="strawberryStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="qqJ-yE-8Sd"/>
+                                                    <action selector="stepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="8SJ-n9-Wiq"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -331,7 +331,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="bananaStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="LYo-Eg-Edu"/>
+                                                    <action selector="stepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="zKf-2F-QcS"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -358,7 +358,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="pineappleStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="bnK-Ia-I51"/>
+                                                    <action selector="stepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="2gZ-tP-Jyz"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -385,7 +385,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="kiwiStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="tYX-MP-KGK"/>
+                                                    <action selector="stepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="xuw-IQ-QZP"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -412,7 +412,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="19" y="163" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="mangoStepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="6YT-jy-b11"/>
+                                                    <action selector="stepperValueChanged:" destination="Yu1-lM-nqp" eventType="valueChanged" id="boI-G9-BiD"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>


### PR DESCRIPTION
안녕하세요 찌루루😊 **[@jae57](https://github.com/jae57)**

PR이 늦어져서 죄송합니다😭

제인, 허황입니다.쥬스메이커 STEP 3 PR도 잘 부탁드립니다👍

## 고민했던 부분

1. **stepper의 -, + 어느 버튼을 누르든지 +1이 되는 현상** 

```swift
//개선 전 
@IBAction func strawberryStepperValueChanged(_ sender: UIStepper) {
    FruitStore.shared.add(fruit: .strawberry)
}
```

stepper을 누르면 `FruitStore.shared.add(fruit: .strawberry)` 가 실행되면서 FruitStore의 재고가 변경되고, 재고가 변경되면 프로퍼티 옵져버가 노티피케이션을 보내서, `StockModifyViewController`의 `changeStockLabel()`을 실행해서 재고 라벨을 변경합니다.

그러나 -,+ 버튼 어느것을 누르든지 +1이 되는 현상이 발생했습니다. 

따라서 stepper을 누르면 stepper의 value를 바꾸고, 그 value를 과일 재고에 적용하는 방식으로 변경했습니다. 

```swift
//개선 후 
@IBAction func stepperValueChanged(_ sender: UIStepper) {
    guard let stepperIdentifier = sender.restorationIdentifier,
          let fruit = Fruit(rawValue: stepperIdentifier) else {
              return
          }
    let quantity = Int(sender.value)
    FruitStore.shared.updateStock(fruit: fruit, quantity: quantity)
}
```

1. **뷰컨트롤러간 데이터 전달 방법**

재고수정 화면 진입시 현재 재고가 표시되도록 하고싶었습니다.

시도해본 방법들은 다음과 같습니다.

1. 재고수정화면의 viewDidLoad에서 stepper의 value와 label의 text를 현재 재고 값으로 설정(성공)
2. 재고수정화면 초기화시 라벨과 스테퍼의 디폴트값을 10으로 설정(실패)
3. VC1에서 VC2로 화면전환시 VC2의 라벨을 바꾸는 함수를 실행하여 변경하기(성공)
4. segue 를 이용해 데이터 전달하기(성공)

시도 1)

재고 수정 화면 초기화 시 `changeStockLabel()`을 통해 라벨에 `FruitStore` 현재 재고 값을 넣어준다. (모델에서 → VC2로 정보 전달)

stock을 변경시 FruitStore의 메서드인 add를 사용하여 Fruitstore.shared 에 접근한다. 

이전에 구현해놓은 stock 변경시 노티를 보내는 노티피케이션을 VC2도 addObserver해서 

VC1, VC2 동시에 주문하기 화면의 재고 변경된다. 

```swift
override func viewDidLoad() {
    super.viewDidLoad()
    initStockModifyViewController()
}
    
func initStockModifyViewController() {
    NotificationCenter.default.addObserver(self, selector: #selector(changeStockLabel), name: FruitStore.shared.didChangeStock, object: nil)
        
    changeStockLabel()
    initializeStepper()
}

@objc
func changeStockLabel() {
    strawberryStockLabel.text =  FruitStore.shared.showStock(of: .strawberry)
    bananaStockLabel.text =  FruitStore.shared.showStock(of: .banana)
    pineappleStockLabel.text =  FruitStore.shared.showStock(of: .pineapple)
    kiwiStockLabel.text =  FruitStore.shared.showStock(of: .kiwi)
    mangoStockLabel.text =  FruitStore.shared.showStock(of: .mango)
}
    
func initializeStepper() {
    strawberryStepper.restorationIdentifier = "딸기"
    bananaStepper.restorationIdentifier = "바나나"
    pineappleStepper.restorationIdentifier = "파인애플"
    kiwiStepper.restorationIdentifier = "키위"
    mangoStepper.restorationIdentifier = "망고"
        
    strawberryStepper.value = Double(FruitStore.shared.showStock(of: .strawberry)) ?? 0.0
    bananaStepper.value = Double(FruitStore.shared.showStock(of: .banana)) ?? 0.0
   pineappleStepper.value = Double(FruitStore.shared.showStock(of: .pineapple)) ?? 0.0
    kiwiStepper.value = Double(FruitStore.shared.showStock(of: .kiwi)) ?? 0.0
    mangoStepper.value = Double(FruitStore.shared.showStock(of: .mango)) ?? 0.0
}
```

시도2)

재고수정화면 초기화시 라벨과 스테퍼의 디폴트값을 10으로 설정한다. (실패)

```swift
// 디폴트 값
	stepper.value = 10
```

```swift
override func viewDidLoad() {
    super.viewDidLoad()
    initializeStepper()
    initializeStockLabel()
    initJuiceMakerViewController()
}

func initJuiceMakerViewController() {
//  changeStockLabel()
    NotificationCenter.default.addObserver(self, selector: #selector(changeStockLabel), name: FruitStore.shared.didChangeStock, object: nil)
}

func initializeStepper() {
    strawberryStepper.value = 10
    bananaStepper.value = 10
    pineappleStepper.value = 10
    kiwiStepper.value = 10
    mangoStepper.value = 10
}
    
func initializeStockLabel() {
    strawberryStockLabel.text = "10"
    bananaStockLabel.text = "10"
    pineappleStockLabel.text = "10"
    kiwiStockLabel.text = "10"
    mangoStockLabel.text = "10"
}

```

문제점: 재고수정화면(VC2)을 초기화시 10으로 값이 설정되어서 이전 화면에서 재고가 10에서 변경되어도 뷰에 반영이 안된다. 

(재고수정화면의 스테퍼에 초기값을 strawberryStepper.value = 10 으로 줬는데, 이전화면에서 쥬스를 만들어서 재고가 바뀐 경우에도 재고수정화면을 새로 로드하면 10이 할당되어서 실패했다.)

→이때 VC1에서 재고 변경된걸 바로 VC2로 전달해서 VC2가 초기화될때마다 변경사항을 업데이트해주면 좋겠다는 생각을 했습니다.

따라서 생각해본 방법들로는, 

시도 3) VC1에서 VC2로 화면전환시 VC2의 라벨을 바꾸는 함수를 실행하여 변경한다. (성공)

```swift
//변경 전 코드: 그냥 화면 전환만 하기
func presentStockModifyView() {
    let stockModifyNavController = StockModifyNavController()
        
    let storyboard = UIStoryboard(name: stockModifyNavController.storyboardName, bundle: nil)
    let stockModifyNC = storyboard.instantiateViewController(identifier: stockModifyNavController.storyboardID)
        
    present(stockModifyNC, animated: true, completion: nil)
}
```

```swift
//변경 후 코드: 화면 전환하며 VC2의 changeStockLabel() 함수 실행하여 현재재고 라벨에 업데이트
func presentStockModifyView() {
    guard let stockModifyNC = storyboard?.instantiateViewController(withIdentifier: "StockModifyNavController") else { return }
    let stockModifyVC = stockModifyNC.children.first as? StockModifyViewController
    stockModifyVC?.loadViewIfNeeded()
    stockModifyVC?.changeStockLabel()
    present(stockModifyNC, animated: true, completion: nil)
}
```

화면 전환시에 전환하는 화면의 메서드를 실행하려고 했더니(`stockModifyVC?.changeStockLabel()`) VC2로 화면이 전환되어도 라벨이 안바뀌었다.

그래서 `print(stockModifyVC?.isViewLoaded)` 로 저 시점에서 VC2가 로드되었는지 확인해보니 false 가 나왔다.

따라서, 뷰를 로드해주는 메서드`.isViewLoaded` 를 사용하여 뷰를 먼저 로드한 후에 메서드를 실행해서 해결했다. 

시도 4) segue 를 이용해 데이터 전달하기

스토리보드에서 재고수정버튼을 재고수정화면(VC2)의 네비게이션컨트롤러와 연결 후에

이 prepare메서드를 VC1에 추가해준다. 

```swift
override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
    if segue.destination is StockModifyNavController {
        let stockModifyNC = segue.destination as? StockModifyNavController
        let stockModifyVC = stockModifyNC?.children.first as? StockModifyViewController
        stockModifyVC?.loadViewIfNeeded()
        stockModifyVC?.changeStockLabel()
    }
}
```

1. **Stepper IBAction을 어떻게 하면 하나로 통합할 수 있을까?**

Stepper는 Button이나 Label처럼 title이 없어서 각각의 Stepper를 식별할 수 있는 방법이 없는줄 알고 있었습니다. 그래서 각각의 스테퍼마다 IBAction을 연결해줬습니다.

```swift
@IBAction func strawberryStepperValueChanged(_ sender: UIStepper) {
    FruitStore.shared.updateStock(fruit: .strawberry, quantity: Int(sender.value))
}
    
@IBAction func bananaStepperValueChanged(_ sender: UIStepper) {
    FruitStore.shared.updateStock(fruit: .banana, quantity: Int(sender.value))
}
    
@IBAction func pineappleStepperValueChanged(_ sender: UIStepper) {
    FruitStore.shared.updateStock(fruit: .pineapple, quantity: Int(sender.value))
}
    
@IBAction func kiwiStepperValueChanged(_ sender: UIStepper) {
    FruitStore.shared.updateStock(fruit: .kiwi, quantity: Int(sender.value))
}
    
@IBAction func mangoStepperValueChanged(_ sender: UIStepper) {
    FruitStore.shared.updateStock(fruit: .mango, quantity: Int(sender.value))
}
```

**해결 방법**

Stepper restorationIdentifier를 지정해줘서 하나의 이벤트로 여러 스테퍼를 컨트롤 할 수 있었습니다.

```swift
func initializeStepper() {
    strawberryStepper.restorationIdentifier = "딸기"
    bananaStepper.restorationIdentifier = "바나나"
    pineappleStepper.restorationIdentifier = "파인애플"
    kiwiStepper.restorationIdentifier = "키위"
    mangoStepper.restorationIdentifier = "망고"
        
   /* ... */
}
```

```swift
@IBAction func stepperValueChanged(_ sender: UIStepper) {
    guard let stepperIdentifier = sender.restorationIdentifier,
          let fruit = Fruit(rawValue: stepperIdentifier) else {
              return
          }
    let quantity = Int(sender.value)
    FruitStore.shared.updateStock(fruit: fruit, quantity: quantity)
}
```

## 질문 사항

1. **다른 시뮬레이터에서 돌렸을 때 주문 버튼 타이틀이 올바르게 나오지 않는 경우가 있었습니다.**

`adjustsFontSizeToFitWidth` 속성을 true로 바꿔서 다른 시뮬레이터에서도 잘 나오게 개선했습니다.

`adjustsFontSizeToFitWidth` 속성을 변경해주려면 주문 버튼을 전부 `IBOutlet`로 연결해야 사용할 수 있었습니다. 

`adjustsFontSizeToFitWidth` 속성을 사용하려고 7개나 되는 버튼들의 `IBOutlet`을 만들어주는게 효율적이지 못하다고 생각하는데 혹시 다른 방법이 있나 궁금합니다. 

스토리보드 내 버튼 인스펙터에는 해당 옵션이 없는거 같고, 구글링 해보니 `UIButton` 확장을 사용해서 인스펙터에 옵션을 추가해주는 코드가 있던데 이해하지 못해서 사용하지는 않았습니다.

```swift
// 구글링 확장 코드
extension UIButton {
    @IBInspectable var adjustFontSizeToWidth: Bool {
        get {
            return self.titleLabel?.adjustsFontSizeToFitWidth ?? false
        }
        set {
            self.titleLabel?.numberOfLines = 1
            self.titleLabel?.adjustsFontSizeToFitWidth = newValue;
            self.titleLabel?.lineBreakMode = .byClipping;
            self.titleLabel?.baselineAdjustment = .alignCenters
            self.contentEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
        }
    }
}
```
<img width="264" alt="스크린샷 2021-11-04 오후 10 00 37" src="https://user-images.githubusercontent.com/27428188/140317821-b6c36916-ceb2-4efb-9826-6a8953e560eb.png">

위 코드를 프로젝트에 넣으면 인스펙터에 옵션이 생깁니다.



한가지 더 궁금한 점이 있습니다. `adjustsFontSizeToFitWidth`를 사용해서 타이틀의 글자가 시뮬레이터 마다 올바르게 나오게 하는 것도 오토레이아웃이라고 볼 수 있는 건가요???

1. **Stepper restorationIdentifier 리터럴 값**

과일 별로 `Stepper` 이벤트를 따로 만들어주는게 효율적이지 못하다는 생각이 들어서 `Stepper restorationIdentifier`을 지정해 줬습니다. 

`restorationIdentifier`을 딸기, 바나나 등 과일 이름으로 지어줬습니다.

과일 이름으로 지어준 이름은 `Fruit` 타입의 원시값으로 `restorationIdentifier`을 지어주면 활용하기 좋을 것 같다는 생각에 과일 이름으로 지어줬습니다. 

저희가 생각했을 때는 `"딸기 스테퍼"` 이런 식으로 지어줘야하는게 아닌가 라는 생각이 들었는데 `restorationIdentifier` 는 나중에 활용하기 좋게 지어줘도 괜찮은건가요???

`restorationIdentifier` 네이밍을 하는 방법도 따로 존재하는지도 궁금합니다.

```swift
func initializeStepper() {
    strawberryStepper.restorationIdentifier = "딸기"
    bananaStepper.restorationIdentifier = "바나나"
    pineappleStepper.restorationIdentifier = "파인애플"
    kiwiStepper.restorationIdentifier = "키위"
    mangoStepper.restorationIdentifier = "망고"
    /* ... */
}
```

```swift
@IBAction func stepperValueChanged(_ sender: UIStepper) {
    guard let stepperIdentifier = sender.restorationIdentifier,
          let fruit = Fruit(rawValue: stepperIdentifier) else {
              return
          }
    let quantity = Int(sender.value)
    FruitStore.shared.updateStock(fruit: fruit, quantity: quantity)
}
```

1. **고민했던부분 3번에서 stepper을 identifier로 식별해서 처리해둘 때 생긴 궁금증입니다.**

viewController가 storyboardID가 있고 Segue가 identifier가 있는 것처럼 스토리보드 내 모든 뷰(버튼, 라벨 등) 들은 각각 고유의 식별자가 있는지 궁금합니다.