### PR TITLE
쥬스메이커 [STEP3] unchain123, kiwi

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4D438928281809D1004E2BA2 /* Fruits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D438927281809D1004E2BA2 /* Fruits.swift */; };
+		4D438928281809D1004E2BA2 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D438927281809D1004E2BA2 /* Fruit.swift */; };
 		8F6A9B8728180D9300FCB772 /* FruitStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6A9B8628180D9300FCB772 /* FruitStoreError.swift */; };
 		8F6A9B8928180E7600FCB772 /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6A9B8828180E7600FCB772 /* Juice.swift */; };
 		8FEB43FB281FCDBE008EBC91 /* StockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEB43FA281FCDBE008EBC91 /* StockViewController.swift */; };
@@ -22,7 +22,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		4D438927281809D1004E2BA2 /* Fruits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruits.swift; sourceTree = "<group>"; };
+		4D438927281809D1004E2BA2 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		8F6A9B8628180D9300FCB772 /* FruitStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStoreError.swift; sourceTree = "<group>"; };
 		8F6A9B8828180E7600FCB772 /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
 		8FEB43FA281FCDBE008EBC91 /* StockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockViewController.swift; sourceTree = "<group>"; };
@@ -64,7 +64,7 @@
 			isa = PBXGroup;
 			children = (
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
-				4D438927281809D1004E2BA2 /* Fruits.swift */,
+				4D438927281809D1004E2BA2 /* Fruit.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				8F6A9B8628180D9300FCB772 /* FruitStoreError.swift */,
 				8F6A9B8828180E7600FCB772 /* Juice.swift */,
@@ -182,7 +182,7 @@
 				8FEB43FB281FCDBE008EBC91 /* StockViewController.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* MakeJuiceViewController.swift in Sources */,
-				4D438928281809D1004E2BA2 /* Fruits.swift in Sources */,
+				4D438928281809D1004E2BA2 /* Fruit.swift in Sources */,
 				8F6A9B8728180D9300FCB772 /* FruitStoreError.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* MakeJuiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* MakeJuiceViewController.swift */; };
+		C73DAF3B255D0CDD00020D38 /* JuiceMakerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */; };
 		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
@@ -30,7 +30,7 @@
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C73DAF3A255D0CDD00020D38 /* MakeJuiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeJuiceViewController.swift; sourceTree = "<group>"; };
+		C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMakerViewController.swift; sourceTree = "<group>"; };
 		C73DAF3D255D0CDD00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -54,7 +54,7 @@
 			children = (
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
-				C73DAF3A255D0CDD00020D38 /* MakeJuiceViewController.swift */,
+				C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */,
 				8FEB43FA281FCDBE008EBC91 /* StockViewController.swift */,
 			);
 			path = Controller;
@@ -181,7 +181,7 @@
 			files = (
 				8FEB43FB281FCDBE008EBC91 /* StockViewController.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* MakeJuiceViewController.swift in Sources */,
+				C73DAF3B255D0CDD00020D38 /* JuiceMakerViewController.swift in Sources */,
 				4D438928281809D1004E2BA2 /* Fruit.swift in Sources */,
 				8F6A9B8728180D9300FCB772 /* FruitStoreError.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-final class MakeJuiceViewController: UIViewController {
+final class JuiceMakerViewController: UIViewController {
     
     @IBOutlet weak var strawberryStockLable: UILabel!
     @IBOutlet weak var bananaStockLable: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
@@ -8,11 +8,11 @@ import UIKit
 
 final class MakeJuiceViewController: UIViewController {
     
-    @IBOutlet weak var strawberryStock: UILabel!
-    @IBOutlet weak var bananaStock: UILabel!
-    @IBOutlet weak var pineappleStock: UILabel!
-    @IBOutlet weak var kiwiStock: UILabel!
-    @IBOutlet weak var mangoStock: UILabel!
+    @IBOutlet weak var strawberryStockLable: UILabel!
+    @IBOutlet weak var bananaStockLable: UILabel!
+    @IBOutlet weak var pineappleStockLable: UILabel!
+    @IBOutlet weak var kiwiStockLable: UILabel!
+    @IBOutlet weak var mangoStockLable: UILabel!
     
     @IBOutlet weak var strawBerryBananJuiceButton: UIButton!
     @IBOutlet weak var mangoKiwiJuiceButton: UIButton!
@@ -45,11 +45,11 @@ final class MakeJuiceViewController: UIViewController {
     }
     
     private func updateViews() {
-        strawberryStock.text = showFruitsStock(name: .strawberry)
-        bananaStock.text = showFruitsStock(name: .banana)
-        pineappleStock.text = showFruitsStock(name: .pineapple)
-        kiwiStock.text = showFruitsStock(name: .kiwi)
-        mangoStock.text = showFruitsStock(name: .mango)
+        strawberryStockLable.text = showFruitsStock(name: .strawberry)
+        bananaStockLable.text = showFruitsStock(name: .banana)
+        pineappleStockLable.text = showFruitsStock(name: .pineapple)
+        kiwiStockLable.text = showFruitsStock(name: .kiwi)
+        mangoStockLable.text = showFruitsStock(name: .mango)
     }
     
     private func showFruitsStock(name: Fruit) -> String {
@@ -59,15 +59,15 @@ final class MakeJuiceViewController: UIViewController {
     private func selectFruitLable(fruit: Fruit) -> UILabel {
         switch fruit {
         case .strawberry:
-            return strawberryStock
+            return strawberryStockLable
         case .mango:
-            return mangoStock
+            return mangoStockLable
         case .kiwi:
-            return kiwiStock
+            return kiwiStockLable
         case .pineapple:
-            return pineappleStock
+            return pineappleStockLable
         case .banana:
-            return bananaStock
+            return bananaStockLable
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
@@ -53,7 +53,7 @@ final class MakeJuiceViewController: UIViewController {
     }
     
     private func showFruitsStock(name: Fruits) -> String {
-        return juiceMaker.fruitStore.showFruitsStock(name: name)
+        return FruitStore.shared.showFruitsStock(name: name)
     }
     
     private func selectFruitLable(fruit: Fruits) -> UILabel {

--- a/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
@@ -102,7 +102,7 @@ final class MakeJuiceViewController: UIViewController {
     private func showCheckStockMessage() {
         let checkStockMessage = UIAlertController(title: "재료가 모자라요. 재고를 수정할까요?", message: nil, preferredStyle: .alert)
         let yesButton = UIAlertAction(title: "예", style: .default) { _ in
-            self.performSegue(withIdentifier: "showFruitStock", sender: nil)
+            self.performSegue(withIdentifier: "showFruitStockSegue", sender: nil)
         }
         let noButton = UIAlertAction(title: "아니오", style: .default, handler: nil)
         

--- a/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
@@ -53,7 +53,7 @@ final class MakeJuiceViewController: UIViewController {
     }
     
     private func showFruitsStock(name: Fruit) -> String {
-        return FruitStore.shared.showFruitsStock(name: name)
+        return String(FruitStore.shared.showFruitsStock(name: name))
     }
     
     private func selectFruitLable(fruit: Fruit) -> UILabel {

--- a/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
@@ -57,11 +57,11 @@ final class MakeJuiceViewController: UIViewController {
         mangoStock.text = showFruitsStock(name: .mango)
     }
     
-    private func showFruitsStock(name: Fruits) -> String {
+    private func showFruitsStock(name: Fruit) -> String {
         return FruitStore.shared.showFruitsStock(name: name)
     }
     
-    private func selectFruitLable(fruit: Fruits) -> UILabel {
+    private func selectFruitLable(fruit: Fruit) -> UILabel {
         switch fruit {
         case .strawberry:
             return strawberryStock

--- a/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
@@ -24,14 +24,9 @@ final class MakeJuiceViewController: UIViewController {
     
     private let juiceMaker = JuiceMaker()
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        setupViews()
-    }
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setupViews()
+        updateViews()
     }
     
     @IBAction private func didTapOrderJuice(_ sender: UIButton) {
@@ -49,7 +44,7 @@ final class MakeJuiceViewController: UIViewController {
         }
     }
     
-    private func setupViews() {
+    private func updateViews() {
         strawberryStock.text = showFruitsStock(name: .strawberry)
         bananaStock.text = showFruitsStock(name: .banana)
         pineappleStock.text = showFruitsStock(name: .pineapple)

--- a/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MakeJuiceViewController.swift
@@ -29,6 +29,11 @@ final class MakeJuiceViewController: UIViewController {
         setupViews()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupViews()
+    }
+    
     @IBAction private func didTapOrderJuice(_ sender: UIButton) {
         do {
             let order = try orderJuice(sender: sender)
@@ -101,9 +106,8 @@ final class MakeJuiceViewController: UIViewController {
     
     private func showCheckStockMessage() {
         let checkStockMessage = UIAlertController(title: "재료가 모자라요. 재고를 수정할까요?", message: nil, preferredStyle: .alert)
-        let yesButton = UIAlertAction(title: "예", style: .default) { action -> Void in
-            let stockViewController = self.storyboard?.instantiateViewController(withIdentifier: "stockViewController")
-            self.present(stockViewController!, animated: true, completion: nil)
+        let yesButton = UIAlertAction(title: "예", style: .default) { _ in
+            self.performSegue(withIdentifier: "showFruitStock", sender: nil)
         }
         let noButton = UIAlertAction(title: "아니오", style: .default, handler: nil)
         

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -2,7 +2,7 @@
 //  stockViewController.swift
 //  JuiceMaker
 //
-//  Created by 오경식 on 2022/05/02.
+//  Created by unchain, kiwi on 2022/05/02.
 //
 
 import UIKit
@@ -20,7 +20,6 @@ class StockViewController: UIViewController {
     @IBOutlet weak var pineappleStepper: UIStepper!
     @IBOutlet weak var kiwiStepper: UIStepper!
     @IBOutlet weak var mangoStepper: UIStepper!
-    
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -27,6 +27,10 @@ class StockViewController: UIViewController {
         setupStepper()
     }
     
+    @IBAction func didTapClosedStockViewController(_ sender: UIBarButtonItem) {
+        self.dismiss(animated: true)
+    }
+    
     func setupStepper() {
         strawberryStepper.value = Double(makeVaildStepperValue(fruit: .strawberry))
         bananaStepper.value = Double(makeVaildStepperValue(fruit: .banana))
@@ -46,9 +50,5 @@ class StockViewController: UIViewController {
         pineappleStock.text = FruitStore.shared.showFruitsStock(name: .pineapple)
         kiwiStock.text = FruitStore.shared.showFruitsStock(name: .kiwi)
         mangoStock.text = FruitStore.shared.showFruitsStock(name: .mango)
-    }
-    
-    @IBAction func didTapClosedStockViewController(_ sender: UIBarButtonItem) {
-        self.dismiss(animated: true)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -31,6 +31,23 @@ class StockViewController: UIViewController {
         self.dismiss(animated: true)
     }
     
+    func findFruitStepper(stepper: UIStepper) throws -> Fruits {
+        switch stepper {
+        case strawberryStepper:
+            return .strawberry
+        case bananaStepper:
+            return .banana
+        case pineappleStepper:
+            return .pineapple
+        case kiwiStepper:
+            return .kiwi
+        case mangoStepper:
+            return .mango
+        default:
+            throw FruitStoreError.wrongMenu
+        }
+    }
+    
     func setupStepper() {
         strawberryStepper.value = Double(makeVaildStepperValue(fruit: .strawberry))
         bananaStepper.value = Double(makeVaildStepperValue(fruit: .banana))

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -26,6 +26,11 @@ class StockViewController: UIViewController {
         setupViews()
     }
     
+    func makeVaildStepperValue(fruit: Fruits) -> Int {
+        guard let stepperValue = FruitStore.shared.fruits[fruit] else { return -1 }
+        return stepperValue
+    }
+    
     func setupViews() {
         strawberryStock.text = FruitStore.shared.showFruitsStock(name: .strawberry)
         bananaStock.text = FruitStore.shared.showFruitsStock(name: .banana)

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -32,15 +32,15 @@ final class StockViewController: UIViewController {
     }
     
     @IBAction private func didTapStepper(_ sender: UIStepper) {
-           do {
-           let fruit = try findFruit(stepper: sender)
-           changeStock(fruit: fruit)
-           } catch FruitStoreError.wrongFruit {
-               print("없는 과일입니다")
-           } catch {
-               print("")
-           }
-       }
+        do {
+            let fruit = try findFruit(stepper: sender)
+            changeStock(fruit: fruit)
+        } catch FruitStoreError.wrongFruit {
+            print("없는 과일입니다")
+        } catch {
+            print("")
+        }
+    }
     
     private func setupViews() {
         strawberryStockLable.text = FruitStore.shared.showFruitsStock(name: .strawberry)

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -24,10 +24,10 @@ class StockViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupView()
+        setupViews()
     }
     
-    func setupView() {
+    func setupViews() {
         strawberryStock.text = FruitStore.shared.showFruitsStock(name: .strawberry)
         bananaStock.text = FruitStore.shared.showFruitsStock(name: .banana)
         pineappleStock.text = FruitStore.shared.showFruitsStock(name: .pineapple)

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -27,7 +27,7 @@ final class StockViewController: UIViewController {
         setupStepper()
     }
     
-    @IBAction private func didTapClosedStockViewController(_ sender: UIBarButtonItem) {
+    @IBAction private func didTapClosedBarButton(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -43,11 +43,15 @@ final class StockViewController: UIViewController {
        }
     
     private func setupViews() {
-        strawberryStockLable.text = FruitStore.shared.showFruitsStock(name: .strawberry)
-        bananaStockLable.text = FruitStore.shared.showFruitsStock(name: .banana)
-        pineappleStockLable.text = FruitStore.shared.showFruitsStock(name: .pineapple)
-        kiwiStockLable.text = FruitStore.shared.showFruitsStock(name: .kiwi)
-        mangoStockLable.text = FruitStore.shared.showFruitsStock(name: .mango)
+        strawberryStockLable.text = showFruitsStock(name: .strawberry)
+        bananaStockLable.text = showFruitsStock(name: .banana)
+        pineappleStockLable.text = showFruitsStock(name: .pineapple)
+        kiwiStockLable.text = showFruitsStock(name: .kiwi)
+        mangoStockLable.text = showFruitsStock(name: .mango)
+    }
+    
+    private func showFruitsStock(name: Fruit) -> String {
+        return String(FruitStore.shared.showFruitsStock(name: name))
     }
     
     private func findFruit(stepper: UIStepper) throws -> Fruit {
@@ -83,16 +87,11 @@ final class StockViewController: UIViewController {
     }
     
     private func setupStepper() {
-        strawberryStepper.value = Double(makeVaildStepperValue(fruit: .strawberry))
-        bananaStepper.value = Double(makeVaildStepperValue(fruit: .banana))
-        pineappleStepper.value = Double(makeVaildStepperValue(fruit: .pineapple))
-        kiwiStepper.value = Double(makeVaildStepperValue(fruit: .kiwi))
-        mangoStepper.value = Double(makeVaildStepperValue(fruit: .mango))
-    }
-    
-    private func makeVaildStepperValue(fruit: Fruit) -> Int {
-        guard let stepperValue = FruitStore.shared.fruits[fruit] else { return -1 }
-        return stepperValue
+        strawberryStepper.value = Double(FruitStore.shared.showFruitsStock(name: .strawberry))
+        bananaStepper.value = Double(FruitStore.shared.showFruitsStock(name: .banana))
+        pineappleStepper.value = Double(FruitStore.shared.showFruitsStock(name: .pineapple))
+        kiwiStepper.value = Double(FruitStore.shared.showFruitsStock(name: .kiwi))
+        mangoStepper.value = Double(FruitStore.shared.showFruitsStock(name: .mango))
     }
     
     private func selectFruitLable(fruit: Fruit) -> UILabel {
@@ -111,7 +110,7 @@ final class StockViewController: UIViewController {
     }
     
     private func changeStock(fruit: Fruit) {
-        FruitStore.shared.fruits[fruit] = Int(findFruitStepper(fruit: fruit).value)
-        selectFruitLable(fruit: fruit).text = FruitStore.shared.showFruitsStock(name: fruit)
+        FruitStore.shared.changeStock(fruit: fruit, newValue: Int(findFruitStepper(fruit: fruit).value))
+        selectFruitLable(fruit: fruit).text = showFruitsStock(name: fruit)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -57,44 +57,49 @@ class StockViewController: UIViewController {
     }
     
     func findFruitStepper(fruit: Fruits) -> UIStepper {
-            switch fruit {
-            case .strawberry:
-                return strawberryStepper
-            case .banana:
-                return bananaStepper
-            case .pineapple:
-                return pineappleStepper
-            case .kiwi:
-                return kiwiStepper
-            case .mango:
-                return mangoStepper
-            }
-    
-    func setupStepper() {
-        strawberryStepper.value = Double(makeVaildStepperValue(fruit: .strawberry))
-        bananaStepper.value = Double(makeVaildStepperValue(fruit: .banana))
-        pineappleStepper.value = Double(makeVaildStepperValue(fruit: .pineapple))
-        kiwiStepper.value = Double(makeVaildStepperValue(fruit: .kiwi))
-        mangoStepper.value = Double(makeVaildStepperValue(fruit: .mango))
-    }
-    
-    func makeVaildStepperValue(fruit: Fruits) -> Int {
-        guard let stepperValue = FruitStore.shared.fruits[fruit] else { return -1 }
-        return stepperValue
-    }
-    
-    private func selectFruitLable(fruit: Fruits) -> UILabel {
         switch fruit {
         case .strawberry:
-            return strawberryStock
-        case .mango:
-            return mangoStock
-        case .kiwi:
-            return kiwiStock
-        case .pineapple:
-            return pineappleStock
+            return strawberryStepper
         case .banana:
-            return bananaStock
+            return bananaStepper
+        case .pineapple:
+            return pineappleStepper
+        case .kiwi:
+            return kiwiStepper
+        case .mango:
+            return mangoStepper
+        }
+        
+        func setupStepper() {
+            strawberryStepper.value = Double(makeVaildStepperValue(fruit: .strawberry))
+            bananaStepper.value = Double(makeVaildStepperValue(fruit: .banana))
+            pineappleStepper.value = Double(makeVaildStepperValue(fruit: .pineapple))
+            kiwiStepper.value = Double(makeVaildStepperValue(fruit: .kiwi))
+            mangoStepper.value = Double(makeVaildStepperValue(fruit: .mango))
+        }
+        
+        func makeVaildStepperValue(fruit: Fruits) -> Int {
+            guard let stepperValue = FruitStore.shared.fruits[fruit] else { return -1 }
+            return stepperValue
+        }
+        
+        private func selectFruitLable(fruit: Fruits) -> UILabel {
+            switch fruit {
+            case .strawberry:
+                return strawberryStock
+            case .mango:
+                return mangoStock
+            case .kiwi:
+                return kiwiStock
+            case .pineapple:
+                return pineappleStock
+            case .banana:
+                return bananaStock
+            }
+        }
+        
+        func changeStock(fruit: Fruits) {
+            FruitStore.shared.fruits[fruit] = Int(findFruitStepper(fruit: fruit).value)
+            selectFruitLable(fruit: fruit).text = FruitStore.shared.showFruitsStock(name: fruit)
         }
     }
-}

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -15,5 +15,7 @@ class StockViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
     
-    
+    @IBAction func didTapClosedStockViewController(_ sender: UIBarButtonItem) {
+        self.dismiss(animated: true)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -35,8 +35,8 @@ class StockViewController: UIViewController {
            do {
            let fruit = try findFruit(stepper: sender)
            changeStock(fruit: fruit)
-           } catch FruitStoreError.wrongMenu {
-               print("없는 메뉴입니다")
+           } catch FruitStoreError.wrongFruit {
+               print("없는 과일입니다")
            } catch {
                print("")
            }
@@ -50,7 +50,7 @@ class StockViewController: UIViewController {
         mangoStock.text = FruitStore.shared.showFruitsStock(name: .mango)
     }
     
-    func findFruit(stepper: UIStepper) throws -> Fruits {
+    func findFruit(stepper: UIStepper) throws -> Fruit {
         switch stepper {
         case strawberryStepper:
             return .strawberry
@@ -67,7 +67,7 @@ class StockViewController: UIViewController {
         }
     }
     
-    func findFruitStepper(fruit: Fruits) -> UIStepper {
+    func findFruitStepper(fruit: Fruit) -> UIStepper {
         switch fruit {
         case .strawberry:
             return strawberryStepper
@@ -90,12 +90,12 @@ class StockViewController: UIViewController {
         mangoStepper.value = Double(makeVaildStepperValue(fruit: .mango))
     }
     
-    func makeVaildStepperValue(fruit: Fruits) -> Int {
+    func makeVaildStepperValue(fruit: Fruit) -> Int {
         guard let stepperValue = FruitStore.shared.fruits[fruit] else { return -1 }
         return stepperValue
     }
     
-    private func selectFruitLable(fruit: Fruits) -> UILabel {
+    private func selectFruitLable(fruit: Fruit) -> UILabel {
         switch fruit {
         case .strawberry:
             return strawberryStock
@@ -110,7 +110,7 @@ class StockViewController: UIViewController {
         }
     }
     
-    func changeStock(fruit: Fruits) {
+    func changeStock(fruit: Fruit) {
         FruitStore.shared.fruits[fruit] = Int(findFruitStepper(fruit: fruit).value)
         selectFruitLable(fruit: fruit).text = FruitStore.shared.showFruitsStock(name: fruit)
     }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -9,11 +9,11 @@ import UIKit
 
 final class StockViewController: UIViewController {
     
-    @IBOutlet weak var strawberryStock: UILabel!
-    @IBOutlet weak var bananaStock: UILabel!
-    @IBOutlet weak var pineappleStock: UILabel!
-    @IBOutlet weak var kiwiStock: UILabel!
-    @IBOutlet weak var mangoStock: UILabel!
+    @IBOutlet weak var strawberryStockLable: UILabel!
+    @IBOutlet weak var bananaStockLable: UILabel!
+    @IBOutlet weak var pineappleStockLable: UILabel!
+    @IBOutlet weak var kiwiStockLable: UILabel!
+    @IBOutlet weak var mangoStockLable: UILabel!
     
     @IBOutlet weak var strawberryStepper: UIStepper!
     @IBOutlet weak var bananaStepper: UIStepper!
@@ -43,11 +43,11 @@ final class StockViewController: UIViewController {
        }
     
     private func setupViews() {
-        strawberryStock.text = FruitStore.shared.showFruitsStock(name: .strawberry)
-        bananaStock.text = FruitStore.shared.showFruitsStock(name: .banana)
-        pineappleStock.text = FruitStore.shared.showFruitsStock(name: .pineapple)
-        kiwiStock.text = FruitStore.shared.showFruitsStock(name: .kiwi)
-        mangoStock.text = FruitStore.shared.showFruitsStock(name: .mango)
+        strawberryStockLable.text = FruitStore.shared.showFruitsStock(name: .strawberry)
+        bananaStockLable.text = FruitStore.shared.showFruitsStock(name: .banana)
+        pineappleStockLable.text = FruitStore.shared.showFruitsStock(name: .pineapple)
+        kiwiStockLable.text = FruitStore.shared.showFruitsStock(name: .kiwi)
+        mangoStockLable.text = FruitStore.shared.showFruitsStock(name: .mango)
     }
     
     private func findFruit(stepper: UIStepper) throws -> Fruit {
@@ -98,15 +98,15 @@ final class StockViewController: UIViewController {
     private func selectFruitLable(fruit: Fruit) -> UILabel {
         switch fruit {
         case .strawberry:
-            return strawberryStock
+            return strawberryStockLable
         case .mango:
-            return mangoStock
+            return mangoStockLable
         case .kiwi:
-            return kiwiStock
+            return kiwiStockLable
         case .pineapple:
-            return pineappleStock
+            return pineappleStockLable
         case .banana:
-            return bananaStock
+            return bananaStockLable
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class StockViewController: UIViewController {
+final class StockViewController: UIViewController {
     
     @IBOutlet weak var strawberryStock: UILabel!
     @IBOutlet weak var bananaStock: UILabel!
@@ -27,11 +27,11 @@ class StockViewController: UIViewController {
         setupStepper()
     }
     
-    @IBAction func didTapClosedStockViewController(_ sender: UIBarButtonItem) {
+    @IBAction private func didTapClosedStockViewController(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true)
     }
     
-    @IBAction func didTapStepper(_ sender: UIStepper) {
+    @IBAction private func didTapStepper(_ sender: UIStepper) {
            do {
            let fruit = try findFruit(stepper: sender)
            changeStock(fruit: fruit)
@@ -42,7 +42,7 @@ class StockViewController: UIViewController {
            }
        }
     
-    func setupViews() {
+    private func setupViews() {
         strawberryStock.text = FruitStore.shared.showFruitsStock(name: .strawberry)
         bananaStock.text = FruitStore.shared.showFruitsStock(name: .banana)
         pineappleStock.text = FruitStore.shared.showFruitsStock(name: .pineapple)
@@ -50,7 +50,7 @@ class StockViewController: UIViewController {
         mangoStock.text = FruitStore.shared.showFruitsStock(name: .mango)
     }
     
-    func findFruit(stepper: UIStepper) throws -> Fruit {
+    private func findFruit(stepper: UIStepper) throws -> Fruit {
         switch stepper {
         case strawberryStepper:
             return .strawberry
@@ -67,7 +67,7 @@ class StockViewController: UIViewController {
         }
     }
     
-    func findFruitStepper(fruit: Fruit) -> UIStepper {
+    private func findFruitStepper(fruit: Fruit) -> UIStepper {
         switch fruit {
         case .strawberry:
             return strawberryStepper
@@ -82,7 +82,7 @@ class StockViewController: UIViewController {
         }
     }
     
-    func setupStepper() {
+    private func setupStepper() {
         strawberryStepper.value = Double(makeVaildStepperValue(fruit: .strawberry))
         bananaStepper.value = Double(makeVaildStepperValue(fruit: .banana))
         pineappleStepper.value = Double(makeVaildStepperValue(fruit: .pineapple))
@@ -90,7 +90,7 @@ class StockViewController: UIViewController {
         mangoStepper.value = Double(makeVaildStepperValue(fruit: .mango))
     }
     
-    func makeVaildStepperValue(fruit: Fruit) -> Int {
+    private func makeVaildStepperValue(fruit: Fruit) -> Int {
         guard let stepperValue = FruitStore.shared.fruits[fruit] else { return -1 }
         return stepperValue
     }
@@ -110,7 +110,7 @@ class StockViewController: UIViewController {
         }
     }
     
-    func changeStock(fruit: Fruit) {
+    private func changeStock(fruit: Fruit) {
         FruitStore.shared.fruits[fruit] = Int(findFruitStepper(fruit: fruit).value)
         selectFruitLable(fruit: fruit).text = FruitStore.shared.showFruitsStock(name: fruit)
     }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -31,6 +31,14 @@ class StockViewController: UIViewController {
         self.dismiss(animated: true)
     }
     
+    func setupViews() {
+        strawberryStock.text = FruitStore.shared.showFruitsStock(name: .strawberry)
+        bananaStock.text = FruitStore.shared.showFruitsStock(name: .banana)
+        pineappleStock.text = FruitStore.shared.showFruitsStock(name: .pineapple)
+        kiwiStock.text = FruitStore.shared.showFruitsStock(name: .kiwi)
+        mangoStock.text = FruitStore.shared.showFruitsStock(name: .mango)
+    }
+    
     func findFruitStepper(stepper: UIStepper) throws -> Fruits {
         switch stepper {
         case strawberryStepper:
@@ -61,11 +69,18 @@ class StockViewController: UIViewController {
         return stepperValue
     }
     
-    func setupViews() {
-        strawberryStock.text = FruitStore.shared.showFruitsStock(name: .strawberry)
-        bananaStock.text = FruitStore.shared.showFruitsStock(name: .banana)
-        pineappleStock.text = FruitStore.shared.showFruitsStock(name: .pineapple)
-        kiwiStock.text = FruitStore.shared.showFruitsStock(name: .kiwi)
-        mangoStock.text = FruitStore.shared.showFruitsStock(name: .mango)
+    private func selectFruitLable(fruit: Fruits) -> UILabel {
+        switch fruit {
+        case .strawberry:
+            return strawberryStock
+        case .mango:
+            return mangoStock
+        case .kiwi:
+            return kiwiStock
+        case .pineapple:
+            return pineappleStock
+        case .banana:
+            return bananaStock
+        }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -56,6 +56,20 @@ class StockViewController: UIViewController {
         }
     }
     
+    func findFruitStepper(fruit: Fruits) -> UIStepper {
+            switch fruit {
+            case .strawberry:
+                return strawberryStepper
+            case .banana:
+                return bananaStepper
+            case .pineapple:
+                return pineappleStepper
+            case .kiwi:
+                return kiwiStepper
+            case .mango:
+                return mangoStepper
+            }
+    
     func setupStepper() {
         strawberryStepper.value = Double(makeVaildStepperValue(fruit: .strawberry))
         bananaStepper.value = Double(makeVaildStepperValue(fruit: .banana))

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -39,7 +39,7 @@ class StockViewController: UIViewController {
         mangoStock.text = FruitStore.shared.showFruitsStock(name: .mango)
     }
     
-    func findFruitStepper(stepper: UIStepper) throws -> Fruits {
+    func findFruit(stepper: UIStepper) throws -> Fruits {
         switch stepper {
         case strawberryStepper:
             return .strawberry

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -24,6 +24,15 @@ class StockViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
+        setupStepper()
+    }
+    
+    func setupStepper() {
+        strawberryStepper.value = Double(makeVaildStepperValue(fruit: .strawberry))
+        bananaStepper.value = Double(makeVaildStepperValue(fruit: .banana))
+        pineappleStepper.value = Double(makeVaildStepperValue(fruit: .pineapple))
+        kiwiStepper.value = Double(makeVaildStepperValue(fruit: .kiwi))
+        mangoStepper.value = Double(makeVaildStepperValue(fruit: .mango))
     }
     
     func makeVaildStepperValue(fruit: Fruits) -> Int {

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -8,11 +8,31 @@
 import UIKit
 
 class StockViewController: UIViewController {
-
+    
+    @IBOutlet weak var strawberryStock: UILabel!
+    @IBOutlet weak var bananaStock: UILabel!
+    @IBOutlet weak var pineappleStock: UILabel!
+    @IBOutlet weak var kiwiStock: UILabel!
+    @IBOutlet weak var mangoStock: UILabel!
+    
+    @IBOutlet weak var strawberryStepper: UIStepper!
+    @IBOutlet weak var bananaStepper: UIStepper!
+    @IBOutlet weak var pineappleStepper: UIStepper!
+    @IBOutlet weak var kiwiStepper: UIStepper!
+    @IBOutlet weak var mangoStepper: UIStepper!
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        setupView()
+    }
+    
+    func setupView() {
+        strawberryStock.text = FruitStore.shared.showFruitsStock(name: .strawberry)
+        bananaStock.text = FruitStore.shared.showFruitsStock(name: .banana)
+        pineappleStock.text = FruitStore.shared.showFruitsStock(name: .pineapple)
+        kiwiStock.text = FruitStore.shared.showFruitsStock(name: .kiwi)
+        mangoStock.text = FruitStore.shared.showFruitsStock(name: .mango)
     }
     
     @IBAction func didTapClosedStockViewController(_ sender: UIBarButtonItem) {

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -31,6 +31,17 @@ class StockViewController: UIViewController {
         self.dismiss(animated: true)
     }
     
+    @IBAction func didTapStepper(_ sender: UIStepper) {
+           do {
+           let fruit = try findFruit(stepper: sender)
+           changeStock(fruit: fruit)
+           } catch FruitStoreError.wrongMenu {
+               print("없는 메뉴입니다")
+           } catch {
+               print("")
+           }
+       }
+    
     func setupViews() {
         strawberryStock.text = FruitStore.shared.showFruitsStock(name: .strawberry)
         bananaStock.text = FruitStore.shared.showFruitsStock(name: .banana)
@@ -69,37 +80,38 @@ class StockViewController: UIViewController {
         case .mango:
             return mangoStepper
         }
-        
-        func setupStepper() {
-            strawberryStepper.value = Double(makeVaildStepperValue(fruit: .strawberry))
-            bananaStepper.value = Double(makeVaildStepperValue(fruit: .banana))
-            pineappleStepper.value = Double(makeVaildStepperValue(fruit: .pineapple))
-            kiwiStepper.value = Double(makeVaildStepperValue(fruit: .kiwi))
-            mangoStepper.value = Double(makeVaildStepperValue(fruit: .mango))
-        }
-        
-        func makeVaildStepperValue(fruit: Fruits) -> Int {
-            guard let stepperValue = FruitStore.shared.fruits[fruit] else { return -1 }
-            return stepperValue
-        }
-        
-        private func selectFruitLable(fruit: Fruits) -> UILabel {
-            switch fruit {
-            case .strawberry:
-                return strawberryStock
-            case .mango:
-                return mangoStock
-            case .kiwi:
-                return kiwiStock
-            case .pineapple:
-                return pineappleStock
-            case .banana:
-                return bananaStock
-            }
-        }
-        
-        func changeStock(fruit: Fruits) {
-            FruitStore.shared.fruits[fruit] = Int(findFruitStepper(fruit: fruit).value)
-            selectFruitLable(fruit: fruit).text = FruitStore.shared.showFruitsStock(name: fruit)
+    }
+    
+    func setupStepper() {
+        strawberryStepper.value = Double(makeVaildStepperValue(fruit: .strawberry))
+        bananaStepper.value = Double(makeVaildStepperValue(fruit: .banana))
+        pineappleStepper.value = Double(makeVaildStepperValue(fruit: .pineapple))
+        kiwiStepper.value = Double(makeVaildStepperValue(fruit: .kiwi))
+        mangoStepper.value = Double(makeVaildStepperValue(fruit: .mango))
+    }
+    
+    func makeVaildStepperValue(fruit: Fruits) -> Int {
+        guard let stepperValue = FruitStore.shared.fruits[fruit] else { return -1 }
+        return stepperValue
+    }
+    
+    private func selectFruitLable(fruit: Fruits) -> UILabel {
+        switch fruit {
+        case .strawberry:
+            return strawberryStock
+        case .mango:
+            return mangoStock
+        case .kiwi:
+            return kiwiStock
+        case .pineapple:
+            return pineappleStock
+        case .banana:
+            return bananaStock
         }
     }
+    
+    func changeStock(fruit: Fruits) {
+        FruitStore.shared.fruits[fruit] = Int(findFruitStepper(fruit: fruit).value)
+        selectFruitLable(fruit: fruit).text = FruitStore.shared.showFruitsStock(name: fruit)
+    }
+}

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -5,7 +5,7 @@
 //  Created by Kiwi, unchain123 on 2022/04/26.
 //
 
-enum Fruits: CaseIterable {
+enum Fruit: CaseIterable {
     case strawberry
     case banana
     case pineapple

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -9,9 +9,10 @@ import Foundation
 // 과일 저장소 타입
 final class FruitStore {
     
+    static let shared = FruitStore()
     private var fruits = [Fruits:Int]()
     
-    init(){
+    private init(){
         for fruitStock in Fruits.allCases {
             fruits[fruitStock] = 10
         }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -31,8 +31,12 @@ final class FruitStore {
         }
     }
 
-    func showFruitsStock(name: Fruit) -> String {
-        guard let fruitsStock = fruits[name] else { return " " }
-        return String(fruitsStock)
+    func showFruitsStock(name: Fruit) -> Int {
+        guard let fruitsStock = fruits[name] else { return -1 }
+        return fruitsStock
+    }
+    
+    func changeStock(fruit: Fruit, newValue: Int) {
+        fruits[fruit] = newValue
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -10,28 +10,28 @@ import Foundation
 final class FruitStore {
     
     static let shared = FruitStore()
-    var fruits = [Fruits:Int]()
+    var fruits = [Fruit:Int]()
     
     private init(){
-        for fruitStock in Fruits.allCases {
+        for fruitStock in Fruit.allCases {
             fruits[fruitStock] = 10
         }
     }
     
-    func consumeFruitsStock(by fruit: [Fruits: Int]) {
+    func consumeFruitsStock(by fruit: [Fruit: Int]) {
         for (name, quantity) in fruit{
             guard let fruitsStock = fruits[name],fruitsStock >= quantity else { return }
             fruits[name] = fruitsStock - quantity
         }
     }
     
-    func checkInventory(about fruit: [Fruits: Int]) throws {
+    func checkInventory(about fruit: [Fruit: Int]) throws {
         for (name, quantity) in fruit{
             guard let fruitsStock = fruits[name], fruitsStock >= quantity else { throw FruitStoreError.outOfStock }
         }
     }
 
-    func showFruitsStock(name: Fruits) -> String {
+    func showFruitsStock(name: Fruit) -> String {
         guard let fruitsStock = fruits[name] else { return " " }
         return String(fruitsStock)
     }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -10,7 +10,7 @@ import Foundation
 final class FruitStore {
     
     static let shared = FruitStore()
-    private var fruits = [Fruits:Int]()
+    var fruits = [Fruits:Int]()
     
     private init(){
         for fruitStock in Fruits.allCases {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -18,11 +18,6 @@ final class FruitStore {
         }
     }
     
-    func addFruitsStock(name: Fruits, quantity: Int) {
-        guard let fruitsStock = fruits[name] else { return }
-        fruits[name] = fruitsStock + quantity
-    }
-    
     func consumeFruitsStock(by fruit: [Fruits: Int]) {
         for (name, quantity) in fruit{
             guard let fruitsStock = fruits[name],fruitsStock >= quantity else { return }

--- a/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
@@ -10,4 +10,5 @@ import Foundation
 enum FruitStoreError: Error {
     case outOfStock
     case wrongMenu
+    case wrongFruit
 }

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -35,7 +35,7 @@ enum Juice {
         }
     }
     
-    var recipe: [Fruits : Int] {
+    var recipe: [Fruit : Int] {
         switch self {
         case .strawberry:
             return [.strawberry: 16]

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,7 +8,7 @@ import Foundation
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
-    let fruitStore = FruitStore()
+    let fruitStore = FruitStore.shared
     
     func canMakeJuice(flavor: Juice) -> Bool {
         let recipe = flavor.recipe

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -456,6 +456,18 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <connections>
+                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="jVD-FH-lsp"/>
+                        <outlet property="bananaStock" destination="gKu-86-RhI" id="TcQ-8O-WcG"/>
+                        <outlet property="kiwiStepper" destination="klA-59-Nu4" id="8sQ-Uj-7SF"/>
+                        <outlet property="kiwiStock" destination="ZDv-1m-HBY" id="kKt-4Q-w46"/>
+                        <outlet property="mangoStepper" destination="xbn-6P-grO" id="nkF-GB-TdG"/>
+                        <outlet property="mangoStock" destination="YJI-ER-LJR" id="4Tv-lj-2VM"/>
+                        <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="iI9-Cu-3T9"/>
+                        <outlet property="pineappleStock" destination="MpT-VW-hCb" id="QIn-57-RsA"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="EWf-bj-4lf"/>
+                        <outlet property="strawberryStock" destination="0yV-kn-zaT" id="u8F-N5-PCh"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="WwV-Td-3Bn" kind="presentation" identifier="showFruitStock" modalPresentationStyle="fullScreen" id="dYg-B5-gvD"/>
+                                <segue destination="WwV-Td-3Bn" kind="presentation" identifier="showFruitStockSegue" modalPresentationStyle="fullScreen" id="dYg-B5-gvD"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -308,6 +308,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="12.333333333333329" y="120.66666666666669" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="didTapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="rPN-oD-bJp"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -335,6 +338,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="12.333333333333314" y="120.66666666666669" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="didTapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="zIp-vw-yVn"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -362,6 +368,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="12.333333333333314" y="120.66666666666669" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="didTapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="HlP-DH-hg1"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -389,6 +398,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="12.000000000000057" y="120.66666666666669" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="didTapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="jYR-Ne-3vz"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>
@@ -416,6 +428,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="12" y="120.66666666666669" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="didTapStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="L6l-tx-LV6"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                         <constraints>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" identifier="showFruitStock" modalPresentationStyle="fullScreen" id="auc-b7-kkM"/>
+                                <segue destination="WwV-Td-3Bn" kind="presentation" identifier="showFruitStock" modalPresentationStyle="fullScreen" id="dYg-B5-gvD"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -279,7 +279,7 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--Stock View Controller-->
+        <!--재고 추가-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController storyboardIdentifier="stockViewController" id="Yu1-lM-nqp" customClass="StockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
@@ -442,35 +442,23 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="byS-IV-ke4">
-                                <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <color key="barTintColor" systemColor="systemGray5Color"/>
-                                <items>
-                                    <navigationItem title="재고 추가" id="rBQ-b6-Cnn">
-                                        <barButtonItem key="rightBarButtonItem" title="닫기" id="6VF-bP-uvh">
-                                            <connections>
-                                                <action selector="didTapClosedStockViewController:" destination="Yu1-lM-nqp" id="Oft-CR-Ad3"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" secondItem="30o-9v-xKK" secondAttribute="trailing" constant="40" id="3dw-AW-76u"/>
-                            <constraint firstItem="byS-IV-ke4" firstAttribute="leading" secondItem="tKV-4l-Vtc" secondAttribute="leading" id="LeB-CD-pbt"/>
                             <constraint firstItem="30o-9v-xKK" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="MOb-kB-C0h"/>
-                            <constraint firstAttribute="trailing" secondItem="byS-IV-ke4" secondAttribute="trailing" id="euc-pO-cNk"/>
-                            <constraint firstItem="byS-IV-ke4" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="ihE-Wt-4SL"/>
                             <constraint firstItem="30o-9v-xKK" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="qSW-6r-0jf"/>
                             <constraint firstItem="30o-9v-xKK" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="40" id="us9-Sp-yDR"/>
-                            <constraint firstItem="byS-IV-ke4" firstAttribute="top" secondItem="gcO-Xb-kNs" secondAttribute="top" id="y8r-Gz-hGO"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <navigationItem key="navigationItem" title="재고 추가" id="g4W-fY-l7r">
+                        <barButtonItem key="rightBarButtonItem" title="닫기" id="6VF-bP-uvh">
+                            <connections>
+                                <action selector="didTapClosedStockViewController:" destination="Yu1-lM-nqp" id="Oft-CR-Ad3"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="bananaStepper" destination="O5s-2N-3iP" id="jVD-FH-lsp"/>
                         <outlet property="bananaStock" destination="gKu-86-RhI" id="TcQ-8O-WcG"/>
@@ -496,6 +484,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" systemColor="systemGray2Color"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -507,15 +496,15 @@
             <point key="canvasLocation" x="1637" y="21"/>
         </scene>
     </scenes>
-    <inferredMetricsTieBreakers>
-        <segue reference="auc-b7-kkM"/>
-    </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray2Color">
+            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGray5Color">
             <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -244,17 +244,17 @@
                     </navigationItem>
                     <connections>
                         <outlet property="bananaJuiceButton" destination="y2A-PH-DJY" id="pUG-cV-mMK"/>
-                        <outlet property="bananaStock" destination="gvk-pA-Lw5" id="0XB-Hl-GUd"/>
+                        <outlet property="bananaStockLable" destination="gvk-pA-Lw5" id="0XB-Hl-GUd"/>
                         <outlet property="kiwiJuiceButton" destination="wcW-7H-RXw" id="FPa-6J-h2N"/>
-                        <outlet property="kiwiStock" destination="FZq-de-TJG" id="fFt-kG-sSi"/>
+                        <outlet property="kiwiStockLable" destination="FZq-de-TJG" id="fFt-kG-sSi"/>
                         <outlet property="mangoJuiceButton" destination="q6G-4X-bVm" id="v09-IN-ouw"/>
                         <outlet property="mangoKiwiJuiceButton" destination="ngP-kF-Yii" id="abd-Wm-2DO"/>
-                        <outlet property="mangoStock" destination="3Ce-SU-JeH" id="aBl-Gv-vxA"/>
+                        <outlet property="mangoStockLable" destination="3Ce-SU-JeH" id="aBl-Gv-vxA"/>
                         <outlet property="pineappleJuiceButton" destination="BFb-ka-wGA" id="eZz-HM-61T"/>
-                        <outlet property="pineappleStock" destination="ccQ-Dk-PuY" id="pE5-bp-sqo"/>
+                        <outlet property="pineappleStockLable" destination="ccQ-Dk-PuY" id="pE5-bp-sqo"/>
                         <outlet property="strawBerryBananJuiceButton" destination="hrc-2F-fzl" id="Oci-lS-wah"/>
                         <outlet property="strawberryJuiceButton" destination="avd-o5-3JM" id="Xru-hj-KgU"/>
-                        <outlet property="strawberryStock" destination="Qas-vP-td6" id="jcg-cQ-wlC"/>
+                        <outlet property="strawberryStockLable" destination="Qas-vP-td6" id="jcg-cQ-wlC"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -461,15 +461,15 @@
                     </navigationItem>
                     <connections>
                         <outlet property="bananaStepper" destination="O5s-2N-3iP" id="jVD-FH-lsp"/>
-                        <outlet property="bananaStock" destination="gKu-86-RhI" id="TcQ-8O-WcG"/>
+                        <outlet property="bananaStockLable" destination="gKu-86-RhI" id="TcQ-8O-WcG"/>
                         <outlet property="kiwiStepper" destination="klA-59-Nu4" id="8sQ-Uj-7SF"/>
-                        <outlet property="kiwiStock" destination="ZDv-1m-HBY" id="kKt-4Q-w46"/>
+                        <outlet property="kiwiStockLable" destination="ZDv-1m-HBY" id="kKt-4Q-w46"/>
                         <outlet property="mangoStepper" destination="xbn-6P-grO" id="nkF-GB-TdG"/>
-                        <outlet property="mangoStock" destination="YJI-ER-LJR" id="4Tv-lj-2VM"/>
+                        <outlet property="mangoStockLable" destination="YJI-ER-LJR" id="4Tv-lj-2VM"/>
                         <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="iI9-Cu-3T9"/>
-                        <outlet property="pineappleStock" destination="MpT-VW-hCb" id="QIn-57-RsA"/>
+                        <outlet property="pineappleStockLable" destination="MpT-VW-hCb" id="QIn-57-RsA"/>
                         <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="EWf-bj-4lf"/>
-                        <outlet property="strawberryStock" destination="0yV-kn-zaT" id="u8F-N5-PCh"/>
+                        <outlet property="strawberryStockLable" destination="0yV-kn-zaT" id="u8F-N5-PCh"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -427,14 +427,28 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="byS-IV-ke4">
+                                <rect key="frame" x="0.0" y="0.0" width="792" height="32"/>
+                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                <color key="barTintColor" systemColor="systemGray5Color"/>
+                                <items>
+                                    <navigationItem title="재고 추가" id="rBQ-b6-Cnn">
+                                        <barButtonItem key="rightBarButtonItem" title="닫기" id="6VF-bP-uvh"/>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" secondItem="30o-9v-xKK" secondAttribute="trailing" constant="40" id="3dw-AW-76u"/>
+                            <constraint firstItem="byS-IV-ke4" firstAttribute="leading" secondItem="tKV-4l-Vtc" secondAttribute="leading" id="LeB-CD-pbt"/>
                             <constraint firstItem="30o-9v-xKK" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="MOb-kB-C0h"/>
+                            <constraint firstAttribute="trailing" secondItem="byS-IV-ke4" secondAttribute="trailing" id="euc-pO-cNk"/>
+                            <constraint firstItem="byS-IV-ke4" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="ihE-Wt-4SL"/>
                             <constraint firstItem="30o-9v-xKK" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="qSW-6r-0jf"/>
                             <constraint firstItem="30o-9v-xKK" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="40" id="us9-Sp-yDR"/>
+                            <constraint firstItem="byS-IV-ke4" firstAttribute="top" secondItem="gcO-Xb-kNs" secondAttribute="top" id="y8r-Gz-hGO"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -428,12 +428,16 @@
                                 </subviews>
                             </stackView>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="byS-IV-ke4">
-                                <rect key="frame" x="0.0" y="0.0" width="792" height="32"/>
+                                <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <color key="barTintColor" systemColor="systemGray5Color"/>
                                 <items>
                                     <navigationItem title="재고 추가" id="rBQ-b6-Cnn">
-                                        <barButtonItem key="rightBarButtonItem" title="닫기" id="6VF-bP-uvh"/>
+                                        <barButtonItem key="rightBarButtonItem" title="닫기" id="6VF-bP-uvh">
+                                            <connections>
+                                                <action selector="didTapClosedStockViewController:" destination="Yu1-lM-nqp" id="Oft-CR-Ad3"/>
+                                            </connections>
+                                        </barButtonItem>
                                     </navigationItem>
                                 </items>
                             </navigationBar>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="MakeJuiceViewController" customModule="JuiceMaker" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="JuiceMakerViewController" customModule="JuiceMaker" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -455,7 +455,7 @@
                     <navigationItem key="navigationItem" title="재고 추가" id="g4W-fY-l7r">
                         <barButtonItem key="rightBarButtonItem" title="닫기" id="6VF-bP-uvh">
                             <connections>
-                                <action selector="didTapClosedStockViewController:" destination="Yu1-lM-nqp" id="Oft-CR-Ad3"/>
+                                <action selector="didTapClosedBarButton:" destination="Yu1-lM-nqp" id="iid-p1-CXV"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -282,7 +282,7 @@
         <!--Stock View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController storyboardIdentifier="stockViewController" id="Yu1-lM-nqp" customClass="stockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="stockViewController" id="Yu1-lM-nqp" customClass="StockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -412,7 +412,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="auc-b7-kkM"/>
+        <segue reference="wH1-3A-cBm"/>
     </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" identifier="showFruitStock" id="auc-b7-kkM"/>
+                                <segue destination="Yu1-lM-nqp" kind="presentation" identifier="showFruitStock" modalPresentationStyle="fullScreen" id="auc-b7-kkM"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -287,104 +287,145 @@
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                <rect key="frame" x="590" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="622" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="580" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="461" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                <rect key="frame" x="410" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="303" y="155" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                <rect key="frame" x="261" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                <rect key="frame" x="154" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="98" y="161" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                <rect key="frame" x="60" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="196" y="158" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                <rect key="frame" x="50" y="192" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="21" translatesAutoresizingMaskIntoConstraints="NO" id="30o-9v-xKK">
+                                <rect key="frame" x="84" y="118.66666666666667" width="676" height="152.66666666666663"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="4Hk-yq-WZB">
+                                        <rect key="frame" x="0.0" y="0.0" width="118.33333333333333" height="152.66666666666666"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                                <rect key="frame" x="21.666666666666671" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                                <rect key="frame" x="21.666666666666671" y="90.666666666666671" width="75" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="12.333333333333329" y="120.66666666666669" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="leading" secondItem="dCK-AJ-zGU" secondAttribute="leading" id="Fpp-4c-va8"/>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="trailing" secondItem="dCK-AJ-zGU" secondAttribute="trailing" id="bea-uJ-HuR"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="Il5-QY-xz2">
+                                        <rect key="frame" x="139.33333333333334" y="0.0" width="118.33333333333334" height="152.66666666666666"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
+                                                <rect key="frame" x="21.666666666666657" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                                <rect key="frame" x="21.666666666666657" y="90.666666666666671" width="75" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="12.333333333333314" y="120.66666666666669" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="leading" secondItem="y33-ND-gz2" secondAttribute="leading" id="Zh1-iq-Zeg"/>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="trailing" secondItem="y33-ND-gz2" secondAttribute="trailing" id="vW8-MY-nac"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="fEr-I8-cdO">
+                                        <rect key="frame" x="278.66666666666669" y="0.0" width="118.66666666666669" height="152.66666666666666"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
+                                                <rect key="frame" x="22" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
+                                                <rect key="frame" x="22" y="90.666666666666671" width="75" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                                <rect key="frame" x="12.333333333333314" y="120.66666666666669" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="leading" secondItem="rac-Ji-vZK" secondAttribute="leading" id="1He-lU-9xV"/>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="trailing" secondItem="rac-Ji-vZK" secondAttribute="trailing" id="Xmj-N7-oSb"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="SfI-ho-4Te">
+                                        <rect key="frame" x="418.33333333333331" y="0.0" width="118.33333333333331" height="152.66666666666666"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
+                                                <rect key="frame" x="21.666666666666686" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
+                                                <rect key="frame" x="21.666666666666686" y="90.666666666666671" width="75" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                                <rect key="frame" x="12.000000000000057" y="120.66666666666669" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="trailing" secondItem="EHe-D1-1xN" secondAttribute="trailing" id="dFi-4l-NCF"/>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="leading" secondItem="EHe-D1-1xN" secondAttribute="leading" id="rND-bQ-xIv"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="n8Z-dq-45L">
+                                        <rect key="frame" x="557.66666666666663" y="0.0" width="118.33333333333337" height="152.66666666666666"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
+                                                <rect key="frame" x="21.666666666666742" y="0.0" width="75" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                                <rect key="frame" x="21.666666666666742" y="90.666666666666671" width="75" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                                <rect key="frame" x="12" y="120.66666666666669" width="94" height="32"/>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="leading" secondItem="w1F-9o-qJR" secondAttribute="leading" id="a28-ZE-ykq"/>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="trailing" secondItem="w1F-9o-qJR" secondAttribute="trailing" id="bdZ-Hx-JaD"/>
+                                        </constraints>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" secondItem="30o-9v-xKK" secondAttribute="trailing" constant="40" id="3dw-AW-76u"/>
+                            <constraint firstItem="30o-9v-xKK" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="MOb-kB-C0h"/>
+                            <constraint firstItem="30o-9v-xKK" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="qSW-6r-0jf"/>
+                            <constraint firstItem="30o-9v-xKK" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="40" id="us9-Sp-yDR"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
                 </viewController>
@@ -412,7 +453,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="wH1-3A-cBm"/>
+        <segue reference="auc-b7-kkM"/>
     </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -294,13 +294,13 @@
                                         <rect key="frame" x="0.0" y="0.0" width="118.33333333333333" height="152.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="21.666666666666671" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="12.333333333333329" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="21.666666666666671" y="90.666666666666671" width="75" height="23"/>
+                                                <rect key="frame" x="12.333333333333329" y="90.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -313,19 +313,21 @@
                                         <constraints>
                                             <constraint firstItem="0yV-kn-zaT" firstAttribute="leading" secondItem="dCK-AJ-zGU" secondAttribute="leading" id="Fpp-4c-va8"/>
                                             <constraint firstItem="0yV-kn-zaT" firstAttribute="trailing" secondItem="dCK-AJ-zGU" secondAttribute="trailing" id="bea-uJ-HuR"/>
+                                            <constraint firstItem="ZQk-f4-zrz" firstAttribute="leading" secondItem="0yV-kn-zaT" secondAttribute="leading" id="ot6-eG-UKA"/>
+                                            <constraint firstItem="ZQk-f4-zrz" firstAttribute="trailing" secondItem="0yV-kn-zaT" secondAttribute="trailing" id="uPv-dQ-jH2"/>
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="Il5-QY-xz2">
                                         <rect key="frame" x="139.33333333333334" y="0.0" width="118.33333333333334" height="152.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="21.666666666666657" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="12.333333333333314" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="21.666666666666657" y="90.666666666666671" width="75" height="23"/>
+                                                <rect key="frame" x="12.333333333333314" y="90.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -336,6 +338,8 @@
                                             </stepper>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstItem="O5s-2N-3iP" firstAttribute="leading" secondItem="gKu-86-RhI" secondAttribute="leading" id="83F-Zn-iGm"/>
+                                            <constraint firstItem="O5s-2N-3iP" firstAttribute="trailing" secondItem="gKu-86-RhI" secondAttribute="trailing" id="OHL-TK-b8l"/>
                                             <constraint firstItem="gKu-86-RhI" firstAttribute="leading" secondItem="y33-ND-gz2" secondAttribute="leading" id="Zh1-iq-Zeg"/>
                                             <constraint firstItem="gKu-86-RhI" firstAttribute="trailing" secondItem="y33-ND-gz2" secondAttribute="trailing" id="vW8-MY-nac"/>
                                         </constraints>
@@ -344,13 +348,13 @@
                                         <rect key="frame" x="278.66666666666669" y="0.0" width="118.66666666666669" height="152.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="22" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="12.333333333333314" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="22" y="90.666666666666671" width="75" height="23"/>
+                                                <rect key="frame" x="12.333333333333314" y="90.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -362,6 +366,8 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="MpT-VW-hCb" firstAttribute="leading" secondItem="rac-Ji-vZK" secondAttribute="leading" id="1He-lU-9xV"/>
+                                            <constraint firstItem="Rcr-xr-eqz" firstAttribute="trailing" secondItem="MpT-VW-hCb" secondAttribute="trailing" id="7wx-LC-bUc"/>
+                                            <constraint firstItem="Rcr-xr-eqz" firstAttribute="leading" secondItem="MpT-VW-hCb" secondAttribute="leading" id="NEO-MI-axO"/>
                                             <constraint firstItem="MpT-VW-hCb" firstAttribute="trailing" secondItem="rac-Ji-vZK" secondAttribute="trailing" id="Xmj-N7-oSb"/>
                                         </constraints>
                                     </stackView>
@@ -369,13 +375,13 @@
                                         <rect key="frame" x="418.33333333333331" y="0.0" width="118.33333333333331" height="152.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="21.666666666666686" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="12.000000000000057" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="21.666666666666686" y="90.666666666666671" width="75" height="23"/>
+                                                <rect key="frame" x="12.000000000000057" y="90.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -386,7 +392,9 @@
                                             </stepper>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstItem="klA-59-Nu4" firstAttribute="leading" secondItem="ZDv-1m-HBY" secondAttribute="leading" id="OVR-62-0Iw"/>
                                             <constraint firstItem="ZDv-1m-HBY" firstAttribute="trailing" secondItem="EHe-D1-1xN" secondAttribute="trailing" id="dFi-4l-NCF"/>
+                                            <constraint firstItem="klA-59-Nu4" firstAttribute="trailing" secondItem="ZDv-1m-HBY" secondAttribute="trailing" id="keD-r9-Pw2"/>
                                             <constraint firstItem="ZDv-1m-HBY" firstAttribute="leading" secondItem="EHe-D1-1xN" secondAttribute="leading" id="rND-bQ-xIv"/>
                                         </constraints>
                                     </stackView>
@@ -394,13 +402,13 @@
                                         <rect key="frame" x="557.66666666666663" y="0.0" width="118.33333333333337" height="152.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="21.666666666666742" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="12" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="21.666666666666742" y="90.666666666666671" width="75" height="23"/>
+                                                <rect key="frame" x="12" y="90.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -411,8 +419,10 @@
                                             </stepper>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstItem="xbn-6P-grO" firstAttribute="trailing" secondItem="YJI-ER-LJR" secondAttribute="trailing" id="OuI-IJ-DsV"/>
                                             <constraint firstItem="YJI-ER-LJR" firstAttribute="leading" secondItem="w1F-9o-qJR" secondAttribute="leading" id="a28-ZE-ykq"/>
                                             <constraint firstItem="YJI-ER-LJR" firstAttribute="trailing" secondItem="w1F-9o-qJR" secondAttribute="trailing" id="bdZ-Hx-JaD"/>
+                                            <constraint firstItem="xbn-6P-grO" firstAttribute="leading" secondItem="YJI-ER-LJR" secondAttribute="leading" id="cUp-Yo-OhS"/>
                                         </constraints>
                                     </stackView>
                                 </subviews>


### PR DESCRIPTION
@HARlBO 
 안녕하십니까 하리보 드디어 마지막 PR입니다.
바쁜와중에 리뷰해주시느라 항상 수고가 많으십니다.
마지막까지 잘 부탁 드리겠습니다.

기능구현 및 코드설명 ✏️
---
* didTapStepper : 스탭퍼를 눌리면 재고의 수정이 가능하게 만든 함수
* setupViews : 재고수정화면으로 넘어오는 첫 화면의 재고 레이블에 현재 재고를 반영해 주는 함수
* findFruit : 스탭퍼의 종류에 따라 연결되어 있는 과일이름을 리턴하는 함수
* findFruitStepper : 과일이름에 따라 연결되어 있는 스탭퍼의 종류를 리턴하는 함수
* setupStepper : 스탭퍼의 기본값을 각 과일들의 재고로 세팅해주는 함수
* makeVaildStepperValue : 스탭퍼의 기본값을 만들어주기 위한 과일재고를 할당 하는 함수
* selectFruitLable : 선택된 과일의 재고를 레이블에 띄워주는 함수
* changeStock : 스탭퍼의 값을 재고에 반영해 주는 함수
* viewWillAppear : 재고수정 화면에서 처음의 화면으로 돌아올 때 수정된 재고가 반영 되지 않기 때문에 첫번째 화면이 나타나는 시점에 레이블의 값을 수정된 재고로 변경하여 주는 함수.

[STEP 3] 고민한점 및 해결방안 🤔
---
- 네비게이션 컨트롤러를 사용하지 않아서 계속 노란색 에러가 났었는데 재고수정 세그를 네비게이션 컨트롤러로 연결 해주어서 해결함

- 스탭퍼를 사용하는 부분에서 스텝퍼.value값을 변경하지 않고 0으로 사용했었을 때 기존의 재고에서 1씩 더하거나 빼는게 아니라 0부터 시작해서 1씩 올라가는 상황이 있었는데 스텝퍼의 벨류값을 과일의 재고값으로 변경 하고나니 해결이 되었습니다.

- 스탭퍼 자체의 플러스 마이너스 클릭의 내부 메서드를 파악하지 못하고 기존에 만들어 두었더 재고를 더하는 함수를 이용해 보려고 했더니 재고가 +1, +2, +3, +4...이런 식으로 올라가는 현상이 나타났습니다. 이후에 스탭퍼 버튼의 특성을 다시 파악하고 외부에서 만든 함수를 하는게 아니라 기존의 값에 대입만 해주는 방법을 택해서 해결 하였습니다.
 
 궁금한 점 🥲
---
- StockViewController를 생성한 이후 재고 변경을 진행하려 했으나, 재고가 변경되지 않고 원래 있던 재고 마저도 반영을 하지 못하였습니다. 그래서 과일 재고 프로퍼티를 가지고 있는 FruitStore 클래스를 싱글톤 패턴으로 구현해 주었더니 재고가 반영이 되고 변경이 가능해졌습니다. 여기서 궁금한 점은 STEP2 과정에서 MakeJuiceViewController만 있었을 경우 싱글톤 패턴을 사용하지 않아도 쥬스 만들기 함수 등 재고의 변경이 반영이 되었는데, 뷰컨트롤러를 새로 만든 후 부터 새로운 뷰컨트롤러에서는 주스를 만들고 줄어든 재고를 반영하지 않고 재고의 초기값인 10으로 설정되어있었습니다. 뷰컨트롤러를 새로 만들고 데이터를 가져오기 위해 클래스를 새로운 뷰컨트롤러 안에서 선언해 주는 경우(screen shot 1) 싱글톤 패턴을 사용 하지 않으면 새로운 인스턴스를 생성하기 때문에 재고가 반영이 안되는 건지 궁금합니다!

screen shot 1
![](https://i.imgur.com/ELKPPrl.png)

- 모달 방식을 사용 하여 화면 전환을 해주 었는데 설정의 Presentation -> same As Destination 에서는 MakeJuiceViewController의 viewWillApear 함수가 호출이 되지 않아 닫기 버튼을 누른 바로 직후에 변경된 재고값을 반영하지 못했습니다. 그러나 Full Screen으로 변경했더니 viewWillapear가 적용이 되었습니다. 왜 이러한 현상이 나타나는지 이유가 궁금합니다!


- 화면 전환 방법을 구글을 검색 하여 구현을 하게 되었는데, storyboard?.instantiateViewController, perfomSegue 이 두 방식의 차이점을 알고 싶습니다!

