### PR TITLE
쥬스메이커 [STEP 2] minsson, seohyeon2

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
+		C73DAF3B255D0CDD00020D38 /* JuiceOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */; };
 		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
@@ -27,7 +27,7 @@
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C73DAF3A255D0CDD00020D38 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceOrderViewController.swift; sourceTree = "<group>"; };
 		C73DAF3D255D0CDD00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -52,7 +52,7 @@
 			children = (
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
-				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */,
 				FD2AD066281FA31A006E99B4 /* InventoryViewController.swift */,
 			);
 			path = Controller;
@@ -178,7 +178,7 @@
 			files = (
 				51806261281BB5F200E92EF8 /* JuiceMaker+Menu.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				C73DAF3B255D0CDD00020D38 /* JuiceOrderViewController.swift in Sources */,
 				510B67BC2818128500A2B8D3 /* AppError.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				FD2AD067281FA31A006E99B4 /* InventoryViewController.swift in Sources */,

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
+		FD2AD067281FA31A006E99B4 /* InventoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2AD066281FA31A006E99B4 /* InventoryViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +33,7 @@
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C73DAF44255D0CDF00020D38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMaker.swift; sourceTree = "<group>"; };
+		FD2AD066281FA31A006E99B4 /* InventoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +53,7 @@
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				FD2AD066281FA31A006E99B4 /* InventoryViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -178,6 +181,7 @@
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				510B67BC2818128500A2B8D3 /* AppError.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
+				FD2AD067281FA31A006E99B4 /* InventoryViewController.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 			);

--- a/JuiceMaker/JuiceMaker/Controller/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/InventoryViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class InventoryViewController: UIViewController {
-
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/JuiceMaker/JuiceMaker/Controller/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/InventoryViewController.swift
@@ -12,7 +12,7 @@ class InventoryViewController: UIViewController {
         super.viewDidLoad()
     }
     
-    @IBAction func touchUpDismissButton(_ sender: UIButton) {
+    @IBAction private func touchUpDismissButton(_ sender: UIButton) {
         dismiss(animated: true, completion: nil)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/InventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/InventoryViewController.swift
@@ -1,0 +1,19 @@
+//
+//  InventoryViewController.swift
+//  JuiceMaker
+//
+//  Created by Minseong Kang on 2022/05/02.
+//
+
+import UIKit
+
+class InventoryViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    @IBAction func touchUpDismissButton(_ sender: UIButton) {
+        dismiss(animated: true, completion: nil)
+    }
+}

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -19,11 +19,12 @@ class JuiceOrderViewController: UIViewController {
     }
     
     func updateFruitsInventoryLabels() {
-        strawberryInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.strawberry]!)
-        bananaInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.banana]!)
-        pineappleInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.pineapple]!)
-        kiwiInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.kiwi]!)
-        mangoInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.mango]!)
+        let errorValue = 999
+        strawberryInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.strawberry] ?? errorValue)
+        bananaInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.banana] ?? errorValue)
+        pineappleInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.pineapple] ?? errorValue)
+        kiwiInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.kiwi] ?? errorValue)
+        mangoInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.mango] ?? errorValue)
     }
     
     private func order(juice: JuiceMaker.Menu) {
@@ -61,7 +62,7 @@ class JuiceOrderViewController: UIViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    @IBAction func TapjuiceOrderButton(_ sender: UIButton) {
+    @IBAction func tapJuiceOrderButton(_ sender: UIButton) {
         let selected = sender.currentTitle
         
         switch selected {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -6,38 +6,34 @@
 
 import UIKit
 
-class ViewController: UIViewController {
-
+class JuiceOrderViewController: UIViewController {
     @IBOutlet weak var strawberryCount: UILabel!
     @IBOutlet weak var bananaCount: UILabel!
     @IBOutlet weak var pineappleCount: UILabel!
     @IBOutlet weak var kiwiCount: UILabel!
     @IBOutlet weak var mangoCount: UILabel!
-    
-    let juiceMaker = JuiceMaker()
-    
+        
     override func viewDidLoad() {
         super.viewDidLoad()
-        updateInventory()
+        updateFruitsCountLabels()
     }
     
-    func updateInventory() {
-        strawberryCount.text = String(juiceMaker.store.fruitsInventory[.strawberry]!)
-        bananaCount.text = String(juiceMaker.store.fruitsInventory[.banana]!)
-        pineappleCount.text = String(juiceMaker.store.fruitsInventory[.pineapple]!)
-        kiwiCount.text = String(juiceMaker.store.fruitsInventory[.kiwi]!)
-        mangoCount.text = String(juiceMaker.store.fruitsInventory[.mango]!)
+    func updateFruitsCountLabels() {
+        strawberryCount.text = String(JuiceMaker.shared.store.fruitsInventory[.strawberry]!)
+        bananaCount.text = String(JuiceMaker.shared.store.fruitsInventory[.banana]!)
+        pineappleCount.text = String(JuiceMaker.shared.store.fruitsInventory[.pineapple]!)
+        kiwiCount.text = String(JuiceMaker.shared.store.fruitsInventory[.kiwi]!)
+        mangoCount.text = String(JuiceMaker.shared.store.fruitsInventory[.mango]!)
     }
     
-    
-    func order(juice: JuiceMaker.Menu) {
+    private func order(juice: JuiceMaker.Menu) {
         do {
-            try juiceMaker.make(juice: juice)
+            try JuiceMaker.shared.make(juice: juice)
             showSuccessAlert(message: "\(juice.rawValue) 나왔습니다! 맛있게 드세요!")
         } catch {
             showFailureAlert(message: "재료가 모자라요. 재고를 수정할까요?")
         }
-        updateInventory()
+        updateFruitsCountLabels()
     }
     
     func showSuccessAlert(message: String) {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -71,33 +71,79 @@ class JuiceOrderViewController: UIViewController {
     }
     
     @IBAction func tapJuiceOrderButton(_ sender: UIButton) {
-        switch sender {
-        case strawberryBananaJuiceOrderButton:
-            order(juice: .strawberryBananaJuice)
-        case mangoKiwiJuiceOrderButton:
-            order(juice: .mangoKiwiJuice)
-        case strawberryJuiceOrderButton:
-            order(juice: .strawberryJuice)
-        case bananaJuiceOrderButton:
-            order(juice: .bananaJuice)
-        case pineappleJuiceOrderButton:
-            order(juice: .pineappleJuice)
-        case kiwiJuiceOrderButton:
-            order(juice: .kiwiJuice)
-        default:
-            order(juice: .mangoJuice)
-        }
+        // 딕셔너리만 사용
+        let IBOutlets = [strawberryBananaJuiceOrderButton: JuiceMaker.Menu.strawberryBananaJuice,
+                         mangoKiwiJuiceOrderButton:JuiceMaker.Menu.mangoKiwiJuice,
+                         strawberryJuiceOrderButton:JuiceMaker.Menu.strawberryJuice,
+                         bananaJuiceOrderButton:JuiceMaker.Menu.bananaJuice,
+                         pineappleJuiceOrderButton:JuiceMaker.Menu.pineappleJuice,
+                         kiwiJuiceOrderButton:JuiceMaker.Menu.kiwiJuice,
+                         mangoJuiceOrderButton:JuiceMaker.Menu.mangoJuice]
+        guard let juice =  IBOutlets[sender] else { return }
+        order(juice: juice)
+        
+ 
+        // extension해서 생성한 함수 + 딕셔너리 사용
+//        guard let menu = sender.test(IBOutlets: IBOutlets) else { return }
+//        order(juice:menu)
+
+        
+        // tag 사용
+//        let juice = sender.id
+//        order(juice: juice)
+        
+        
+        // 기존 코드
+//        switch sender {
+//        case strawberryBananaJuiceOrderButton:
+//            order(juice: .strawberryBananaJuice)
+//        case mangoKiwiJuiceOrderButton:
+//            order(juice: .mangoKiwiJuice)
+//        case strawberryJuiceOrderButton:
+//            order(juice: .strawberryJuice)
+//        case bananaJuiceOrderButton:
+//            order(juice: .bananaJuice)
+//        case pineappleJuiceOrderButton:
+//            order(juice: .pineappleJuice)
+//        case kiwiJuiceOrderButton:
+//            order(juice: .kiwiJuice)
+//        default:
+//            order(juice: .mangoJuice)
+//        }
     }
 }
 
-//extension UIButton {
-//    enum JuiceName: String {
-//        case strawberryJuice = "딸기쥬스"
-//        case bananaJuice = "바나나쥬스"
-//        case kiwiJuice = "키위쥬스"
-//        case pineappleJuice = "파인애플쥬스"
-//        case strawberryBananaJuice = "딸바쥬스"
-//        case mangoJuice = "망고쥬스"
-//        case mangoKiwiJuice = "망키쥬스"
-//    }
-//}
+extension UIButton {
+//  🤨 함수 사용 방법
+    func test(IBOutlets: [UIButton?:JuiceMaker.Menu]) -> JuiceMaker.Menu? {
+        var menu: JuiceMaker.Menu? = nil
+        IBOutlets.forEach {
+            if $0.key == self {
+                menu = $0.value
+            }
+        }
+        return menu
+    }
+    
+//  😢 tag 사용 방법
+    var id: JuiceMaker.Menu {
+        let tag = self.tag
+        
+        switch tag {
+        case 0:
+            return .strawberryBananaJuice
+        case 1:
+            return .mangoKiwiJuice
+        case 2:
+            return .strawberryJuice
+        case 3:
+            return .bananaJuice
+        case 4:
+            return .pineappleJuice
+        case 5:
+            return .kiwiJuice
+        default:
+            return .mangoJuice
+        }
+    }
+}

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -112,38 +112,38 @@ class JuiceOrderViewController: UIViewController {
 //        }
     }
 }
-
-extension UIButton {
-//  🤨 함수 사용 방법
-    func test(IBOutlets: [UIButton?:JuiceMaker.Menu]) -> JuiceMaker.Menu? {
-        var menu: JuiceMaker.Menu? = nil
-        IBOutlets.forEach {
-            if $0.key == self {
-                menu = $0.value
-            }
-        }
-        return menu
-    }
-    
-//  😢 tag 사용 방법
-    var id: JuiceMaker.Menu {
-        let tag = self.tag
-        
-        switch tag {
-        case 0:
-            return .strawberryBananaJuice
-        case 1:
-            return .mangoKiwiJuice
-        case 2:
-            return .strawberryJuice
-        case 3:
-            return .bananaJuice
-        case 4:
-            return .pineappleJuice
-        case 5:
-            return .kiwiJuice
-        default:
-            return .mangoJuice
-        }
-    }
-}
+//
+//extension UIButton {
+////  🤨 함수 사용 방법
+//    func convertOrderButtonToMenuType(IBOutlets: [UIButton?:JuiceMaker.Menu]) -> JuiceMaker.Menu? {
+//        var menu: JuiceMaker.Menu? = nil
+//        IBOutlets.forEach {
+//            if $0.key == self {
+//                menu = $0.value
+//            }
+//        }
+//        return menu
+//    }
+//
+////  😢 tag 사용 방법
+//    var id: JuiceMaker.Menu {
+//        let tag = self.tag
+//
+//        switch tag {
+//        case 0:
+//            return .strawberryBananaJuice
+//        case 1:
+//            return .mangoKiwiJuice
+//        case 2:
+//            return .strawberryJuice
+//        case 3:
+//            return .bananaJuice
+//        case 4:
+//            return .pineappleJuice
+//        case 5:
+//            return .kiwiJuice
+//        default:
+//            return .mangoJuice
+//        }
+//    }
+//}

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -26,6 +26,19 @@ class JuiceOrderViewController: UIViewController {
         updateFruitsInventoryLabels()
     }
     
+    @IBAction private func tapJuiceOrderButton(_ sender: UIButton) {
+        // 딕셔너리만 사용
+        let juiceMenuForEachButton = [strawberryBananaJuiceOrderButton: JuiceMaker.Menu.strawberryBananaJuice,
+                         mangoKiwiJuiceOrderButton: JuiceMaker.Menu.mangoKiwiJuice,
+                         strawberryJuiceOrderButton: JuiceMaker.Menu.strawberryJuice,
+                         bananaJuiceOrderButton: JuiceMaker.Menu.bananaJuice,
+                         pineappleJuiceOrderButton: JuiceMaker.Menu.pineappleJuice,
+                         kiwiJuiceOrderButton: JuiceMaker.Menu.kiwiJuice,
+                         mangoJuiceOrderButton: JuiceMaker.Menu.mangoJuice]
+        guard let juice = juiceMenuForEachButton[sender] else { return }
+        order(juice: juice)
+    }
+    
     private func updateFruitsInventoryLabels() {
         let errorValue = 999
         strawberryInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.strawberry] ?? errorValue)
@@ -69,81 +82,4 @@ class JuiceOrderViewController: UIViewController {
         
         present(alert, animated: true, completion: nil)
     }
-    
-    @IBAction private func tapJuiceOrderButton(_ sender: UIButton) {
-        // 딕셔너리만 사용
-        let IBOutlets = [strawberryBananaJuiceOrderButton: JuiceMaker.Menu.strawberryBananaJuice,
-                         mangoKiwiJuiceOrderButton:JuiceMaker.Menu.mangoKiwiJuice,
-                         strawberryJuiceOrderButton:JuiceMaker.Menu.strawberryJuice,
-                         bananaJuiceOrderButton:JuiceMaker.Menu.bananaJuice,
-                         pineappleJuiceOrderButton:JuiceMaker.Menu.pineappleJuice,
-                         kiwiJuiceOrderButton:JuiceMaker.Menu.kiwiJuice,
-                         mangoJuiceOrderButton:JuiceMaker.Menu.mangoJuice]
-        guard let juice =  IBOutlets[sender] else { return }
-        order(juice: juice)
-        
- 
-        // extension해서 생성한 함수 + 딕셔너리 사용
-//        guard let menu = sender.test(IBOutlets: IBOutlets) else { return }
-//        order(juice:menu)
-
-        
-        // tag 사용
-//        let juice = sender.id
-//        order(juice: juice)
-        
-        
-        // 기존 코드
-//        switch sender {
-//        case strawberryBananaJuiceOrderButton:
-//            order(juice: .strawberryBananaJuice)
-//        case mangoKiwiJuiceOrderButton:
-//            order(juice: .mangoKiwiJuice)
-//        case strawberryJuiceOrderButton:
-//            order(juice: .strawberryJuice)
-//        case bananaJuiceOrderButton:
-//            order(juice: .bananaJuice)
-//        case pineappleJuiceOrderButton:
-//            order(juice: .pineappleJuice)
-//        case kiwiJuiceOrderButton:
-//            order(juice: .kiwiJuice)
-//        default:
-//            order(juice: .mangoJuice)
-//        }
-    }
 }
-//
-//extension UIButton {
-////  🤨 함수 사용 방법
-//    func convertOrderButtonToMenuType(IBOutlets: [UIButton?:JuiceMaker.Menu]) -> JuiceMaker.Menu? {
-//        var menu: JuiceMaker.Menu? = nil
-//        IBOutlets.forEach {
-//            if $0.key == self {
-//                menu = $0.value
-//            }
-//        }
-//        return menu
-//    }
-//
-////  😢 tag 사용 방법
-//    var id: JuiceMaker.Menu {
-//        let tag = self.tag
-//
-//        switch tag {
-//        case 0:
-//            return .strawberryBananaJuice
-//        case 1:
-//            return .mangoKiwiJuice
-//        case 2:
-//            return .strawberryJuice
-//        case 3:
-//            return .bananaJuice
-//        case 4:
-//            return .pineappleJuice
-//        case 5:
-//            return .kiwiJuice
-//        default:
-//            return .mangoJuice
-//        }
-//    }
-//}

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -46,10 +46,11 @@ class JuiceOrderViewController: UIViewController {
     
     func showFailureAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        let yesAction = UIAlertAction(title: "예", style: .default) {
-            (action) in 
-            let storyboard = self.storyboard!.instantiateViewController(identifier: "InventoryViewController")
-            self.present(storyboard, animated: true, completion: nil)
+        let yesAction = UIAlertAction(title: "예", style: .default) { [weak self] (action) in
+            guard let storyboard = self?.storyboard?.instantiateViewController(identifier: "InventoryViewController") else {
+                return
+            }
+            self?.present(storyboard, animated: true, completion: nil)
         }
         
         let noAction = UIAlertAction(title: "아니오", style: .default)

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -7,23 +7,23 @@
 import UIKit
 
 class JuiceOrderViewController: UIViewController {
-    @IBOutlet weak var strawberryCount: UILabel!
-    @IBOutlet weak var bananaCount: UILabel!
-    @IBOutlet weak var pineappleCount: UILabel!
-    @IBOutlet weak var kiwiCount: UILabel!
-    @IBOutlet weak var mangoCount: UILabel!
+    @IBOutlet weak var strawberryInventoryLabel: UILabel!
+    @IBOutlet weak var bananaInventoryLabel: UILabel!
+    @IBOutlet weak var pineappleInventoryLabel: UILabel!
+    @IBOutlet weak var kiwiInventoryLabel: UILabel!
+    @IBOutlet weak var mangoInventoryLabel: UILabel!
         
     override func viewDidLoad() {
         super.viewDidLoad()
-        updateFruitsCountLabels()
+        updateFruitsInventoryLabels()
     }
     
-    func updateFruitsCountLabels() {
-        strawberryCount.text = String(JuiceMaker.shared.store.fruitsInventory[.strawberry]!)
-        bananaCount.text = String(JuiceMaker.shared.store.fruitsInventory[.banana]!)
-        pineappleCount.text = String(JuiceMaker.shared.store.fruitsInventory[.pineapple]!)
-        kiwiCount.text = String(JuiceMaker.shared.store.fruitsInventory[.kiwi]!)
-        mangoCount.text = String(JuiceMaker.shared.store.fruitsInventory[.mango]!)
+    func updateFruitsInventoryLabels() {
+        strawberryInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.strawberry]!)
+        bananaInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.banana]!)
+        pineappleInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.pineapple]!)
+        kiwiInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.kiwi]!)
+        mangoInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.mango]!)
     }
     
     private func order(juice: JuiceMaker.Menu) {
@@ -33,7 +33,7 @@ class JuiceOrderViewController: UIViewController {
         } catch {
             showFailureAlert(message: "재료가 모자라요. 재고를 수정할까요?")
         }
-        updateFruitsCountLabels()
+        updateFruitsInventoryLabels()
     }
     
     func showSuccessAlert(message: String) {
@@ -61,7 +61,7 @@ class JuiceOrderViewController: UIViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    @IBAction func juiceOrderButtonTapped(_ sender: UIButton) {
+    @IBAction func TapjuiceOrderButton(_ sender: UIButton) {
         let selected = sender.currentTitle
         
         switch selected {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -7,26 +7,26 @@
 import UIKit
 
 class JuiceOrderViewController: UIViewController {
-    @IBOutlet weak var strawberryInventoryLabel: UILabel!
-    @IBOutlet weak var bananaInventoryLabel: UILabel!
-    @IBOutlet weak var pineappleInventoryLabel: UILabel!
-    @IBOutlet weak var kiwiInventoryLabel: UILabel!
-    @IBOutlet weak var mangoInventoryLabel: UILabel!
+    @IBOutlet private weak var strawberryInventoryLabel: UILabel!
+    @IBOutlet private weak var bananaInventoryLabel: UILabel!
+    @IBOutlet private weak var pineappleInventoryLabel: UILabel!
+    @IBOutlet private weak var kiwiInventoryLabel: UILabel!
+    @IBOutlet private weak var mangoInventoryLabel: UILabel!
     
-    @IBOutlet weak var strawberryBananaJuiceOrderButton: UIButton!
-    @IBOutlet weak var mangoKiwiJuiceOrderButton: UIButton!
-    @IBOutlet weak var strawberryJuiceOrderButton: UIButton!
-    @IBOutlet weak var bananaJuiceOrderButton: UIButton!
-    @IBOutlet weak var pineappleJuiceOrderButton: UIButton!
-    @IBOutlet weak var kiwiJuiceOrderButton: UIButton!
-    @IBOutlet weak var mangoJuiceOrderButton: UIButton!
+    @IBOutlet private weak var strawberryBananaJuiceOrderButton: UIButton!
+    @IBOutlet private weak var mangoKiwiJuiceOrderButton: UIButton!
+    @IBOutlet private weak var strawberryJuiceOrderButton: UIButton!
+    @IBOutlet private weak var bananaJuiceOrderButton: UIButton!
+    @IBOutlet private weak var pineappleJuiceOrderButton: UIButton!
+    @IBOutlet private weak var kiwiJuiceOrderButton: UIButton!
+    @IBOutlet private weak var mangoJuiceOrderButton: UIButton!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         updateFruitsInventoryLabels()
     }
     
-    func updateFruitsInventoryLabels() {
+    private func updateFruitsInventoryLabels() {
         let errorValue = 999
         strawberryInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.strawberry] ?? errorValue)
         bananaInventoryLabel.text = String(JuiceMaker.shared.store.fruitsInventory[.banana] ?? errorValue)
@@ -45,7 +45,7 @@ class JuiceOrderViewController: UIViewController {
         }
     }
     
-    func showSuccessAlert(message: String) {
+    private func showSuccessAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let okAction = UIAlertAction(title: "고마워요 😘", style: .default)
         
@@ -53,7 +53,7 @@ class JuiceOrderViewController: UIViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    func showFailureAlert(message: String) {
+    private func showFailureAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let yesAction = UIAlertAction(title: "예", style: .default) { [weak self] (action) in
             guard let storyboard = self?.storyboard?.instantiateViewController(identifier: "InventoryViewController") else {
@@ -70,7 +70,7 @@ class JuiceOrderViewController: UIViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    @IBAction func tapJuiceOrderButton(_ sender: UIButton) {
+    @IBAction private func tapJuiceOrderButton(_ sender: UIButton) {
         // 딕셔너리만 사용
         let IBOutlets = [strawberryBananaJuiceOrderButton: JuiceMaker.Menu.strawberryBananaJuice,
                          mangoKiwiJuiceOrderButton:JuiceMaker.Menu.mangoKiwiJuice,

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -12,7 +12,15 @@ class JuiceOrderViewController: UIViewController {
     @IBOutlet weak var pineappleInventoryLabel: UILabel!
     @IBOutlet weak var kiwiInventoryLabel: UILabel!
     @IBOutlet weak var mangoInventoryLabel: UILabel!
-        
+    
+    @IBOutlet weak var strawberryBananaJuiceOrderButton: UIButton!
+    @IBOutlet weak var mangoKiwiJuiceOrderButton: UIButton!
+    @IBOutlet weak var strawberryJuiceOrderButton: UIButton!
+    @IBOutlet weak var bananaJuiceOrderButton: UIButton!
+    @IBOutlet weak var pineappleJuiceOrderButton: UIButton!
+    @IBOutlet weak var kiwiJuiceOrderButton: UIButton!
+    @IBOutlet weak var mangoJuiceOrderButton: UIButton!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         updateFruitsInventoryLabels()
@@ -31,10 +39,10 @@ class JuiceOrderViewController: UIViewController {
         do {
             try JuiceMaker.shared.make(juice: juice)
             showSuccessAlert(message: "\(juice.rawValue) 나왔습니다! 맛있게 드세요!")
+            updateFruitsInventoryLabels()
         } catch {
             showFailureAlert(message: "재료가 모자라요. 재고를 수정할까요?")
         }
-        updateFruitsInventoryLabels()
     }
     
     func showSuccessAlert(message: String) {
@@ -63,20 +71,18 @@ class JuiceOrderViewController: UIViewController {
     }
     
     @IBAction func tapJuiceOrderButton(_ sender: UIButton) {
-        let selected = sender.currentTitle
-        
-        switch selected {
-        case "딸바쥬스 주문":
+        switch sender {
+        case strawberryBananaJuiceOrderButton:
             order(juice: .strawberryBananaJuice)
-        case "망키쥬스 주문":
+        case mangoKiwiJuiceOrderButton:
             order(juice: .mangoKiwiJuice)
-        case "딸기쥬스 주문":
+        case strawberryJuiceOrderButton:
             order(juice: .strawberryJuice)
-        case "바나나쥬스 주문":
+        case bananaJuiceOrderButton:
             order(juice: .bananaJuice)
-        case "파인애플쥬스 주문":
+        case pineappleJuiceOrderButton:
             order(juice: .pineappleJuice)
-        case "키위쥬스 주문":
+        case kiwiJuiceOrderButton:
             order(juice: .kiwiJuice)
         default:
             order(juice: .mangoJuice)
@@ -84,3 +90,14 @@ class JuiceOrderViewController: UIViewController {
     }
 }
 
+//extension UIButton {
+//    enum JuiceName: String {
+//        case strawberryJuice = "딸기쥬스"
+//        case bananaJuice = "바나나쥬스"
+//        case kiwiJuice = "키위쥬스"
+//        case pineappleJuice = "파인애플쥬스"
+//        case strawberryBananaJuice = "딸바쥬스"
+//        case mangoJuice = "망고쥬스"
+//        case mangoKiwiJuice = "망키쥬스"
+//    }
+//}

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -18,8 +18,16 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
     }
+    
+    func updateInventory() {
+        strawberryCount.text = String(juiceMaker.store.fruitsInventory[.strawberry]!)
+        bananaCount.text = String(juiceMaker.store.fruitsInventory[.banana]!)
+        pineappleCount.text = String(juiceMaker.store.fruitsInventory[.pineapple]!)
+        kiwiCount.text = String(juiceMaker.store.fruitsInventory[.kiwi]!)
+        mangoCount.text = String(juiceMaker.store.fruitsInventory[.mango]!)
+    }
+    
     
     func order(juice: JuiceMaker.Menu) {
         do {
@@ -28,8 +36,8 @@ class ViewController: UIViewController {
         } catch {
             showFailureAlert(message: "재료가 모자라요. 재고를 수정할까요?")
         }
+        updateInventory()
     }
-    
     
     func showSuccessAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -18,6 +18,7 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        updateInventory()
     }
     
     func updateInventory() {
@@ -63,32 +64,25 @@ class ViewController: UIViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    @IBAction func strawberryBananaJuiceOrderTapped(_ sender: UIButton) {
-        order(juice: .strawberryBananaJuice)
-    }
-    
-    @IBAction func mangoKiwiJuiceOrderTapped(_ sender: UIButton) {
-        order(juice: .mangoKiwiJuice)
-    }
-    
-    @IBAction func strawberryJuiceOrderTapped(_ sender: UIButton) {
-        order(juice: .strawberryJuice)
-    }
-  
-    @IBAction func bananaJuiceOrderTapped(_ sender: UIButton) {
-        order(juice: .bananaJuice)
-    }
-    
-    @IBAction func pineappleJuiceOrderTapped(_ sender: UIButton) {
-        order(juice: .pineappleJuice)
-    }
-    
-    @IBAction func kiwiJuiceOrderTapped(_ sender: UIButton) {
-        order(juice: .kiwiJuice)
-    }
- 
-    @IBAction func mangoJuiceOrderTapped(_ sender: UIButton) {
-        order(juice: .mangoJuice)
+    @IBAction func juiceOrderButtonTapped(_ sender: UIButton) {
+        let selected = sender.currentTitle
+        
+        switch selected {
+        case "딸바쥬스 주문":
+            order(juice: .strawberryBananaJuice)
+        case "망키쥬스 주문":
+            order(juice: .mangoKiwiJuice)
+        case "딸기쥬스 주문":
+            order(juice: .strawberryJuice)
+        case "바나나쥬스 주문":
+            order(juice: .bananaJuice)
+        case "파인애플쥬스 주문":
+            order(juice: .pineappleJuice)
+        case "키위쥬스 주문":
+            order(juice: .kiwiJuice)
+        default:
+            order(juice: .mangoJuice)
+        }
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -8,11 +8,79 @@ import UIKit
 
 class ViewController: UIViewController {
 
+    @IBOutlet weak var strawberryCount: UILabel!
+    @IBOutlet weak var bananaCount: UILabel!
+    @IBOutlet weak var pineappleCount: UILabel!
+    @IBOutlet weak var kiwiCount: UILabel!
+    @IBOutlet weak var mangoCount: UILabel!
+    
+    let juiceMaker = JuiceMaker()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
     }
-
-
+    
+    func order(juice: JuiceMaker.Menu) {
+        do {
+            try juiceMaker.make(juice: juice)
+            showSuccessAlert(message: "\(juice.rawValue) 나왔습니다! 맛있게 드세요!")
+        } catch {
+            showFailureAlert(message: "재료가 모자라요. 재고를 수정할까요?")
+        }
+    }
+    
+    
+    func showSuccessAlert(message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "고마워요 😘", style: .default)
+        
+        alert.addAction(okAction)
+        present(alert, animated: true, completion: nil)
+    }
+    
+    func showFailureAlert(message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let yesAction = UIAlertAction(title: "예", style: .default) {
+            (action) in 
+            let storyboard = self.storyboard!.instantiateViewController(identifier: "InventoryViewController")
+            self.present(storyboard, animated: true, completion: nil)
+        }
+        
+        let noAction = UIAlertAction(title: "아니오", style: .default)
+        
+        alert.addAction(yesAction)
+        alert.addAction(noAction)
+        
+        present(alert, animated: true, completion: nil)
+    }
+    
+    @IBAction func strawberryBananaJuiceOrderTapped(_ sender: UIButton) {
+        order(juice: .strawberryBananaJuice)
+    }
+    
+    @IBAction func mangoKiwiJuiceOrderTapped(_ sender: UIButton) {
+        order(juice: .mangoKiwiJuice)
+    }
+    
+    @IBAction func strawberryJuiceOrderTapped(_ sender: UIButton) {
+        order(juice: .strawberryJuice)
+    }
+  
+    @IBAction func bananaJuiceOrderTapped(_ sender: UIButton) {
+        order(juice: .bananaJuice)
+    }
+    
+    @IBAction func pineappleJuiceOrderTapped(_ sender: UIButton) {
+        order(juice: .pineappleJuice)
+    }
+    
+    @IBAction func kiwiJuiceOrderTapped(_ sender: UIButton) {
+        order(juice: .kiwiJuice)
+    }
+ 
+    @IBAction func mangoJuiceOrderTapped(_ sender: UIButton) {
+        order(juice: .mangoJuice)
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -25,10 +25,8 @@ class FruitStore {
             let amountOfIngredient = ingredient[fruit] ?? 0
             guard var inventory = fruitsInventory[fruit] else { throw AppError.invalidInputOfFruit }
             
-            print("\(fruit) 사용전 재고: \(inventory)")
             inventory -= amountOfIngredient
             fruitsInventory[fruit] = inventory
-            print("\(fruit) 사용후 재고: \(inventory)")
         }
     }
     
@@ -37,10 +35,8 @@ class FruitStore {
             let amountOfSupply = ingredient[fruit] ?? 0
             guard var inventory = fruitsInventory[fruit] else { throw AppError.invalidInputOfFruit }
             
-            print("\(fruit) 입고전 재고: \(inventory)")
             inventory += amountOfSupply
             fruitsInventory[fruit] = inventory
-            print("\(fruit) 입고후 재고: \(inventory)")
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -14,7 +14,7 @@ class FruitStore {
     }
     
     typealias FruitsInventory = [Fruit: Int]
-    private var fruitsInventory: FruitsInventory = [:]
+    private(set) var fruitsInventory: FruitsInventory = [:]
     
     init(initialInventory:Int = 10) {
         Fruit.allCases.forEach { fruitsInventory[$0] = initialInventory }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker+Menu.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker+Menu.swift
@@ -1,12 +1,12 @@
 extension JuiceMaker {
-    enum Menu {
-        case strawberryJuice
-        case bananaJuice
-        case kiwiJuice
-        case pineappleJuice
-        case strawberryBananaJuice
-        case mangoJuice
-        case mangoKiwiJuice
+    enum Menu: String {
+        case strawberryJuice = "딸기쥬스"
+        case bananaJuice = "바나나쥬스"
+        case kiwiJuice = "키위쥬스"
+        case pineappleJuice = "파인애플쥬스"
+        case strawberryBananaJuice = "딸바쥬스"
+        case mangoJuice = "망고쥬스"
+        case mangoKiwiJuice = "망키쥬스"
         
         var recipe: [FruitStore.Fruit: Int] {
             switch self {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -16,6 +16,5 @@ struct JuiceMaker {
         guard fruitsToUse != nil else { throw AppError.lackOfInventory }
         
         try store.reduceInventory(of: juice.recipe)
-        print("\(juice)쥬스 나왔습니다! 맛있게 드세요!")
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,7 +5,7 @@
 // 
 
 struct JuiceMaker {
-    private var store = FruitStore()
+    private(set) var store = FruitStore()
         
     func make(juice: Menu) throws {
         let fruitsToUse = store.grabIngredients(of: juice.recipe)

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -6,7 +6,10 @@
 
 struct JuiceMaker {
     private(set) var store = FruitStore()
-        
+    static let shared = JuiceMaker()
+    
+    private init() { }
+    
     func make(juice: Menu) throws {
         let fruitsToUse = store.grabIngredients(of: juice.recipe)
         

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
-        <capability name="Image references" minToolsVersion="12.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -376,15 +374,14 @@
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KWA-Iz-51I">
-                                <rect key="frame" x="31" y="20" width="51" height="36"/>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KWA-Iz-51I">
+                                <rect key="frame" x="44" y="20" width="36" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="">
-                                    <imageReference key="image" image="xmark.circle" catalog="system" symbolScale="large"/>
-                                    <preferredSymbolConfiguration key="preferredSymbolConfigurationForImage" configurationType="pointSize" pointSize="18"/>
-                                    <attributedString key="attributedSubtitle"/>
-                                </buttonConfiguration>
+                                <state key="normal" title="Button" image="xmark.circle" catalog="system">
+                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font">
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                    </preferredSymbolConfiguration>
+                                </state>
                                 <connections>
                                     <action selector="touchUpDismissButton:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="Pm9-kK-AGq"/>
                                 </connections>
@@ -397,7 +394,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="901"/>
+            <point key="canvasLocation" x="1636.4928909952605" y="900"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="cAf-jL-tPK">

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -126,7 +126,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="strawberryBananaJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mae-wq-8zX"/>
+                                                    <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="N0d-Xv-3jV"/>
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
@@ -141,7 +141,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="mangoKiwiJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="lrp-qA-shF"/>
+                                                    <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="e7r-bI-crH"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -160,7 +160,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="strawberryJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ht2-dr-r4U"/>
+                                                            <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="h2p-Wx-FoP"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
@@ -171,7 +171,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="bananaJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="v20-gM-ueG"/>
+                                                            <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LxK-Q6-sAh"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
@@ -182,7 +182,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="pineappleJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7yR-i8-WYh"/>
+                                                            <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2iJ-BA-CZm"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
@@ -193,7 +193,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="kiwiJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="FPC-gu-wZ3"/>
+                                                            <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iij-hX-8Kf"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
@@ -204,7 +204,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="mangoJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="alA-9E-zom"/>
+                                                            <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="a0J-96-Vcd"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+    <device id="retina6_1" orientation="landscape" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -13,23 +15,23 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="JuiceOrderViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="16" y="64" width="568" height="210"/>
+                                <rect key="frame" x="60" y="64" width="776" height="145"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="101" height="210"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="142.5" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="101" height="179"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="187" width="101" height="23"/>
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -38,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="117" y="0.0" width="100.5" height="210"/>
+                                        <rect key="frame" x="158.5" y="0.0" width="142.5" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="100.5" height="179"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="187" width="100.5" height="23"/>
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -56,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="233.5" y="0.0" width="101" height="210"/>
+                                        <rect key="frame" x="317" y="0.0" width="142" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="101" height="179"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="142" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="187" width="101" height="23"/>
+                                                <rect key="frame" x="0.0" y="122" width="142" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -74,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="350.5" y="0.0" width="100.5" height="210"/>
+                                        <rect key="frame" x="475" y="0.0" width="142.5" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="100.5" height="179"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="187" width="100.5" height="23"/>
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -92,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="467" y="0.0" width="101" height="210"/>
+                                        <rect key="frame" x="633.5" y="0.0" width="142.5" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="101" height="179"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="187" width="101" height="23"/>
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -112,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="16" y="294" width="568" height="286"/>
+                                <rect key="frame" x="60" y="229" width="776" height="144"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="568" height="139"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="776" height="68"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="217.5" height="139"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="301" height="68"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -129,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="233.5" y="0.0" width="101" height="139"/>
+                                                <rect key="frame" x="317" y="0.0" width="142" height="68"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="350.5" y="0.0" width="217.5" height="139"/>
+                                                <rect key="frame" x="475" y="0.0" width="301" height="68"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -146,13 +148,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="147" width="568" height="139"/>
+                                        <rect key="frame" x="0.0" y="76" width="776" height="68"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="568" height="139"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="776" height="68"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="101" height="139"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -163,7 +165,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="117" y="0.0" width="100.5" height="139"/>
+                                                        <rect key="frame" x="158.5" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -174,7 +176,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="233.5" y="0.0" width="101" height="139"/>
+                                                        <rect key="frame" x="317" y="0.0" width="142" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -185,7 +187,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="350.5" y="0.0" width="100.5" height="139"/>
+                                                        <rect key="frame" x="475" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -196,7 +198,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="467" y="0.0" width="101" height="139"/>
+                                                        <rect key="frame" x="633.5" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -242,10 +244,17 @@
                     </navigationItem>
                     <connections>
                         <outlet property="bananaInventoryLabel" destination="gvk-pA-Lw5" id="ti6-rO-tmE"/>
+                        <outlet property="bananaJuiceOrderButton" destination="y2A-PH-DJY" id="uwl-ME-RIB"/>
                         <outlet property="kiwiInventoryLabel" destination="FZq-de-TJG" id="WFf-aj-ouV"/>
+                        <outlet property="kiwiJuiceOrderButton" destination="wcW-7H-RXw" id="Yin-bw-DZv"/>
                         <outlet property="mangoInventoryLabel" destination="3Ce-SU-JeH" id="VAz-gh-adg"/>
+                        <outlet property="mangoJuiceOrderButton" destination="q6G-4X-bVm" id="cze-6g-6aJ"/>
+                        <outlet property="mangoKiwiJuiceOrderButton" destination="ngP-kF-Yii" id="uUa-a8-ETL"/>
                         <outlet property="pineappleInventoryLabel" destination="ccQ-Dk-PuY" id="Udd-4c-Y8B"/>
+                        <outlet property="pineappleJuiceOrderButton" destination="BFb-ka-wGA" id="E89-7x-kAv"/>
+                        <outlet property="strawberryBananaJuiceOrderButton" destination="hrc-2F-fzl" id="IGZ-d4-TYa"/>
                         <outlet property="strawberryInventoryLabel" destination="Qas-vP-td6" id="51y-6h-TDp"/>
+                        <outlet property="strawberryJuiceOrderButton" destination="avd-o5-3JM" id="qsq-U2-ZQm"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -258,7 +267,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -275,7 +284,7 @@
             <objects>
                 <viewController storyboardIdentifier="InventoryViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Yu1-lM-nqp" customClass="InventoryViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
@@ -401,7 +410,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -415,7 +424,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="wH1-3A-cBm"/>
+        <segue reference="WQU-OQ-nY0"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="xmark.circle" catalog="system" width="128" height="121"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_1" orientation="landscape" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -134,7 +133,7 @@
                                                 <rect key="frame" x="317" y="0.0" width="142" height="68"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                            <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
                                                 <rect key="frame" x="475" y="0.0" width="301" height="68"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -153,7 +152,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
                                                 <rect key="frame" x="0.0" y="0.0" width="776" height="68"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
+                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
                                                         <rect key="frame" x="0.0" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -164,7 +163,7 @@
                                                             <action selector="tapJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="h2p-Wx-FoP"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="158.5" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -175,7 +174,7 @@
                                                             <action selector="tapJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LxK-Q6-sAh"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                    <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="317" y="0.0" width="142" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -186,7 +185,7 @@
                                                             <action selector="tapJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2iJ-BA-CZm"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="475" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -197,7 +196,7 @@
                                                             <action selector="tapJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iij-hX-8Kf"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                    <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="633.5" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -241,11 +241,11 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="bananaCount" destination="gvk-pA-Lw5" id="ti6-rO-tmE"/>
-                        <outlet property="kiwiCount" destination="FZq-de-TJG" id="WFf-aj-ouV"/>
-                        <outlet property="mangoCount" destination="3Ce-SU-JeH" id="VAz-gh-adg"/>
-                        <outlet property="pineappleCount" destination="ccQ-Dk-PuY" id="Udd-4c-Y8B"/>
-                        <outlet property="strawberryCount" destination="Qas-vP-td6" id="51y-6h-TDp"/>
+                        <outlet property="bananaInventoryLabel" destination="gvk-pA-Lw5" id="ti6-rO-tmE"/>
+                        <outlet property="kiwiInventoryLabel" destination="FZq-de-TJG" id="WFf-aj-ouV"/>
+                        <outlet property="mangoInventoryLabel" destination="3Ce-SU-JeH" id="VAz-gh-adg"/>
+                        <outlet property="pineappleInventoryLabel" destination="ccQ-Dk-PuY" id="Udd-4c-Y8B"/>
+                        <outlet property="strawberryInventoryLabel" destination="Qas-vP-td6" id="51y-6h-TDp"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
-    <device id="retina6_0" orientation="landscape" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -12,25 +11,25 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="JuiceOrderViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="60" y="52" width="724" height="136.66666666666666"/>
+                                <rect key="frame" x="16" y="64" width="568" height="210"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="101" height="210"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="101" height="179"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="187" width="101" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -39,16 +38,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="148" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="117" y="0.0" width="100.5" height="210"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="100.5" height="179"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="187" width="100.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -57,16 +56,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="296" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="233.5" y="0.0" width="101" height="210"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="101" height="179"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="187" width="101" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -75,16 +74,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="444" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="350.5" y="0.0" width="100.5" height="210"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="100.5" height="179"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="187" width="100.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -93,16 +92,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="592" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="467" y="0.0" width="101" height="210"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="101" height="179"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="187" width="101" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -113,13 +112,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="60" y="208.66666666666663" width="724" height="140.33333333333337"/>
+                                <rect key="frame" x="16" y="294" width="568" height="286"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="724" height="66"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="568" height="139"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="217.5" height="139"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -130,11 +129,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="296" y="0.0" width="132" height="66"/>
+                                                <rect key="frame" x="233.5" y="0.0" width="101" height="139"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="444" y="0.0" width="280" height="66"/>
+                                                <rect key="frame" x="350.5" y="0.0" width="217.5" height="139"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -147,13 +146,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="74.000000000000028" width="724" height="66.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="147" width="568" height="139"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="724" height="66.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="568" height="139"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="101" height="139"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -164,7 +163,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="117" y="0.0" width="100.5" height="139"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -175,7 +174,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="233.5" y="0.0" width="101" height="139"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -186,7 +185,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="350.5" y="0.0" width="100.5" height="139"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -197,7 +196,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="467" y="0.0" width="101" height="139"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -276,7 +275,7 @@
             <objects>
                 <viewController storyboardIdentifier="InventoryViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Yu1-lM-nqp" customClass="InventoryViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
@@ -416,7 +415,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="WQU-OQ-nY0"/>
+        <segue reference="wH1-3A-cBm"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="xmark.circle" catalog="system" width="128" height="121"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -125,7 +125,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="N0d-Xv-3jV"/>
+                                                    <action selector="tapJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="N0d-Xv-3jV"/>
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
@@ -140,7 +140,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="e7r-bI-crH"/>
+                                                    <action selector="tapJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="e7r-bI-crH"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -159,7 +159,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="h2p-Wx-FoP"/>
+                                                            <action selector="tapJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="h2p-Wx-FoP"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
@@ -170,7 +170,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LxK-Q6-sAh"/>
+                                                            <action selector="tapJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LxK-Q6-sAh"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
@@ -181,7 +181,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2iJ-BA-CZm"/>
+                                                            <action selector="tapJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2iJ-BA-CZm"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
@@ -192,7 +192,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iij-hX-8Kf"/>
+                                                            <action selector="tapJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iij-hX-8Kf"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
@@ -203,7 +203,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="juiceOrderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="a0J-96-Vcd"/>
+                                                            <action selector="tapJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="a0J-96-Vcd"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -126,6 +127,9 @@
                                                 <state key="normal" title="딸바쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="strawberryBananaJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mae-wq-8zX"/>
+                                                </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
                                                 <rect key="frame" x="296" y="0.0" width="132" height="66"/>
@@ -138,6 +142,9 @@
                                                 <state key="normal" title="망키쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="mangoKiwiJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="lrp-qA-shF"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -154,6 +161,9 @@
                                                         <state key="normal" title="딸기쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="strawberryJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ht2-dr-r4U"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
@@ -162,6 +172,9 @@
                                                         <state key="normal" title="바나나쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="bananaJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="v20-gM-ueG"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
@@ -170,6 +183,9 @@
                                                         <state key="normal" title="파인애플쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="pineappleJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7yR-i8-WYh"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
@@ -178,6 +194,9 @@
                                                         <state key="normal" title="키위쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="kiwiJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="FPC-gu-wZ3"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
@@ -186,6 +205,9 @@
                                                         <state key="normal" title="망고쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="mangoJuiceOrderTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="alA-9E-zom"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                             </stackView>
@@ -215,12 +237,23 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
+                            <connections>
+                                <segue destination="Yu1-lM-nqp" kind="presentation" id="WQU-OQ-nY0"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="bananaCount" destination="gvk-pA-Lw5" id="ti6-rO-tmE"/>
+                        <outlet property="kiwiCount" destination="FZq-de-TJG" id="WFf-aj-ouV"/>
+                        <outlet property="mangoCount" destination="3Ce-SU-JeH" id="VAz-gh-adg"/>
+                        <outlet property="pineappleCount" destination="ccQ-Dk-PuY" id="Udd-4c-Y8B"/>
+                        <outlet property="strawberryCount" destination="Qas-vP-td6" id="51y-6h-TDp"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="762.72321428571422" y="92.753623188405811"/>
+            <point key="canvasLocation" x="928" y="900"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="LzN-aE-P5w">
@@ -238,12 +271,12 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="66L-FI-VI3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
+            <point key="canvasLocation" x="240" y="900"/>
         </scene>
-        <!--View Controller-->
+        <!--Inventory View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="InventoryViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Yu1-lM-nqp" customClass="InventoryViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -343,6 +376,19 @@
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KWA-Iz-51I">
+                                <rect key="frame" x="31" y="20" width="51" height="36"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="">
+                                    <imageReference key="image" image="xmark.circle" catalog="system" symbolScale="large"/>
+                                    <preferredSymbolConfiguration key="preferredSymbolConfigurationForImage" configurationType="pointSize" pointSize="18"/>
+                                    <attributedString key="attributedSubtitle"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="touchUpDismissButton:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="Pm9-kK-AGq"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -369,10 +415,14 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2s5-lS-967" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="21"/>
+            <point key="canvasLocation" x="1636" y="-426"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="WQU-OQ-nY0"/>
+    </inferredMetricsTieBreakers>
     <resources>
+        <image name="xmark.circle" catalog="system" width="128" height="121"/>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>


### PR DESCRIPTION
@leejun6694 

안녕하세요, 쿠마! 😁
JuiceMaker 프로젝트 5조 민쏜과 현이입니다.

Step 2 PR 보냅니다. 검토 부탁드립니다! ☺️
감사합니다!




### 1. 쥬스 주문 버튼
- 처음에는 쥬스 주문 버튼 7개를 각각의 `@IBAction func`로 가져왔습니다.
- 7개의 버튼은 모두 같은 메서드를 사용하는 같은 역할의 버튼이라고 생각해 하나의 메서드로 묶어보았습니다.
- 개선하고 싶은 점:
	- 현재 코드에서는 스토리보드에서 버튼의 내용을 바꾸면 `juiceOrderButtonTapped` 메서드의 switch 문의 case와 일치하지 않아 분기처리에 문제가 생깁니다.
	- 만약 7개의 버튼 각각에 JuiceMaker.Menu 타입을 담을 수 있다면, `juiceOrderButtonTapped` 메서드의 아규먼트로 메뉴 자체를 전달 받고 싶습니다. 이런 방식의 구현이 가능하다면 switch문 분기를 사용하는 대신, 전달 받은 메뉴를 `order` 메서드에 넣어주기만 하면 코드가 훨씬 간결해지고, 버튼의 타이틀을 수정하면서 발생할 수 있는 문제도 해결될 것 같습니다.
	- `질문👀`: 이런 접근 방법으로 개선해보는 게 가능할까요? 가능하다면, 어떤 키워드를 검색해보면 좋을까요? 

<img width="1596" alt="Pasted image 20220503112639" src="https://user-images.githubusercontent.com/96630194/166413551-ea09892b-b654-457e-8a39-938a61a8e41f.png">



### 2. 재고 변동을 전달 받는 방식
활동학습에서 Notification으로 이벤트를 처리하는 방법을 배웠습니다. 이번 쥬스 프로젝트에도 적용해 볼 수 있을 것 같아 재고가 변화될 때마다 알림을 받아 재고 레이블을 업데이트하는 NotificationCenter를 아래와 같이 작성해보았습니다.

```swift
func notification(name: Notification.Name) {
        
        NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil) 
        { 
            Notification in self.updateInventory()
        }
        
        NotificationCenter.default.post(name: name, object: nil)
}

// order에서 notifiation() 호출
func order(juice: JuiceMaker.Menu) {
        // ... 위에 코드 생략
        notification(name: Notification.Name("재고 변화"))
    }
```

`addObserver`와 `post`를 같은 메서드 안에서 호출한 건 이벤트가 일어나는 곳과 처리하는 곳이 동일하다고 생각했기 때문입니다. 현재 상태에서는 `order 메서드`의 `notification()` 호출 하는 자리에 `updateInventory()` 를 넣어도 동일하게 작동합니다.

활동학습 시간에 다뤘던 내용이기에 활용해보려고 했지만, 현재 프로젝트에서는 노티피케이션 센터의 개념을 활용할 때의 장점이 보이지 않았습니다. 오히려 코드가 더 길어지고 가독성이 떨어진다는 생각이 들어, 작성한 내용을 코드에 반영하지는 않았습니다.

1) 현재 코드에 노티피케이션을 활용할 때의 장점이 있을까요?
2) 만약 사용한다고 가정한다면, 아직 Notification 사용법이 익숙치 않아 위와 같이 구현했는데, 이벤트 발생과 처리를 동일한 함수에서 처리하는게 좋은 방향인지 궁금합니다.
