### PR TITLE
쥬스메이커 [STEP 2] Gundy, 준호

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
 		EB98D8D828BDF11E00BB1553 /* FruitStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB98D8D728BDF11E00BB1553 /* FruitStoreError.swift */; };
+		EBFB25CB28C5E9920058D16C /* StockEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFB25CA28C5E9920058D16C /* StockEditViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		C73DAF44255D0CDF00020D38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMaker.swift; sourceTree = "<group>"; };
 		EB98D8D728BDF11E00BB1553 /* FruitStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStoreError.swift; sourceTree = "<group>"; };
+		EBFB25CA28C5E9920058D16C /* StockEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockEditViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +55,7 @@
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				EBFB25CA28C5E9920058D16C /* StockEditViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -182,6 +185,7 @@
 				BFC7C35D28BDCF4100DF9406 /* Juice.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
+				EBFB25CB28C5E9920058D16C /* StockEditViewController.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 			);

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		BFC7C35B28BD9F5E00DF9406 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC7C35A28BD9F5E00DF9406 /* Fruit.swift */; };
 		BFC7C35D28BDCF4100DF9406 /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC7C35C28BDCF4100DF9406 /* Juice.swift */; };
+		BFE6A9AF28C83110008A0D84 /* AlertText.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE6A9AE28C83110008A0D84 /* AlertText.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -24,6 +25,7 @@
 /* Begin PBXFileReference section */
 		BFC7C35A28BD9F5E00DF9406 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		BFC7C35C28BDCF4100DF9406 /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
+		BFE6A9AE28C83110008A0D84 /* AlertText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertText.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -68,6 +70,7 @@
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				EB98D8D728BDF11E00BB1553 /* FruitStoreError.swift */,
 				BFC7C35A28BD9F5E00DF9406 /* Fruit.swift */,
+				BFE6A9AE28C83110008A0D84 /* AlertText.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -182,6 +185,7 @@
 				BFC7C35B28BD9F5E00DF9406 /* Fruit.swift in Sources */,
 				EB98D8D828BDF11E00BB1553 /* FruitStoreError.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
+				BFE6A9AF28C83110008A0D84 /* AlertText.swift in Sources */,
 				BFC7C35D28BDCF4100DF9406 /* Juice.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -1,0 +1,14 @@
+//
+//  StockEditViewController.swift
+//  JuiceMaker
+//
+//  Created by Gundy, 준호
+//
+
+import UIKit
+
+class StockEditViewController: UIViewController {
+    @IBAction func touchUpDismissButton(_ sender: UIButton) {
+        dismiss(animated: true)
+    }
+}

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -7,9 +7,47 @@
 import UIKit
 
 class ViewController: UIViewController {
+    var juiceMaker: JuiceMaker = .init(fruitStore: .init(initialStock: 10))
+    
+    @IBOutlet weak var strawberryJuiceOrderButton: UIButton!
+    @IBOutlet weak var bananaJuiceOrderButton: UIButton!
+    @IBOutlet weak var kiwiJuiceOrderButton: UIButton!
+    @IBOutlet weak var pineappleJuiceOrderButton: UIButton!
+    @IBOutlet weak var strawberryBananaMixJuiceOrderButton: UIButton!
+    @IBOutlet weak var mangoJuiceOrderButton: UIButton!
+    @IBOutlet weak var mangoKiwiMixJuiceOrderButton: UIButton!
 
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+    
+    @IBAction func touchUpJuiceOrderButton(_ sender: UIButton) {
+        let juice: Juice
+        switch sender {
+        case strawberryJuiceOrderButton:
+            juice = .strawberryJuice
+        case bananaJuiceOrderButton:
+            juice = .bananaJuice
+        case kiwiJuiceOrderButton:
+            juice = .kiwiJuice
+        case pineappleJuiceOrderButton:
+            juice = .pineappleJuice
+        case strawberryBananaMixJuiceOrderButton:
+            juice = .strawberryBananaMixJuice
+        case mangoJuiceOrderButton:
+            juice = .mangoJuice
+        case mangoKiwiMixJuiceOrderButton:
+            juice = .mangoKiwiMixJuice
+        default:
+            return
+        }
+        let result: Result<Juice,FruitStoreError> = juiceMaker.make(juice)
+        switch result {
+        case .success:
+            showOKAlert("\(juice.name) 나왔습니다! 맛있게 드세요!")
+        case .failure:
+            showEditAlert("재료가 모자라요. 재고를 수정할까요?")
+        }
     }
     
     func showOKAlert(_ message: String) {

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -30,7 +30,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpEditStockButton(_ sender: UIBarButtonItem) {
-        prsentStockEditView()
+        presentStockEditView()
     }
     
     @IBAction func touchUpJuiceOrderButton(_ sender: UIButton) {
@@ -69,36 +69,35 @@ class ViewController: UIViewController {
     }
     
     func showOkayAlert(_ message: String) {
-        let alert = UIAlertController(title: nil,
-                                      message: message,
-                                      preferredStyle: .alert)
         let okAction = UIAlertAction(title: AlertText.okay,
                                      style: .default,
                                      handler: nil)
-        alert.addAction(okAction)
-        present(alert,
-                animated: true,
-                completion: nil)
+        showAlert(message, alertActions: okAction)
     }
     
     func showStockEditAlert(_ message: String) {
-        let alert = UIAlertController(title: nil,
-                                      message: message,
-                                      preferredStyle: .alert)
         let editAction = UIAlertAction(title: AlertText.yes,
                                        style: .default) { (action) in
-            self.prsentStockEditView()
+            self.presentStockEditView()
         }
         let cancelAction = UIAlertAction(title: AlertText.no,
                                          style: .default)
-        alert.addAction(editAction)
-        alert.addAction(cancelAction)
+        showAlert(message, alertActions: editAction, cancelAction)
+    }
+    
+    func showAlert(_ message: String, alertActions: UIAlertAction...) {
+        let alert = UIAlertController(title: nil,
+                                      message: message,
+                                      preferredStyle: .alert)
+        for alertAction in alertActions {
+            alert.addAction(alertAction)
+        }
         present(alert,
                 animated: true,
                 completion: nil)
     }
     
-    func prsentStockEditView() {
+    func presentStockEditView() {
         guard let stockEditViewController = self.storyboard?.instantiateViewController(withIdentifier: "StockEditViewController") as? StockEditViewController else {
             return
         }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -41,7 +41,7 @@ class ViewController: UIViewController {
         switch result {
         case .success(let juice):
             updateFruitStockLabel()
-            showOkayAlert("\(juice.name) 나왔습니다! 맛있게 드세요!")
+            showOkayAlert("\(juice.name) \(AlertText.juiceCompletion)")
         case .failure(let fruitStoreError):
             showStockEditAlert("\(fruitStoreError.localizedDescription)")
         }
@@ -72,7 +72,7 @@ class ViewController: UIViewController {
         let alert = UIAlertController(title: nil,
                                       message: message,
                                       preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "OK",
+        let okAction = UIAlertAction(title: AlertText.okay,
                                      style: .default,
                                      handler: nil)
         alert.addAction(okAction)
@@ -85,11 +85,11 @@ class ViewController: UIViewController {
         let alert = UIAlertController(title: nil,
                                       message: message,
                                       preferredStyle: .alert)
-        let editAction = UIAlertAction(title: "예",
+        let editAction = UIAlertAction(title: AlertText.yes,
                                        style: .default) { (action) in
             self.prsentStockEditView()
         }
-        let cancelAction = UIAlertAction(title: "아니오",
+        let cancelAction = UIAlertAction(title: AlertText.no,
                                          style: .default)
         alert.addAction(editAction)
         alert.addAction(cancelAction)

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -8,7 +8,7 @@ import UIKit
 
 class ViewController: UIViewController {
     
-    var fruitStore: FruitStore = .init(initialStock: 10)
+    var fruitStore: FruitStore = .init(inventory: [.strawberry: 10, .banana:10, .kiwi: 10, .mango: 10])
     lazy var juiceMaker: JuiceMaker = .init(fruitStore: fruitStore)
     
     @IBOutlet weak var strawberryJuiceOrderButton: UIButton!
@@ -23,7 +23,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var pineappleStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         updateFruitStockLabel()
@@ -39,11 +39,16 @@ class ViewController: UIViewController {
         }
         let result: Result<Juice, FruitStoreError> = juiceMaker.make(juice)
         switch result {
-        case .success(let juice):
+        case .success(let madeJuice):
             updateFruitStockLabel()
-            showOkayAlert("\(juice.name) \(AlertText.juiceCompletion)")
+            showOkayAlert("\(madeJuice.name) \(AlertText.juiceCompletion)")
         case .failure(let fruitStoreError):
-            showStockEditAlert("\(fruitStoreError.localizedDescription)")
+            switch fruitStoreError {
+            case .outOfStock:
+                showStockEditAlert(fruitStoreError.localizedDescription)
+            default:
+                showOkayAlert(fruitStoreError.localizedDescription)
+            }
         }
     }
     
@@ -111,18 +116,28 @@ class ViewController: UIViewController {
     func updateFruitStockLabel() {
         if let strawberryStock = try? fruitStore.currentStock(of: .strawberry) {
             strawberryStockLabel.text = "\(strawberryStock)"
+        } else {
+            strawberryStockLabel.text = FruitStoreError.notExist
         }
         if let bananaStock = try? fruitStore.currentStock(of: .banana) {
             bananaStockLabel.text = "\(bananaStock)"
+        } else {
+            bananaStockLabel.text = FruitStoreError.notExist
         }
         if let kiwiStock = try? fruitStore.currentStock(of: .kiwi) {
             kiwiStockLabel.text = "\(kiwiStock)"
+        } else {
+            kiwiStockLabel.text = FruitStoreError.notExist
         }
         if let pineappleStock = try? fruitStore.currentStock(of: .pineapple) {
             pineappleStockLabel.text = "\(pineappleStock)"
+        } else {
+            pineappleStockLabel.text = FruitStoreError.notExist
         }
         if let mangoStock = try? fruitStore.currentStock(of: .mango) {
             mangoStockLabel.text = "\(mangoStock)"
+        } else {
+            mangoStockLabel.text = FruitStoreError.notExist
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -34,32 +34,37 @@ class ViewController: UIViewController {
     }
     
     @IBAction func touchUpJuiceOrderButton(_ sender: UIButton) {
-        let juice: Juice
-        switch sender {
-        case strawberryJuiceOrderButton:
-            juice = .strawberryJuice
-        case bananaJuiceOrderButton:
-            juice = .bananaJuice
-        case kiwiJuiceOrderButton:
-            juice = .kiwiJuice
-        case pineappleJuiceOrderButton:
-            juice = .pineappleJuice
-        case strawberryBananaMixJuiceOrderButton:
-            juice = .strawberryBananaMixJuice
-        case mangoJuiceOrderButton:
-            juice = .mangoJuice
-        case mangoKiwiMixJuiceOrderButton:
-            juice = .mangoKiwiMixJuice
-        default:
+        guard let juice: Juice = juice(orderedBy: sender) else {
             return
         }
-        let result: Result<Juice,FruitStoreError> = juiceMaker.make(juice)
+        let result: Result<Juice, FruitStoreError> = juiceMaker.make(juice)
         switch result {
-        case .success:
+        case .success(let juice):
             updateFruitStockLabel()
             showOkayAlert("\(juice.name) 나왔습니다! 맛있게 드세요!")
-        case .failure:
-            showStockEditAlert("재료가 모자라요. 재고를 수정할까요?")
+        case .failure(let fruitStoreError):
+            showStockEditAlert("\(fruitStoreError.localizedDescription)")
+        }
+    }
+    
+    func juice(orderedBy button: UIButton) -> Juice? {
+        switch button {
+        case strawberryJuiceOrderButton:
+            return .strawberryJuice
+        case bananaJuiceOrderButton:
+            return .bananaJuice
+        case kiwiJuiceOrderButton:
+            return .kiwiJuice
+        case pineappleJuiceOrderButton:
+            return .pineappleJuice
+        case strawberryBananaMixJuiceOrderButton:
+            return .strawberryBananaMixJuice
+        case mangoJuiceOrderButton:
+            return .mangoJuice
+        case mangoKiwiMixJuiceOrderButton:
+            return .mangoKiwiMixJuice
+        default:
+            return nil
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -16,9 +16,15 @@ class ViewController: UIViewController {
     @IBOutlet weak var strawberryBananaMixJuiceOrderButton: UIButton!
     @IBOutlet weak var mangoJuiceOrderButton: UIButton!
     @IBOutlet weak var mangoKiwiMixJuiceOrderButton: UIButton!
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var mangoStockLabel: UILabel!
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        updateFruitStockLabel()
     }
     
     @IBAction func touchUpEditStockButton(_ sender: UIBarButtonItem) {
@@ -48,6 +54,7 @@ class ViewController: UIViewController {
         let result: Result<Juice,FruitStoreError> = juiceMaker.make(juice)
         switch result {
         case .success:
+            updateFruitStockLabel()
             showOKAlert("\(juice.name) 나왔습니다! 맛있게 드세요!")
         case .failure:
             showEditAlert("재료가 모자라요. 재고를 수정할까요?")
@@ -93,5 +100,23 @@ class ViewController: UIViewController {
         self.present(stockEditViewController,
                      animated: true,
                      completion: nil)
+    }
+    
+    func updateFruitStockLabel() {
+        if let strawberryStock = try? juiceMaker.fruitStore.currentStock(of: .strawberry) {
+            strawberryStockLabel.text = "\(strawberryStock)"
+        }
+        if let bananaStock = try? juiceMaker.fruitStore.currentStock(of: .banana) {
+            bananaStockLabel.text = "\(bananaStock)"
+        }
+        if let kiwiStock = try? juiceMaker.fruitStore.currentStock(of: .kiwi) {
+            kiwiStockLabel.text = "\(kiwiStock)"
+        }
+        if let pineappleStock = try? juiceMaker.fruitStore.currentStock(of: .pineapple) {
+            pineappleStockLabel.text = "\(pineappleStock)"
+        }
+        if let mangoStock = try? juiceMaker.fruitStore.currentStock(of: .mango) {
+            mangoStockLabel.text = "\(mangoStock)"
+        }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -7,7 +7,9 @@
 import UIKit
 
 class ViewController: UIViewController {
-    var juiceMaker: JuiceMaker = .init(fruitStore: .init(initialStock: 10))
+    
+    var fruitStore: FruitStore = .init(initialStock: 10)
+    lazy var juiceMaker: JuiceMaker = .init(fruitStore: fruitStore)
     
     @IBOutlet weak var strawberryJuiceOrderButton: UIButton!
     @IBOutlet weak var bananaJuiceOrderButton: UIButton!
@@ -103,19 +105,19 @@ class ViewController: UIViewController {
     }
     
     func updateFruitStockLabel() {
-        if let strawberryStock = try? juiceMaker.fruitStore.currentStock(of: .strawberry) {
+        if let strawberryStock = try? fruitStore.currentStock(of: .strawberry) {
             strawberryStockLabel.text = "\(strawberryStock)"
         }
-        if let bananaStock = try? juiceMaker.fruitStore.currentStock(of: .banana) {
+        if let bananaStock = try? fruitStore.currentStock(of: .banana) {
             bananaStockLabel.text = "\(bananaStock)"
         }
-        if let kiwiStock = try? juiceMaker.fruitStore.currentStock(of: .kiwi) {
+        if let kiwiStock = try? fruitStore.currentStock(of: .kiwi) {
             kiwiStockLabel.text = "\(kiwiStock)"
         }
-        if let pineappleStock = try? juiceMaker.fruitStore.currentStock(of: .pineapple) {
+        if let pineappleStock = try? fruitStore.currentStock(of: .pineapple) {
             pineappleStockLabel.text = "\(pineappleStock)"
         }
-        if let mangoStock = try? juiceMaker.fruitStore.currentStock(of: .mango) {
+        if let mangoStock = try? fruitStore.currentStock(of: .mango) {
             mangoStockLabel.text = "\(mangoStock)"
         }
     }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -10,8 +10,18 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
     }
-
-
+    
+    func showOKAlert(_ message: String) {
+        let alert = UIAlertController(title: nil,
+                                      message: message,
+                                      preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "OK",
+                                     style: .default,
+                                     handler: nil)
+        alert.addAction(okAction)
+        present(alert,
+                animated: true,
+                completion: nil)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -21,6 +21,10 @@ class ViewController: UIViewController {
         super.viewDidLoad()
     }
     
+    @IBAction func touchUpEditStockButton(_ sender: UIBarButtonItem) {
+        prsentStockEditView()
+    }
+    
     @IBAction func touchUpJuiceOrderButton(_ sender: UIButton) {
         let juice: Juice
         switch sender {
@@ -68,7 +72,9 @@ class ViewController: UIViewController {
                                       message: message,
                                       preferredStyle: .alert)
         let editAction = UIAlertAction(title: "예",
-                                       style: .default)
+                                       style: .default) { (action) in
+            self.prsentStockEditView()
+        }
         let cancelAction = UIAlertAction(title: "아니오",
                                          style: .default)
         alert.addAction(editAction)
@@ -76,5 +82,16 @@ class ViewController: UIViewController {
         present(alert,
                 animated: true,
                 completion: nil)
+    }
+    
+    func prsentStockEditView() {
+        guard let stockEditViewController = self.storyboard?.instantiateViewController(withIdentifier: "StockEditViewController") as? StockEditViewController else {
+            return
+        }
+        stockEditViewController.modalTransitionStyle = .coverVertical
+        stockEditViewController.modalPresentationStyle = .fullScreen
+        self.present(stockEditViewController,
+                     animated: true,
+                     completion: nil)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -24,4 +24,19 @@ class ViewController: UIViewController {
                 animated: true,
                 completion: nil)
     }
+    
+    func showEditAlert(_ message: String) {
+        let alert = UIAlertController(title: nil,
+                                      message: message,
+                                      preferredStyle: .alert)
+        let editAction = UIAlertAction(title: "예",
+                                       style: .default)
+        let cancelAction = UIAlertAction(title: "아니오",
+                                         style: .default)
+        alert.addAction(editAction)
+        alert.addAction(cancelAction)
+        present(alert,
+                animated: true,
+                completion: nil)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -55,13 +55,13 @@ class ViewController: UIViewController {
         switch result {
         case .success:
             updateFruitStockLabel()
-            showOKAlert("\(juice.name) 나왔습니다! 맛있게 드세요!")
+            showOkayAlert("\(juice.name) 나왔습니다! 맛있게 드세요!")
         case .failure:
-            showEditAlert("재료가 모자라요. 재고를 수정할까요?")
+            showStockEditAlert("재료가 모자라요. 재고를 수정할까요?")
         }
     }
     
-    func showOKAlert(_ message: String) {
+    func showOkayAlert(_ message: String) {
         let alert = UIAlertController(title: nil,
                                       message: message,
                                       preferredStyle: .alert)
@@ -74,7 +74,7 @@ class ViewController: UIViewController {
                 completion: nil)
     }
     
-    func showEditAlert(_ message: String) {
+    func showStockEditAlert(_ message: String) {
         let alert = UIAlertController(title: nil,
                                       message: message,
                                       preferredStyle: .alert)

--- a/JuiceMaker/JuiceMaker/Model/AlertText.swift
+++ b/JuiceMaker/JuiceMaker/Model/AlertText.swift
@@ -1,0 +1,13 @@
+//
+//  AlertText.swift
+//  JuiceMaker
+//
+//  Created by Gundy, 준호
+//
+
+enum AlertText {
+    static let okay: String = "OK"
+    static let yes: String = "예"
+    static let no: String = "아니오"
+    static let juiceCompletion: String = "나왔습니다! 맛있게 드세요!"
+}

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -49,7 +49,7 @@ class FruitStore {
     }
     
     private func checkInventoryHasStock(of fruit: Fruit, moreThan amount: Int) throws {
-        let currentStock = try getCurrentStock(of: fruit)
+        let currentStock = try currentStock(of: fruit)
         guard currentStock >= amount else {
             throw FruitStoreError.outOfStock
         }
@@ -62,7 +62,7 @@ class FruitStore {
         return true
     }
     
-    func getCurrentStock(of fruit: Fruit) throws -> Int {
+    func currentStock(of fruit: Fruit) throws -> Int {
         guard let currentStock = inventory[fruit] else {
             throw FruitStoreError.notInInventoryFruitList
         }

--- a/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
@@ -11,6 +11,7 @@ enum FruitStoreError: Error {
     case outOfStock
     case unexpectedError
     
+    static let notExist: String = "X"
     var localizedDescription: String {
         switch self {
         case .invalidAmount:

--- a/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
@@ -11,14 +11,14 @@ enum FruitStoreError: Error {
     case outOfStock
     case unexpectedError
     
-    var failureReason: String {
+    var localizedDescription: String {
         switch self {
         case .invalidAmount:
             return "잘못된 수량입니다."
         case .notInInventoryFruitList:
             return "창고 내부 목록에 없는 과일입니다."
         case .outOfStock:
-            return "재고가 부족합니다."
+            return "재료가 모자라요. 재고를 수정할까요?"
         case .unexpectedError:
             return "예상하지 못한 에러입니다."
         }

--- a/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
@@ -9,6 +9,7 @@ enum FruitStoreError: Error {
     case invalidAmount
     case notInInventoryFruitList
     case outOfStock
+    case unexpectedError
     
     var failureReason: String {
         switch self {
@@ -18,6 +19,8 @@ enum FruitStoreError: Error {
             return "창고 내부 목록에 없는 과일입니다."
         case .outOfStock:
             return "재고가 부족합니다."
+        case .unexpectedError:
+            return "예상하지 못한 에러입니다."
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -19,6 +19,25 @@ enum Juice {
         let amount: Int
     }
     
+    var name: String {
+        switch self {
+        case .strawberryJuice:
+            return "딸기쥬스"
+        case .bananaJuice:
+            return "바나나쥬스"
+        case .kiwiJuice:
+            return "키위쥬스"
+        case .pineappleJuice:
+            return "파인애플쥬스"
+        case .strawberryBananaMixJuice:
+            return "딸바쥬스"
+        case .mangoJuice:
+            return "망고쥬스"
+        case .mangoKiwiMixJuice:
+            return "망키쥬스"
+        }
+    }
+    
     var recipe: [Ingredient] {
         switch self {
         case .strawberryJuice:

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 struct JuiceMaker {
-    private let fruitStore: FruitStore
+    let fruitStore: FruitStore
     
     init(fruitStore: FruitStore) {
         self.fruitStore = fruitStore

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -4,6 +4,8 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
+import Foundation
+
 struct JuiceMaker {
     private let fruitStore: FruitStore
     
@@ -11,18 +13,21 @@ struct JuiceMaker {
         self.fruitStore = fruitStore
     }
     
-    func make(_ juice: Juice) {
+    func make(_ juice: Juice) -> Result<Juice, FruitStoreError> {
         do {
             try fruitStore.checkStockOfIngredients(in: juice.recipe)
             for ingredient in juice.recipe {
                 fruitStore.changeStock(of: ingredient.fruit, by: -ingredient.amount)
             }
         } catch FruitStoreError.notInInventoryFruitList {
-            print(FruitStoreError.notInInventoryFruitList.failureReason)
+            return .failure(.notInInventoryFruitList)
         } catch FruitStoreError.outOfStock {
-            print(FruitStoreError.outOfStock.failureReason)
+            return .failure(.outOfStock)
+        } catch FruitStoreError.invalidAmount {
+            return .failure(.invalidAmount)
         } catch {
-            print(error)
+            return .failure(.unexpectedError)
         }
+        return .success(juice)
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 struct JuiceMaker {
-    let fruitStore: FruitStore
+    private let fruitStore: FruitStore
     
     init(fruitStore: FruitStore) {
         self.fruitStore = fruitStore

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -23,8 +23,6 @@ struct JuiceMaker {
             return .failure(.notInInventoryFruitList)
         } catch FruitStoreError.outOfStock {
             return .failure(.outOfStock)
-        } catch FruitStoreError.invalidAmount {
-            return .failure(.invalidAmount)
         } catch {
             return .failure(.unexpectedError)
         }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -215,7 +215,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
+                            <connections>
+                                <segue destination="WwV-Td-3Bn" kind="presentation" modalPresentationStyle="fullScreen" modalTransitionStyle="coverVertical" id="kdZ-eI-pIU"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -240,10 +244,10 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--View Controller-->
+        <!--Stock Edit View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" sceneMemberID="viewController">
+                <viewController id="Yu1-lM-nqp" customClass="StockEditViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -343,6 +347,15 @@
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cpR-nc-oU7">
+                                <rect key="frame" x="722" y="34" width="61" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="나가기"/>
+                                <connections>
+                                    <action selector="touchUpDismissButton:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="G9z-vc-rYR"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="WwV-Td-3Bn" kind="presentation" modalPresentationStyle="fullScreen" modalTransitionStyle="coverVertical" id="kdZ-eI-pIU"/>
+                                <action selector="touchUpEditStockButton:" destination="BYZ-38-t0r" id="XVO-mb-Un3"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -277,7 +277,7 @@
         <!--Stock Edit View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" customClass="StockEditViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="StockEditViewController" id="Yu1-lM-nqp" customClass="StockEditViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -126,6 +126,9 @@
                                                 <state key="normal" title="딸바쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gso-t2-UAy"/>
+                                                </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
                                                 <rect key="frame" x="296" y="0.0" width="132" height="66"/>
@@ -138,6 +141,9 @@
                                                 <state key="normal" title="망키쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gcM-kL-12I"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -154,6 +160,9 @@
                                                         <state key="normal" title="딸기쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="touchUpJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Chi-9N-1Ka"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
@@ -162,6 +171,9 @@
                                                         <state key="normal" title="바나나쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="touchUpJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ctl-hp-nc8"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
@@ -170,6 +182,9 @@
                                                         <state key="normal" title="파인애플쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="touchUpJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QWy-b8-iLH"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
@@ -178,6 +193,9 @@
                                                         <state key="normal" title="키위쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="touchUpJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="sFa-6m-xWM"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
@@ -186,6 +204,9 @@
                                                         <state key="normal" title="망고쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="touchUpJuiceOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rJv-tO-75W"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                             </stackView>
@@ -221,6 +242,15 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="bananaJuiceOrderButton" destination="y2A-PH-DJY" id="uHS-td-Tos"/>
+                        <outlet property="kiwiJuiceOrderButton" destination="wcW-7H-RXw" id="cUB-rA-Wxy"/>
+                        <outlet property="mangoJuiceOrderButton" destination="q6G-4X-bVm" id="QLJ-Y9-dXE"/>
+                        <outlet property="mangoKiwiMixJuiceOrderButton" destination="ngP-kF-Yii" id="mld-QX-cSS"/>
+                        <outlet property="pineappleJuiceOrderButton" destination="BFb-ka-wGA" id="cVe-oh-1nv"/>
+                        <outlet property="strawberryBananaMixJuiceOrderButton" destination="hrc-2F-fzl" id="Swk-6f-HTe"/>
+                        <outlet property="strawberryJuiceOrderButton" destination="avd-o5-3JM" id="60X-Ze-EoR"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -244,12 +244,17 @@
                     </navigationItem>
                     <connections>
                         <outlet property="bananaJuiceOrderButton" destination="y2A-PH-DJY" id="uHS-td-Tos"/>
+                        <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="Nzr-AX-DwG"/>
                         <outlet property="kiwiJuiceOrderButton" destination="wcW-7H-RXw" id="cUB-rA-Wxy"/>
+                        <outlet property="kiwiStockLabel" destination="FZq-de-TJG" id="UEu-wC-HvV"/>
                         <outlet property="mangoJuiceOrderButton" destination="q6G-4X-bVm" id="QLJ-Y9-dXE"/>
                         <outlet property="mangoKiwiMixJuiceOrderButton" destination="ngP-kF-Yii" id="mld-QX-cSS"/>
+                        <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="A70-pS-wdZ"/>
                         <outlet property="pineappleJuiceOrderButton" destination="BFb-ka-wGA" id="cVe-oh-1nv"/>
+                        <outlet property="pineappleStockLabel" destination="ccQ-Dk-PuY" id="I1C-9T-gcx"/>
                         <outlet property="strawberryBananaMixJuiceOrderButton" destination="hrc-2F-fzl" id="Swk-6f-HTe"/>
                         <outlet property="strawberryJuiceOrderButton" destination="avd-o5-3JM" id="60X-Ze-EoR"/>
+                        <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="j80-we-Cr8"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -378,10 +383,10 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cpR-nc-oU7">
-                                <rect key="frame" x="722" y="34" width="61" height="31"/>
+                                <rect key="frame" x="728" y="34" width="49" height="31"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="나가기"/>
+                                <buttonConfiguration key="configuration" style="plain" title="닫기"/>
                                 <connections>
                                     <action selector="touchUpDismissButton:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="G9z-vc-rYR"/>
                                 </connections>


### PR DESCRIPTION
@junbangg
안녕하세요 알라딘!🏜
두 번째 PR도 잘 부탁드립니다.
약간 두서없이 적은 내용도 있지만...우리의 프린스 알리는 지니처럼 찰떡같이 알아들을 것이라고 믿습니다! 감사해요!!🙌

#### 함수별 기능
- `showOkayAlert`: 쥬스가 완성되었을 때 호출할 얼럿을 띄우는 메서드
- `showStockEditAlert`: 주문받은 쥬스를 만들 과일의 재고가 부족할 때, 재고 수정 페이지로 넘어갈 것인지 선택을 받는 얼럿을 띄우는 메서드
- `touchUpJuiceOrderButton`: 각 쥬스별로 주문 버튼을 터치했을 때 쥬스를 만들게 하는 메서드
- `presentStockEditView`: 재고 수정 뷰로 화면전환을 하는 메서드
- `touchUpDismissButton`: 닫기 버튼을 누르면 재고수정 뷰에서 빠져나오게 하는 메서드
- `updateFruitStockLabel`: 과일의 재고 데이터를 뷰의 레이블에 업데이트하는 메서드

### 코드를 작성할 때 고민되었던 점
- FruitStoreError를 캐치해 print하던 `make` 메서드를 이용해 쥬스를 만드려다보니, 반환 값이 필요해졌습니다. 그 반환에 따라 어느 얼럿을 띄울 것인지를 선택해야 했기 때문입니다. 기존에 `make` 메서드를 작성할 때도 오류처리를 한 것은 나름의 이유가 있었기 때문에 이 상황을 쉽게 해결하려고 오류처리를 없앨 수는 없었습니다. 그 결과 반환 타입을 `Result` 타입으로 선택해 적절한 얼럿을 호출하게 하였습니다.
- 이번 스텝의 구현 사항에는 재고수정 뷰로 화면전환까지만 구현할 뿐, 그 화면에서 빠져나오는 기능을 요구하지 않습니다. 하지만 테스트 과정이나 리뷰의 편의를 생각해 닫기 버튼을 구현하는 게 옳다고 생각하였습니다. 다음 스텝에서 요구하는 버튼과는 달라졌지만, 수정을 할 생각으로 만들었습니다.

### 조언을 얻고 싶은 부분
- 얼럿에 들어갈 메시지를 문자열로 전달할 때나 얼럿 액션의 title 같은 경우는 현재 매직리터럴로 보입니다. 모든 경우에서 매직리터럴은 배열 등으로 따로 타입을 정의해서 처리해 주는 것이 좋을까요?

- `updateFruitStockLabel` 메서드를 작성하면서, 새로 오류 처리 없이 과일의 재고를 반환하는 메서드를 생성하기보다는 기존에 구현했던 메서드인 `currentStock`을 호출해 사용하기로 결정하였습니다. 다만 `currentStock` 메서드는 원래 `checkInventoryHasStock` 메서드에서 현재 창고 품목에 있는지 확인하고 수량을 가져오는 용도로 호출해 사용하고 있었는데, `checkInventoryHasStock` 메서드와 `currentStock`메서드를 분리하는 것이 더 좋았을까요? `updateFruitStockLabel` 메서드에서는 던져진 오류에 적절한 처리를 해주지 않기 때문에 이런 고민이 들었습니다.
- if let 문에 else 블록을 추가해서 에러가 발생한 경우를 추가하는 게 좋을까요?
~~~swift
    func updateFruitStockLabel() {
        if let strawberryStock = try? juiceMaker.fruitStore.currentStock(of: .strawberry) {
            strawberryStockLabel.text = "\(strawberryStock)"
        }
        if let bananaStock = try? juiceMaker.fruitStore.currentStock(of: .banana) {
            bananaStockLabel.text = "\(bananaStock)"
        }
        if let kiwiStock = try? juiceMaker.fruitStore.currentStock(of: .kiwi) {
            kiwiStockLabel.text = "\(kiwiStock)"
        }
        if let pineappleStock = try? juiceMaker.fruitStore.currentStock(of: .pineapple) {
            pineappleStockLabel.text = "\(pineappleStock)"
        }
        if let mangoStock = try? juiceMaker.fruitStore.currentStock(of: .mango) {
            mangoStockLabel.text = "\(mangoStock)"
        }
    }
~~~

- fruitStore 상수를 만든 뒤에 JuiceMaker 이니셜라이저에 만든 fruitStore를 전달해서 저장 프로퍼티에 할당하려고 했는 데 아래와 같은 에러가 발생했습니다.
- 아래 사용한 방법처럼 이니셜라이저에서 바로 FruitStore의 인스턴스를 만들어서 전달하니 에러는 발생하지 않았습니다.
- 왜 두 가지 방법의 결과가 다른 지 궁금합니다.

- 알아보니 ViewController의 인스턴스가 만들어 지기 전에는 self의 프로퍼티에 접근할 수 없어, fruitStore 프로퍼티를 사용할 수 없기 때문에 juiceMaker의 기본값을 초기화 할 때 fruitStore 프로퍼티를 사용할 수 없었습니다. lazy를 붙여 지연 저장 프로퍼티로 하면 사용할 때 초기화가 되기 때문에 fruitStore 프로퍼티를 사용할 수 있습니다. 메서드는 프로퍼티와 달리 인스턴스 생성 후에 사용되는 것이므로 self의 프로퍼티에 대한 접근이 가능했습니다. 뷰 컨트롤러의 인스턴스를 이니셜라이저를 통해 만들어주면 Lazy 키워드 없이도 지금처럼 juiceMaker와 fruitStore를 사용가능한지 궁금합니다.
- ViewController의 인스턴스화는 어디서 어떻게 되는지도 궁금합니다.
~~~swift
    // 시도했던 방법 - 실패
    let fruitStore: FruitStore = FruitStore(initialStock: 10)
    var juiceMaker: JuiceMaker = .init(fruitStore: fruitStore) 
    // Cannot use instance member 'fruitStore' within property initializer; property initializers run before 'self' is available
    
    /*
    struct JuiceMaker {
    let fruitStore: FruitStore
    
    init(fruitStore: FruitStore) {
      self.fruitStore = fruitStore
    }
    */

    // 사용한 방법
    var juiceMaker: JuiceMaker = .init(fruitStore: .init(initialStock: 10))

    // 수정한 방법
    var fruitStore: FruitStore = .init(initialStock: 10)
    lazy var juiceMaker: JuiceMaker = .init(fruitStore: fruitStore)
~~~

- 쥬스 제조 후 완성 메시지를 출력하는 showOkayAlert 메서드와 재고가 부족하다는 메시지를 출력하는 showStockEditAlert 메서드를 만들었습니다.
- showOkayAlert 메서드는 출력 메시지를 다르게하면 재사용이 가능해서 showOkayAlert로 네이밍을 했습니다.
- showStockEditAlert 메서드는 재고가 부족하다는 메시지를 출력한 뒤 사용자가 예/아니오 중 무엇을 선택하는 지에 따라 재고수정화면으로 이동하거나 얼럿이 닫힙니다. 특정 행위(재고수정화면으로 이동)가 바로 이어서 발생할 수 있기 때문에 ShowStockEditAlert로 네이밍을 했습니다.
- 네이밍이 적절한 지 궁금합니다.
~~~swift
    func showOkayAlert(_ message: String) {
        let alert = UIAlertController(title: nil,
                                      message: message,
                                      preferredStyle: .alert)
        let okAction = UIAlertAction(title: "OK",
                                     style: .default,
                                     handler: nil)
        alert.addAction(okAction)
        present(alert,
                animated: true,
                completion: nil)
    }
    
    func showStockEditAlert(_ message: String) {
        let alert = UIAlertController(title: nil,
                                      message: message,
                                      preferredStyle: .alert)
        let editAction = UIAlertAction(title: "예",
                                       style: .default) { (action) in
            self.prsentStockEditView()
        }
        let cancelAction = UIAlertAction(title: "아니오",
                                         style: .default)
        alert.addAction(editAction)
        alert.addAction(cancelAction)
        present(alert,
                animated: true,
                completion: nil)
    }
~~~

- viewController의 메서드는 은닉화를 어떻게 하면 좋을 지 궁금합니다.과연 뷰 컨트롤러에서는 은닉화가 의미가 있는가? 이니셜라이저가 없는데 뷰 인스턴스는 생성이 되는가? 하는 생각이 들었습니다. 이에 조언을 구하고 싶습니다.