### PR TITLE
쥬스 메이커 [STEP 1] 써니쿠키, SummerCat

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,17 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4175A1FD28BCB7C1000C4434 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4175A1FC28BCB7C1000C4434 /* main.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
-		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
-		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
-		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
-		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
-		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4175A1FC28BCB7C1000C4434 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -56,6 +52,7 @@
 			children = (
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
+				4175A1FC28BCB7C1000C4434 /* main.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -154,9 +151,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */,
-				C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */,
-				C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -168,9 +162,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
-				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
-				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
+				4175A1FD28BCB7C1000C4434 /* main.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,13 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4175A1FD28BCB7C1000C4434 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4175A1FC28BCB7C1000C4434 /* main.swift */; };
+		690BE1C528BDA8FB00E44432 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
+		690BE1C628BDA8FD00E44432 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
+		690BE1C728BDA90F00E44432 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
+		690BE1C828BDA91100E44432 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
+		690BE1C928BDA91400E44432 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
+		690BE1CB28BDAA5100E44432 /* JuiceMakerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690BE1CA28BDAA5100E44432 /* JuiceMakerError.swift */; };
+		690BE1CC28BDB0A200E44432 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		4175A1FC28BCB7C1000C4434 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		690BE1CA28BDAA5100E44432 /* JuiceMakerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMakerError.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -52,7 +58,7 @@
 			children = (
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
-				4175A1FC28BCB7C1000C4434 /* main.swift */,
+				690BE1CA28BDAA5100E44432 /* JuiceMakerError.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -151,6 +157,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				690BE1C928BDA91400E44432 /* LaunchScreen.storyboard in Resources */,
+				690BE1C828BDA91100E44432 /* Assets.xcassets in Resources */,
+				690BE1C728BDA90F00E44432 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -161,8 +170,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				690BE1CC28BDB0A200E44432 /* ViewController.swift in Sources */,
+				690BE1C628BDA8FD00E44432 /* SceneDelegate.swift in Sources */,
+				690BE1C528BDA8FB00E44432 /* AppDelegate.swift in Sources */,
+				690BE1CB28BDAA5100E44432 /* JuiceMakerError.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
-				4175A1FD28BCB7C1000C4434 /* main.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -222,6 +234,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -283,6 +296,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
@@ -311,6 +325,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = JuiceMaker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -329,6 +344,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = JuiceMaker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -17,9 +17,13 @@ class ViewController: UIViewController {
 
         print(myJuiceMaker.fruitStore.fruitStock)
 
-        //myJuiceMaker.makeJuice(.mangoKiwiJuice, total: 1)
-        //
-        //print(myJuiceMaker.fruitStore.fruitStock)
+        myJuiceMaker.makeJuice(.mangoKiwiJuice, total: 2)
+        
+        print(myJuiceMaker.fruitStore.fruitStock)
+        
+        myJuiceMaker.makeJuice(.strawberryJuice, total: 3)
+        
+        print(myJuiceMaker.fruitStore.fruitStock)
 
     }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -13,16 +13,14 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view.
         
         let myJuiceMaker = JuiceMaker()
+        print(myJuiceMaker.fruitStore.fruitStock)
         myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
-
         print(myJuiceMaker.fruitStore.fruitStock)
 
         myJuiceMaker.makeJuice(.mangoKiwiJuice, total: 2)
-        
         print(myJuiceMaker.fruitStore.fruitStock)
         
-        myJuiceMaker.makeJuice(.strawberryJuice, total: 3)
-        
+        myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
         print(myJuiceMaker.fruitStore.fruitStock)
 
     }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -15,6 +15,8 @@ class ViewController: UIViewController {
         let myJuiceMaker = JuiceMaker()
         myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
         myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
+        
+        
     }
 
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -11,6 +11,16 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+        
+        let myJuiceMaker = JuiceMaker()
+        myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
+
+        print(myJuiceMaker.fruitStore.fruitStock)
+
+        //myJuiceMaker.makeJuice(.mangoKiwiJuice, total: 1)
+        //
+        //print(myJuiceMaker.fruitStore.fruitStock)
+
     }
 
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -13,18 +13,9 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view.
         
         let myJuiceMaker = JuiceMaker()
-        print(myJuiceMaker.fruitStore.fruitStock)
         myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
-        print(myJuiceMaker.fruitStore.fruitStock)
-
-        myJuiceMaker.makeJuice(.mangoKiwiJuice, total: 2)
-        print(myJuiceMaker.fruitStore.fruitStock)
-        
         myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
-        print(myJuiceMaker.fruitStore.fruitStock)
-
     }
-
 
 }
 

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -1,6 +1,6 @@
 //
 //  JuiceMaker - FruitStore.swift
-//  Created by yagom. 
+//  Created by 써니쿠키, SummerCat
 //  Copyright © yagom academy. All rights reserved.
 //
 
@@ -15,25 +15,19 @@ class FruitStore {
         case mango
     }
     
-    var fruitStock: Dictionary<Fruit, Int> = [.strawberry : 10,
-                                              .banana : 0,
-                                              .pineapple : 10,
-                                              .kiwi : 10,
-                                              .mango : 10]
+    var fruitStock: Dictionary<Fruit, Int> = [
+        .strawberry : 10,
+        .banana : 10,
+        .pineapple : 10,
+        .kiwi : 10,
+        .mango : 10,
+    ]
     
     func changeStockOf(fruit: Fruit, by quantity: Int) {
         guard let currentStock = fruitStock[fruit] else {
             return
         }
         
-        guard currentStock >= quantity else {
-            return
-        }
-        
         fruitStock[fruit] = currentStock + quantity
     }
 }
-
-
-
-

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -15,8 +15,8 @@ class FruitStore {
         case mango
     }
     
-    var fruitStock: Dictionary<Fruit, Int> = [.strawberry : 30,
-                                              .banana : 10,
+    var fruitStock: Dictionary<Fruit, Int> = [.strawberry : 10,
+                                              .banana : 0,
                                               .pineapple : 10,
                                               .kiwi : 10,
                                               .mango : 10]

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -15,7 +15,7 @@ class FruitStore {
         case mango
     }
     
-    var fruitStock: Dictionary<Fruit, Int> = [
+    private var fruitStock: Dictionary<Fruit, Int> = [
         .strawberry : 10,
         .banana : 10,
         .pineapple : 10,

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,5 +8,32 @@ import Foundation
 
 // 과일 저장소 타입
 class FruitStore {
+    enum Fruit {
+        case strawberry
+        case banana
+        case pineapple
+        case kiwi
+        case mango
+    }
     
+    var fruitStock: Dictionary<Fruit, Int> = [.strawberry : 10,
+                                              .banana : 10,
+                                              .pineapple : 10,
+                                              .kiwi : 10,
+                                              .mango : 10]
+    
+    func changeStockOf(fruit: Fruit, by quantity: Int) {
+        guard let currentStock = fruitStock[fruit] else {
+            return
+        }
+        
+        guard currentStock >= quantity else {
+            return
+        }
+        
+        fruitStock[fruit] = currentStock + quantity
+    }
 }
+
+
+

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -23,14 +23,6 @@ class FruitStore {
         .mango : 10,
     ]
     
-    func changeStockOf(fruit: Fruit, by quantity: Int) {
-        guard let currentStock = fruitStock[fruit] else {
-            return
-        }
-        
-        fruitStock[fruit] = currentStock + quantity
-    }
-    
     func checkStockOf(_ ingredient: Fruit, total: Int) throws {
         guard let curStock = fruitStock[ingredient] else {
             throw JuiceMakerError.noSuchFruit
@@ -39,5 +31,13 @@ class FruitStore {
         guard curStock >= total else {
             throw JuiceMakerError.stockShortage
         }
+    }
+    
+    func changeStockOf(fruit: Fruit, by quantity: Int) {
+        guard let currentStock = fruitStock[fruit] else {
+            return
+        }
+        
+        fruitStock[fruit] = currentStock + quantity
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 
-// 과일 저장소 타입
 class FruitStore {
     enum Fruit {
         case strawberry
@@ -16,7 +15,7 @@ class FruitStore {
         case mango
     }
     
-    var fruitStock: Dictionary<Fruit, Int> = [.strawberry : 10,
+    var fruitStock: Dictionary<Fruit, Int> = [.strawberry : 30,
                                               .banana : 10,
                                               .pineapple : 10,
                                               .kiwi : 10,
@@ -34,6 +33,7 @@ class FruitStore {
         fruitStock[fruit] = currentStock + quantity
     }
 }
+
 
 
 

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -24,9 +24,7 @@ class FruitStore {
     ]
     
     func changeStockOf(fruit: Fruit, by quantity: Int) {
-        guard let currentStock = fruitStock[fruit] else {
-            return
-        }
+        let currentStock = fruitStock[fruit, default: 0]
         
         fruitStock[fruit] = currentStock + quantity
     }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -30,4 +30,14 @@ class FruitStore {
         
         fruitStock[fruit] = currentStock + quantity
     }
+    
+    func checkStockOf(_ ingredient: Fruit, total: Int) throws {
+        guard let curStock = fruitStock[ingredient] else {
+            throw JuiceMakerError.noSuchFruit
+        }
+        
+        guard curStock >= total else {
+            throw JuiceMakerError.stockShortage
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -58,28 +58,28 @@ struct JuiceMaker {
     }
     
     func makeJuice(_ juice: Juice, total: Int) {
-
+        do {
+            try checkFruitStore(for: juice, total: total)
+        } catch let error as JuiceMakerError {
+            print(error.errorDescription)
+            return
+        } catch {
+            print("\(error)")
+            return
+        }
         
-        orderFruit()
+        useFruit(juice, total: total)
         
         print("\(juice.juiceName) \(total)잔 완성")
     }
     
-    func goToFruitStore() {
+    func checkFruitStore(for juice: Juice, total: Int) throws {
         for (ingredient, quantity) in juice.recipe {
-            do {
-                try fruitStore.checkStockOf(ingredient, total: quantity * total)
-            } catch let error as JuiceMakerError {
-                print(error.errorDescription)
-                return
-            } catch {
-                print("\(error)")
-                return
-            }
+            try fruitStore.checkStockOf(ingredient, total: quantity * total)
         }
     }
     
-    func  () {
+    func useFruit(_ juice: Juice, total: Int) {
         for (ingredient, quantity) in juice.recipe {
             fruitStore.changeStockOf(fruit: ingredient, by: -quantity * total)
         }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 
-// 쥬스 메이커 타입
 struct JuiceMaker {
     let fruitStore = FruitStore()
     
@@ -18,20 +17,67 @@ struct JuiceMaker {
         case strawberryBananaJuice
         case mangoJuice
         case mangoKiwiJuice
+
+        
+        var ingredient: (first: FruitStore.Fruit, second: FruitStore.Fruit?) {
+            switch self {
+            case .strawberryJuice:
+                return (.strawberry, nil)
+            case .bananaJuice:
+                return (.banana, nil)
+            case .kiwiJuice:
+                return (.kiwi, nil)
+            case .pineappleJuice:
+                return (.pineapple, nil)
+            case .strawberryBananaJuice:
+                return (.strawberry, .banana)
+            case .mangoJuice:
+                return (.mango, nil)
+            case .mangoKiwiJuice:
+                return (.mango, .kiwi)
+            }
+        }
+        
+        func ingredientsCount() -> (first: Int, second: Int) {
+            switch self {
+            case .strawberryJuice:
+                return (16, 0)
+            case .bananaJuice:
+                return (2,0)
+            case .kiwiJuice:
+                return (3,0)
+            case .pineappleJuice:
+                return (2,0)
+            case .strawberryBananaJuice:
+                return (10, 1)
+            case .mangoJuice:
+                return (3,0)
+            case .mangoKiwiJuice:
+                return (2,1)
+            }
+        }
     }
     
     func makeJuice(_ juice: Juice, total: Int) {
-//        switch juice {
-//        case .strawberryJuice:
-//        case .bananaJuice:
-//        case .kiwiJuice:
-//        case .pineappleJuice
-//        case .strawberryBananaJuice
-//        case .mangoJuice
-//        case .mangoKiwiJuice
-//        }
+        let ingredients = juice.ingredientsCount()
         
-//        checkStock(<#T##juice: Juice##Juice#>, total: <#Int#>)
+        switch juice {
+        case .strawberryJuice, .bananaJuice, .kiwiJuice, .pineappleJuice, .mangoJuice:
+            guard checkStockOf(fruit: juice.ingredient.first, count: ingredients.first * total) else {
+                return
+            }
+            fruitStore.changeStockOf(fruit: juice.ingredient.first, by: -ingredients.first * total)
+        case .strawberryBananaJuice, .mangoKiwiJuice:
+            guard let secondIngredient = juice.ingredient.second else {
+                return
+            }
+            guard checkStockOf(fruit: juice.ingredient.first, count: ingredients.first * total),
+                  checkStockOf(fruit: secondIngredient, count: ingredients.second * total) else {
+                return
+            }
+            fruitStore.changeStockOf(fruit: juice.ingredient.first, by: -ingredients.first * total)
+            fruitStore.changeStockOf(fruit: secondIngredient, by: -ingredients.second * total)
+        }
     }
     
     func checkStockOf(fruit: FruitStore.Fruit, count: Int) -> Bool {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,5 +8,41 @@ import Foundation
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
+    let fruitStore = FruitStore()
     
+    enum Juice {
+        case strawberryJuice
+        case bananaJuice
+        case kiwiJuice
+        case pineappleJuice
+        case strawberryBananaJuice
+        case mangoJuice
+        case mangoKiwiJuice
+    }
+    
+    func makeJuice(_ juice: Juice, total: Int) {
+//        switch juice {
+//        case .strawberryJuice:
+//        case .bananaJuice:
+//        case .kiwiJuice:
+//        case .pineappleJuice
+//        case .strawberryBananaJuice
+//        case .mangoJuice
+//        case .mangoKiwiJuice
+//        }
+        
+//        checkStock(<#T##juice: Juice##Juice#>, total: <#Int#>)
+    }
+    
+    func checkStockOf(fruit: FruitStore.Fruit, count: Int) -> Bool {
+        guard let currentStock = fruitStore.fruitStock[fruit] else {
+            return false
+        }
+        
+        guard currentStock >= count else {
+            return false
+        }
+        
+        return true
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -1,97 +1,10 @@
 //
 //  JuiceMaker - JuiceMaker.swift
-//  Created by yagom. 
+//  Created by 써니쿠키, SummerCat
 //  Copyright © yagom academy. All rights reserved.
 // 
 
 import Foundation
-
-//struct JuiceMaker {
-//    let fruitStore = FruitStore()
-//
-//    enum Juice {
-//        case strawberryJuice
-//        case bananaJuice
-//        case kiwiJuice
-//        case pineappleJuice
-//        case strawberryBananaJuice
-//        case mangoJuice
-//        case mangoKiwiJuice
-//
-//
-//        var ingredient: (first: FruitStore.Fruit, second: FruitStore.Fruit?) {
-//            switch self {
-//            case .strawberryJuice:
-//                return (.strawberry, nil)
-//            case .bananaJuice:
-//                return (.banana, nil)
-//            case .kiwiJuice:
-//                return (.kiwi, nil)
-//            case .pineappleJuice:
-//                return (.pineapple, nil)
-//            case .strawberryBananaJuice:
-//                return (.strawberry, .banana)
-//            case .mangoJuice:
-//                return (.mango, nil)
-//            case .mangoKiwiJuice:
-//                return (.mango, .kiwi)
-//            }
-//        }
-//
-//        func ingredientsCount() -> (first: Int, second: Int) {
-//            switch self {
-//            case .strawberryJuice:
-//                return (16, 0)
-//            case .bananaJuice:
-//                return (2,0)
-//            case .kiwiJuice:
-//                return (3,0)
-//            case .pineappleJuice:
-//                return (2,0)
-//            case .strawberryBananaJuice:
-//                return (10, 1)
-//            case .mangoJuice:
-//                return (3,0)
-//            case .mangoKiwiJuice:
-//                return (2,1)
-//            }
-//        }
-//    }
-//
-//    func makeJuice(_ juice: Juice, total: Int) {
-//        let ingredients = juice.ingredientsCount()
-//
-//        switch juice {
-//        case .strawberryJuice, .bananaJuice, .kiwiJuice, .pineappleJuice, .mangoJuice:
-//            guard checkStockOf(fruit: juice.ingredient.first, count: ingredients.first * total) else {
-//                return
-//            }
-//            fruitStore.changeStockOf(fruit: juice.ingredient.first, by: -ingredients.first * total)
-//        case .strawberryBananaJuice, .mangoKiwiJuice:
-//            guard let secondIngredient = juice.ingredient.second else {
-//                return
-//            }
-//            guard checkStockOf(fruit: juice.ingredient.first, count: ingredients.first * total),
-//                  checkStockOf(fruit: secondIngredient, count: ingredients.second * total) else {
-//                return
-//            }
-//            fruitStore.changeStockOf(fruit: juice.ingredient.first, by: -ingredients.first * total)
-//            fruitStore.changeStockOf(fruit: secondIngredient, by: -ingredients.second * total)
-//        }
-//    }
-//
-//    func checkStockOf(fruit: FruitStore.Fruit, count: Int) -> Bool {
-//        guard let currentStock = fruitStore.fruitStock[fruit] else {
-//            return false
-//        }
-//
-//        guard currentStock >= count else {
-//            return false
-//        }
-//
-//        return true
-//    }
-//}
 
 struct JuiceMaker {
     let fruitStore = FruitStore()
@@ -104,6 +17,25 @@ struct JuiceMaker {
         case strawberryBananaJuice
         case mangoJuice
         case mangoKiwiJuice
+        
+        var juiceName: String {
+            switch self {
+            case .strawberryJuice:
+                return "딸기쥬스"
+            case .bananaJuice:
+                return "바나나쥬스"
+            case .kiwiJuice:
+                return "키위쥬스"
+            case .pineappleJuice:
+                return "파인애플쥬스"
+            case .strawberryBananaJuice:
+                return "딸바쥬스"
+            case .mangoJuice:
+                return "망고쥬스"
+            case .mangoKiwiJuice:
+                return "망키쥬스"
+            }
+        }
         
         var recipe: Dictionary<FruitStore.Fruit, Int> {
             switch self {
@@ -126,7 +58,13 @@ struct JuiceMaker {
     }
     
     func makeJuice(_ juice: Juice, total: Int) {
-        guard checkStockOf(juice, total: total) else {
+        do {
+            try checkStockOf(juice, total: total)
+        } catch let error as JuiceMakerError {
+            print(error.errorDescription)
+            return
+        } catch {
+            print("\(error)")
             return
         }
         
@@ -135,22 +73,23 @@ struct JuiceMaker {
         for (ingredient, quantity) in recipe {
             fruitStore.changeStockOf(fruit: ingredient, by: -(quantity * total))
         }
-        print("\(juice) 한 잔 완성")
+        
+        print("\(juice.juiceName) \(total)잔 완성")
     }
     
-    func checkStockOf(_ juice: Juice, total: Int) -> Bool {
+    private func checkStockOf(_ juice: Juice, total: Int) throws {
         let recipe = juice.recipe
         
         for (ingredient, quantity) in recipe {
             guard let currentStock = fruitStore.fruitStock[ingredient] else {
-                return false
+                return
             }
             
             guard currentStock >= quantity * total else {
-                return false
+                throw JuiceMakerError.stockShortage
             }
         }
         
-        return true
+        return
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -6,6 +6,93 @@
 
 import Foundation
 
+//struct JuiceMaker {
+//    let fruitStore = FruitStore()
+//
+//    enum Juice {
+//        case strawberryJuice
+//        case bananaJuice
+//        case kiwiJuice
+//        case pineappleJuice
+//        case strawberryBananaJuice
+//        case mangoJuice
+//        case mangoKiwiJuice
+//
+//
+//        var ingredient: (first: FruitStore.Fruit, second: FruitStore.Fruit?) {
+//            switch self {
+//            case .strawberryJuice:
+//                return (.strawberry, nil)
+//            case .bananaJuice:
+//                return (.banana, nil)
+//            case .kiwiJuice:
+//                return (.kiwi, nil)
+//            case .pineappleJuice:
+//                return (.pineapple, nil)
+//            case .strawberryBananaJuice:
+//                return (.strawberry, .banana)
+//            case .mangoJuice:
+//                return (.mango, nil)
+//            case .mangoKiwiJuice:
+//                return (.mango, .kiwi)
+//            }
+//        }
+//
+//        func ingredientsCount() -> (first: Int, second: Int) {
+//            switch self {
+//            case .strawberryJuice:
+//                return (16, 0)
+//            case .bananaJuice:
+//                return (2,0)
+//            case .kiwiJuice:
+//                return (3,0)
+//            case .pineappleJuice:
+//                return (2,0)
+//            case .strawberryBananaJuice:
+//                return (10, 1)
+//            case .mangoJuice:
+//                return (3,0)
+//            case .mangoKiwiJuice:
+//                return (2,1)
+//            }
+//        }
+//    }
+//
+//    func makeJuice(_ juice: Juice, total: Int) {
+//        let ingredients = juice.ingredientsCount()
+//
+//        switch juice {
+//        case .strawberryJuice, .bananaJuice, .kiwiJuice, .pineappleJuice, .mangoJuice:
+//            guard checkStockOf(fruit: juice.ingredient.first, count: ingredients.first * total) else {
+//                return
+//            }
+//            fruitStore.changeStockOf(fruit: juice.ingredient.first, by: -ingredients.first * total)
+//        case .strawberryBananaJuice, .mangoKiwiJuice:
+//            guard let secondIngredient = juice.ingredient.second else {
+//                return
+//            }
+//            guard checkStockOf(fruit: juice.ingredient.first, count: ingredients.first * total),
+//                  checkStockOf(fruit: secondIngredient, count: ingredients.second * total) else {
+//                return
+//            }
+//            fruitStore.changeStockOf(fruit: juice.ingredient.first, by: -ingredients.first * total)
+//            fruitStore.changeStockOf(fruit: secondIngredient, by: -ingredients.second * total)
+//        }
+//    }
+//
+//    func checkStockOf(fruit: FruitStore.Fruit, count: Int) -> Bool {
+//        guard let currentStock = fruitStore.fruitStock[fruit] else {
+//            return false
+//        }
+//
+//        guard currentStock >= count else {
+//            return false
+//        }
+//
+//        return true
+//    }
+//}
+
 struct JuiceMaker {
     let fruitStore = FruitStore()
     
@@ -17,76 +104,51 @@ struct JuiceMaker {
         case strawberryBananaJuice
         case mangoJuice
         case mangoKiwiJuice
-
         
-        var ingredient: (first: FruitStore.Fruit, second: FruitStore.Fruit?) {
+        var recipe: Dictionary<FruitStore.Fruit, Int> {
             switch self {
             case .strawberryJuice:
-                return (.strawberry, nil)
+                return [.strawberry: 16]
             case .bananaJuice:
-                return (.banana, nil)
+                return [.banana: 2]
             case .kiwiJuice:
-                return (.kiwi, nil)
+                return [.kiwi: 3]
             case .pineappleJuice:
-                return (.pineapple, nil)
+                return [.pineapple: 2]
             case .strawberryBananaJuice:
-                return (.strawberry, .banana)
+                return [.strawberry: 10, .banana: 1]
             case .mangoJuice:
-                return (.mango, nil)
+                return [.mango: 3]
             case .mangoKiwiJuice:
-                return (.mango, .kiwi)
-            }
-        }
-        
-        func ingredientsCount() -> (first: Int, second: Int) {
-            switch self {
-            case .strawberryJuice:
-                return (16, 0)
-            case .bananaJuice:
-                return (2,0)
-            case .kiwiJuice:
-                return (3,0)
-            case .pineappleJuice:
-                return (2,0)
-            case .strawberryBananaJuice:
-                return (10, 1)
-            case .mangoJuice:
-                return (3,0)
-            case .mangoKiwiJuice:
-                return (2,1)
+                return [.mango: 2, .kiwi: 1]
             }
         }
     }
     
     func makeJuice(_ juice: Juice, total: Int) {
-        let ingredients = juice.ingredientsCount()
-        
-        switch juice {
-        case .strawberryJuice, .bananaJuice, .kiwiJuice, .pineappleJuice, .mangoJuice:
-            guard checkStockOf(fruit: juice.ingredient.first, count: ingredients.first * total) else {
-                return
-            }
-            fruitStore.changeStockOf(fruit: juice.ingredient.first, by: -ingredients.first * total)
-        case .strawberryBananaJuice, .mangoKiwiJuice:
-            guard let secondIngredient = juice.ingredient.second else {
-                return
-            }
-            guard checkStockOf(fruit: juice.ingredient.first, count: ingredients.first * total),
-                  checkStockOf(fruit: secondIngredient, count: ingredients.second * total) else {
-                return
-            }
-            fruitStore.changeStockOf(fruit: juice.ingredient.first, by: -ingredients.first * total)
-            fruitStore.changeStockOf(fruit: secondIngredient, by: -ingredients.second * total)
+        guard checkStockOf(juice, total: total) else {
+            return
         }
+        
+        let recipe = juice.recipe
+        
+        for (ingredient, quantity) in recipe {
+            fruitStore.changeStockOf(fruit: ingredient, by: -(quantity * total))
+        }
+        print("\(juice) 한 잔 완성")
     }
     
-    func checkStockOf(fruit: FruitStore.Fruit, count: Int) -> Bool {
-        guard let currentStock = fruitStore.fruitStock[fruit] else {
-            return false
-        }
+    func checkStockOf(_ juice: Juice, total: Int) -> Bool {
+        let recipe = juice.recipe
         
-        guard currentStock >= count else {
-            return false
+        for (ingredient, quantity) in recipe {
+            guard let currentStock = fruitStore.fruitStock[ingredient] else {
+                return false
+            }
+            
+            guard currentStock >= quantity * total else {
+                return false
+            }
         }
         
         return true

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -73,13 +73,13 @@ struct JuiceMaker {
         print("\(juice.juiceName) \(total)잔 완성")
     }
     
-    func checkFruitStore(for juice: Juice, total: Int) throws {
+    private func checkFruitStore(for juice: Juice, total: Int) throws {
         for (ingredient, quantity) in juice.recipe {
             try fruitStore.checkStockOf(ingredient, total: quantity * total)
         }
     }
     
-    func useFruit(_ juice: Juice, total: Int) {
+    private func useFruit(_ juice: Juice, total: Int) {
         for (ingredient, quantity) in juice.recipe {
             fruitStore.changeStockOf(fruit: ingredient, by: -quantity * total)
         }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 struct JuiceMaker {
-    let fruitStore = FruitStore()
+    private let fruitStore = FruitStore()
     
     enum Juice {
         case strawberryJuice

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -58,36 +58,30 @@ struct JuiceMaker {
     }
     
     func makeJuice(_ juice: Juice, total: Int) {
-        do {
-            try checkStockOf(juice, total: total)
-        } catch let error as JuiceMakerError {
-            print(error.errorDescription)
-            return
-        } catch {
-            print("\(error)")
-            return
-        }
+
         
-        let recipe = juice.recipe
-        
-        for (ingredient, quantity) in recipe {
-            fruitStore.changeStockOf(fruit: ingredient, by: -(quantity * total))
-        }
+        orderFruit()
         
         print("\(juice.juiceName) \(total)잔 완성")
     }
     
-    private func checkStockOf(_ juice: Juice, total: Int) throws {
-        let recipe = juice.recipe
-        
-        for (ingredient, quantity) in recipe {
-            guard let currentStock = fruitStore.fruitStock[ingredient] else {
+    func goToFruitStore() {
+        for (ingredient, quantity) in juice.recipe {
+            do {
+                try fruitStore.checkStockOf(ingredient, total: quantity * total)
+            } catch let error as JuiceMakerError {
+                print(error.errorDescription)
+                return
+            } catch {
+                print("\(error)")
                 return
             }
-            
-            guard currentStock >= quantity * total else {
-                throw JuiceMakerError.stockShortage
-            }
+        }
+    }
+    
+    func  () {
+        for (ingredient, quantity) in juice.recipe {
+            fruitStore.changeStockOf(fruit: ingredient, by: -quantity * total)
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -89,7 +89,5 @@ struct JuiceMaker {
                 throw JuiceMakerError.stockShortage
             }
         }
-        
-        return
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum JuiceMakerError: Error {
-    case stockShortage
+    case stockShortage, noSuchFruit
 }
 
 extension JuiceMakerError {
@@ -9,6 +9,8 @@ extension JuiceMakerError {
         switch self {
         case .stockShortage:
             return "재고 부족"
+        case .noSuchFruit:
+            return "해당 과일은 취급하지 않음"
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum JuiceMakerError: Error {
+    case stockShortage
+}
+
+extension JuiceMakerError {
+    var errorDescription: String {
+        switch self {
+        case .stockShortage:
+            return "재고 부족"
+        }
+    }
+}

--- a/JuiceMaker/JuiceMaker/Model/main.swift
+++ b/JuiceMaker/JuiceMaker/Model/main.swift
@@ -1,0 +1,13 @@
+//
+//  main.swift
+//  JuiceMaker
+//
+//  Created by 맹선아 on 2022/08/29.
+//
+
+import Foundation
+
+
+let a = FruitStore()
+a.changeStockOf(fruit: .strawberry, by: 2)
+print(a.fruitStock)

--- a/JuiceMaker/JuiceMaker/Model/main.swift
+++ b/JuiceMaker/JuiceMaker/Model/main.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 
-let a = FruitStore()
-a.changeStockOf(fruit: .strawberry, by: 2)
-print(a.fruitStock)
+
+
+let myJuiceMaker = JuiceMaker()
+myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
+
+print(myJuiceMaker.fruitStore.fruitStock)

--- a/JuiceMaker/JuiceMaker/Model/main.swift
+++ b/JuiceMaker/JuiceMaker/Model/main.swift
@@ -14,3 +14,7 @@ let myJuiceMaker = JuiceMaker()
 myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
 
 print(myJuiceMaker.fruitStore.fruitStock)
+
+//myJuiceMaker.makeJuice(.mangoKiwiJuice, total: 1)
+//
+//print(myJuiceMaker.fruitStore.fruitStock)

--- a/JuiceMaker/JuiceMaker/Model/main.swift
+++ b/JuiceMaker/JuiceMaker/Model/main.swift
@@ -10,11 +10,3 @@ import Foundation
 
 
 
-let myJuiceMaker = JuiceMaker()
-myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
-
-print(myJuiceMaker.fruitStore.fruitStock)
-
-//myJuiceMaker.makeJuice(.mangoKiwiJuice, total: 1)
-//
-//print(myJuiceMaker.fruitStore.fruitStock)

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>


### PR DESCRIPTION
@내일날씨맑음(@SungPyo)
안녕하세요 웨더!
Step1 PR 드립니다!
가독성을 높이려고 노력했습니다..!
혹시 이해가 안되시는 PR내용이 있으면 언제든지 DM주세요!
감사합니다 😇

---

## 1. 프로젝트 구성

### `FruitStore`
- `FruitStore`는 `enum` 타입의 `Fruit`를 통해 취급하는 과일을 명시합니다.
- 각 과일의 재고는 `[Fruit: Int]` 형태의 딕셔너리 `fruitStock` 프로퍼티에서 관리합니다.
    ```swift
    private var fruitStock: Dictionary<Fruit, Int> = [
            .strawberry : 10,
            .banana : 10,
            .pineapple : 10,
            .kiwi : 10,
            .mango : 10,
        ]
    ```
    - `fruitStock` 딕셔너리 작성 시 마지막 Element 뒤에 `,`를 붙인 이유
        - [구글의 Swift 컨벤션](https://google.github.io/swift/#braces)
        - array와 dictionary의 각 element가 한 줄에 하나씩 작성되었을 경우, 뒤에 꼭 `,`를 붙여야 한다. 이렇게 해야 나중에 항목이 추가되었을 때 더 명확하게 차이를 알 수 있다.
     ![](https://i.imgur.com/LXCgkly.png)
      - 접근제어자를 `private`으로 설정한 이유: 과일가게의 과일의 재고 값을 외부에서 마음대로 바꾸지 못하도록 해야 한다고 생각해서 `private`을 사용해 `FruitStore` 내에서만 접근이 가능하도록 설정했습니다. 

- `changeStockOf` 함수
    - `FruitStore`가 가지고 있는 과일의 재고의 수량을 변경하는 함수입니다.
    ```swift
    func changeStockOf(fruit: Fruit, by quantity: Int) {
            guard let currentStock = fruitStock[fruit] else {
                return
            }

            fruitStock[fruit] = currentStock + quantity
        }
    ```
    - `guard`문을 사용해 현재의 재고 수량을 옵셔널 바인딩 해서 `currentStock`에 넣은 후, 조정한 수량만큼 `fruitStock[fruit]`에 넣어줍니다.
    - `fruitStock[fruit] = currentStock = quantity`에서 옵셔널 바인딩이 필요하지 않은 이유는, `fuitStock[fruit]`의 값이 존재하지 않더라도, `currentStock + quantity`의 값을 새로 할당해주기 때문입니다.

-  `checkStockOf` 함수
    - `JuiceMaker`가 요청한 과일의 수량을 확인하는 함수입니다.
    - 요청이 들어온 과일이 존재하지 않을 경우, `noSuchFruit` 에러를 반환합니다.
    - 요청이 들어온 과일의 수량이 부족할 경우, `stockShortage` 에러를 반환합니다.

### `JuiceMaker`
- `JuiceMaker`는 `FruitStore`를 소유하기 위해 `fruitStore`라는 `FruitStore`의 인스턴스를 갖습니다.
- `JuiceMaker`는 `enum` 타입의 `Juice`를 통해 취급하는 쥬스를 명시합니다. `enum` 타입 안에 `juiceName` 프로퍼티를 만들어 각 쥬스의 한글이름을 반환할 수 있도록 하고,  `recipe` 프로퍼티에 사용하는 과일과 갯수를 딕셔너리로 정리해 주었습니다.
    - 딕셔너리를 사용해서 `recipe`를 작성한 이유: **고민한 부분**에 작성
- `makeJuice` 메서드는 쥬스 제작이 가능한지 확인하기 위해 `checkFruitStore` 메서드를 통해 레시피에 맞는 과일갯수를 체크하고, 사용한 과일만큼 `useFruitStore` 메서드를 통해 `fruitStore`의 과일 재고를 조정합니다. 
    - 이 과정중 do - try - catch 구문을 사용하여 error를 처리합니다.
    - `JuiceMakerError`로 다운캐스팅 된 `error` 상수를 catch에서 정의해, `errorDescription`으로 에러 메시지를 불러옵니다.
    - error가 catch 될 시에 음료제작을 중단하기 위해 return처리 됩니다. 
- `checkFruitStore` 메서드는 `recipe`에서 필요한 과일의 개수와 `fruitStore`의 재고를 비교하기 위해 `FruitStore`의 `checkStockOf` 메서드를 이용합니다. `checkStockOf`에 과일의 종류와, 해당 과일의 필요한 총량을 전달합니다. 딕셔너리의 key값을 이용하기 위해 for - in 구문을 이용했습니다.
    - `JuiceMaker`의 `changeStockOf`에서 던진 오류를 `checkFruitStore`에서 처리할 수도 있지만, 그렇게 작성할 경우 함수의 depth가 깊어져 가독성이 떨어진다고 판단해 오류를 한번 더 던져서 `makeJuice`에서 오류를 처리하도록 했습니다.

- `useFruit` 메서드는 `fruitStore`의 과일의 재고를 조정합니다.


### `JuiceMakerError`
- `JuiceMakerError`에서는 `Error` 프로토콜을 채택한 `enum`타입을 이용해 에러를 case별로 정리했습니다.
- `extension`을 이용해 do-catch구문에서 에러메세지로 이용할 구문을 `errorDescription` 프로퍼티에 정리했습니다. 사용시에는 as로 다운캐스팅하여 `errorDescription`을 이용해 에러메세지를 출력할 수 있도록 하였습니다.
    - `LocalizedError` 프로토콜에 이미 `errorDescription`이 구현되어 있지만 `LocalizedError`를 채택하지 않은 이유는, `LocalizedError`에 구현되어 있는 `errorDescription`의 반환값이 `String?`이기 때문입니다.
    - 정의된 유형의 에러가 발생했을 때에만 `errorDescription`을 내보내는 방향으로 설계했기 때문에 옵셔널 타입으로 반환할 필요가 없다고 생각해, `String`을 반환하는 `errorDescription`을 `extension`에 새로 정의해서 사용했습니다.

---

## 2. 실행 예시
| 코드 | 출력 |
|------|---|
|<img width="350" src="https://i.imgur.com/DuDhrbk.png"> |<img width="350" src="https://i.imgur.com/82VzY4r.png">|

- `딸바쥬스`를 만들고 난 후`딸기`의 재고가 0이기 때문에, 이후에 `딸바쥬스`를 만들어달라고 요청한 경우 쥬스를 만들지 않고 `재고 부족` 메시지를 출력합니다.
    - 이 때, 두 과일(`딸기`, `바나나`) 중 하나라도 재고가 부족한 경우 쥬스를 만들지 않고 두 과일의 재고 모두 조정되지 않습니다.

---

## 3. 고민한 부분

### `enum Juice` 타입에서 사용하는 과일의 종류, 갯수 연결하기
열거형으로 정리한 쥬스타입의 case마다 레시피로 사용되는 각 과일의 갯수를 연관지어 지정해놓고 싶었습니다. 예를 들어, 딸기바나나쥬스는 딸기 10개 바나나 1개를 사용하기 때문에 `case 딸기바나나쥬스` 에는 딸기 10개, 바나나 1개를 연결하고 싶었습니다.
- **시도1 : 연관값(Associated Values) 사용**
    ```swift
    case strawberryBananaJuice(strawberry: 10, banana: 1)
    ```
    - 연관값을 사용할 경우, 만들 쥬스를 고르기 위해 case를 불러올 때 연관값을 반드시 초기화(할당)해야 해서 최초에 할당한 연관값이 사용되지 않는 문제가 있었습니다.

 - **시도2 : 튜플을 리턴해주는 메서드, 프로퍼티 사용**
     ```swift
        enum Juice {
            case bananaJuice
            case strawberryBananaJuice

            var ingredient: (first: FruitStore.Fruit, second: FruitStore.Fruit?) {
                switch self {
               case .bananaJuice:
                    return (.banana, nil)
               case .strawberryBananaJuice:
                    return (.strawberry, .banana)
                }
            }

            func ingredientsCount() -> (first: Int, second: Int) {
                switch self {
                case .bananaJuice:
                    return (2,0)
                case .strawberryBananaJuice:
                    return (10, 1)

                }
            }

    //사용 시
    let firstfruitType = Juice.ingredient.first 
    let firstfruitCount = Juice.ingredients.first         
    let secondfruitType = Juice.ingredient.second //옵셔널바인딩 포함
    let secondruitCount = Juice.ingredients.socond       
    ```
    - 과일타입과 갯수를 튜플로 묶어 리턴하는 방법을 시도했지만, 과일이름과 갯수를 서로 다른 프로퍼티와 메서드에서 따로 리턴해주기 때문에 코드를 읽는 사람입장에서 어떤 과일이 몇개가 쓰이는지 연결짓기가 어려울 것 같다고 생각했습니다. 
    - 한개의 튜플에 라벨을 달아 과일명과 갯수를 같이 넣어주는 방법도 있지만 튜플은 그 크기가 정해져있기에 과일을 한 개만 사용하는 쥬스와 두 개를 사용하는 쥬스를 프로퍼티(혹은 메서드)한 곳에 같이 담기가 어려워 사용하지 않았습니다.

- **시도 3. 딕셔너리 타입을 리턴해주는 프로퍼티 사용**
    ```swift
     var recipe: Dictionary<FruitStore.Fruit, Int> {
                switch self {
                case .strawberryJuice:
                    return [.strawberry: 16]
                case .strawberryBananaJuice:
                    return [.strawberry: 10, .banana: 1]
                }
     }
    ```
    - `recipe` 프로퍼티에 과일 종류와 개수를 딕셔너리로 반환시켜주는 컨셉을 채택했습니다. 과일 종류와 개수를 명확히 보여줄 수 있고, 그 크기도 정해져있지 않고 순서도 중요하지 않기 때문에 딕셔너리를 사용하는게 베스트라고 생각했습니다.

---

## 해결 안 된 부분

### 컬렉션 타입 결정 
프로젝트를 처음 clone했을 때, `JuiceMaker`는 구조체로 `FruitStore`는 클래스로 선언되어 있었습니다. 둘이 왜 다른 컬렉션 타입으로 선언되어야 하는지 이유를 찾지 못했습니다. 
