### PR TITLE
쥬스 메이커 [STEP 2] inho, 토털이

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -327,12 +327,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = R4D3JSH53Q;
 				INFOPLIST_FILE = JuiceMaker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.JuiceMaker;
+				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.JuiceMaker.inho;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -345,12 +346,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = R4D3JSH53Q;
 				INFOPLIST_FILE = JuiceMaker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.JuiceMaker;
+				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.JuiceMaker.inho;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
+		C73DAF3B255D0CDD00020D38 /* JuiceMakerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */; };
 		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
@@ -28,7 +28,7 @@
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C73DAF3A255D0CDD00020D38 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMakerViewController.swift; sourceTree = "<group>"; };
 		C73DAF3D255D0CDD00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -52,7 +52,7 @@
 			children = (
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
-				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */,
 				3C71E63B28C6D73900C4C6DF /* StockEditViewController.swift */,
 			);
 			path = Controller;
@@ -180,7 +180,7 @@
 				3C71E63C28C6D73900C4C6DF /* StockEditViewController.swift in Sources */,
 				3CA262AE28BDD96A00A10C26 /* JuiceMakerError.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				C73DAF3B255D0CDD00020D38 /* JuiceMakerViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C71E63C28C6D73900C4C6DF /* StockEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C71E63B28C6D73900C4C6DF /* StockEditViewController.swift */; };
 		3CA262AE28BDD96A00A10C26 /* JuiceMakerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA262AD28BDD96A00A10C26 /* JuiceMakerError.swift */; };
 		B2E7C8FF28BDC9A100A75058 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E7C8FE28BDC9A100A75058 /* Fruit.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
@@ -20,6 +21,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3C71E63B28C6D73900C4C6DF /* StockEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockEditViewController.swift; sourceTree = "<group>"; };
 		3CA262AD28BDD96A00A10C26 /* JuiceMakerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMakerError.swift; sourceTree = "<group>"; };
 		B2E7C8FE28BDC9A100A75058 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
@@ -51,6 +53,7 @@
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				3C71E63B28C6D73900C4C6DF /* StockEditViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -174,6 +177,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B2E7C8FF28BDC9A100A75058 /* Fruit.swift in Sources */,
+				3C71E63C28C6D73900C4C6DF /* StockEditViewController.swift in Sources */,
 				3CA262AE28BDD96A00A10C26 /* JuiceMakerError.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
@@ -327,6 +331,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = JuiceMaker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -345,6 +350,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = JuiceMaker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -1,12 +1,12 @@
 //
-//  JuiceMaker - ViewController.swift
+//  JuiceMaker - JuiceMakerViewController.swift
 //  Created by yagom. 
 //  Copyright © yagom academy. All rights reserved.
 // 
 
 import UIKit
 
-class ViewController: UIViewController {
+class JuiceMakerViewController: UIViewController {
 
     private let juiceMaker: JuiceMaker = JuiceMaker()
     @IBOutlet weak var strawberryStockLabel: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -11,6 +11,8 @@ class StockEditViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        navigationController?.navigationBar.backgroundColor = .systemGray5
     }
 
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -1,0 +1,16 @@
+//
+//  StockEditViewController.swift
+//  JuiceMaker
+//
+//  Created by jin on 9/6/22.
+//
+
+import UIKit
+
+class StockEditViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+}

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -49,7 +49,7 @@ class ViewController: UIViewController {
         if let orderedJuice = JuiceMaker.Juice(rawValue: sender.tag) {
             do {
                 try juiceMaker.produce(juice: orderedJuice)
-                showOrderedAlert(juice: orderedJuice)
+                showOrderSucceedAlert(juice: orderedJuice)
             } catch JuiceMakerError.outOfStock {
                 showOrderFailedAlert()
             } catch {
@@ -78,7 +78,7 @@ class ViewController: UIViewController {
         }
     }
     
-    private func showOrderedAlert(juice: JuiceMaker.Juice) {
+    private func showOrderSucceedAlert(juice: JuiceMaker.Juice) {
         let message = fetchOrderedAlertMessage(juice: juice)
         let alert = UIAlertController(title: nil,
                                       message: message,

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -8,7 +8,7 @@ import UIKit
 
 class ViewController: UIViewController {
 
-    let juiceMaker: JuiceMaker = JuiceMaker()
+    private let juiceMaker: JuiceMaker = JuiceMaker()
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
     @IBOutlet weak var pineappleStockLabel: UILabel!
@@ -22,13 +22,13 @@ class ViewController: UIViewController {
         updateAllStockLabels()
     }
     
-    func updateAllStockLabels() {
+    private func updateAllStockLabels() {
         Fruit.allCases.forEach({ fruit in
             updateStockLabel(of: fruit)
         })
     }
     
-    func updateStockLabel(of fruit: Fruit) {
+    private func updateStockLabel(of fruit: Fruit) {
         guard let fruitStock = try? juiceMaker.fetchStock(of: fruit) else { return }
         
         switch fruit {
@@ -59,7 +59,7 @@ class ViewController: UIViewController {
         updateAllStockLabels()
     }
     
-    func fetchOrderedAlertMessage(juice: JuiceMaker.Juice) -> String {
+    private func fetchOrderedAlertMessage(juice: JuiceMaker.Juice) -> String {
         switch juice {
         case .strawberryJuice:
             return "딸기쥬스 나왔습니다! 맛있게 드세요!"
@@ -78,7 +78,7 @@ class ViewController: UIViewController {
         }
     }
     
-    func showOrderedAlert(juice: JuiceMaker.Juice) {
+    private func showOrderedAlert(juice: JuiceMaker.Juice) {
         let message = fetchOrderedAlertMessage(juice: juice)
         let alert = UIAlertController(title: nil,
                                       message: message,
@@ -90,7 +90,7 @@ class ViewController: UIViewController {
         present(alert, animated: true)
     }
     
-    func showOrderFailedAlert() {
+    private func showOrderFailedAlert() {
         let message = "재료가 모자라요. 재고를 수정할까요?"
         let alert = UIAlertController(title: nil,
                                       message: message,
@@ -107,7 +107,7 @@ class ViewController: UIViewController {
         present(alert, animated: true)
     }
     
-    func presentStockEditViewController() {
+    private func presentStockEditViewController() {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let stockEditVC = storyboard.instantiateViewController(identifier: "stockEditNavigation")
         

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -8,6 +8,13 @@ import UIKit
 
 class ViewController: UIViewController {
 
+    var juiceMaker: JuiceMaker = JuiceMaker()
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var mangoStockLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -49,7 +49,7 @@ class ViewController: UIViewController {
         if let orderedJuice = JuiceMaker.Juice(rawValue: sender.tag) {
             do {
                 try juiceMaker.produce(juice: orderedJuice)
-                showOrderedAlert(juice: orderedJuice)
+                showOrderSuccessedAlert(juice: orderedJuice)
             } catch JuiceMakerError.outOfStock {
                 showOrderFailedAlert()
             } catch {
@@ -78,7 +78,7 @@ class ViewController: UIViewController {
         }
     }
     
-    private func showOrderedAlert(juice: JuiceMaker.Juice) {
+    private func showOrderSucceedAlert(juice: JuiceMaker.Juice) {
         let message = fetchOrderedAlertMessage(juice: juice)
         let alert = UIAlertController(title: nil,
                                       message: message,

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -56,8 +56,16 @@ class ViewController: UIViewController {
     
     @IBAction func touchUpOrderButton(_ sender: UIButton) {
         if let orderedJuice = JuiceMaker.Juice(rawValue: sender.tag) {
-            juiceMaker.produce(juice: orderedJuice)
+            do {
+                try juiceMaker.produce(juice: orderedJuice)
+                showOrderedAlert(juice: orderedJuice)
+            } catch JuiceMakerError.outOfStock {
+                showOrderFailedAlert()
+            } catch {
+                print("unexpected error: \(error)")
+            }
         }
+        updateStockLabel()
     }
     
     func fetchOrderedAlertMessage(juice: JuiceMaker.Juice) -> String {

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -50,13 +50,15 @@ class ViewController: UIViewController {
             do {
                 try juiceMaker.produce(juice: orderedJuice)
                 showOrderSucceedAlert(juice: orderedJuice)
+                orderedJuice.recipe.ingredient.keys.forEach({ fruit in
+                    updateStockLabel(of: fruit)
+                })
             } catch JuiceMakerError.outOfStock {
                 showOrderFailedAlert()
             } catch {
                 print("unexpected error: \(error)")
             }
         }
-        updateAllStockLabels()
     }
     
     private func showOrderSucceedAlert(juice: JuiceMaker.Juice) {

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -59,27 +59,8 @@ class ViewController: UIViewController {
         updateAllStockLabels()
     }
     
-    private func fetchOrderedAlertMessage(juice: JuiceMaker.Juice) -> String {
-        switch juice {
-        case .strawberryJuice:
-            return "딸기쥬스 나왔습니다! 맛있게 드세요!"
-        case .bananaJuice:
-            return "바나나쥬스 나왔습니다! 맛있게 드세요!"
-        case .kiwiJuice:
-            return "키위쥬스 나왔습니다! 맛있게 드세요!"
-        case .mangoJuice:
-            return "망고쥬스 나왔습니다! 맛있게 드세요!"
-        case .mangoKiwiJuice:
-            return "망키쥬스 나왔습니다! 맛있게 드세요!"
-        case .pineappleJuice:
-            return "파인애플쥬스 나왔습니다! 맛있게 드세요!"
-        case .strawberryBananaJuice:
-            return "딸바쥬스 나왔습니다! 맛있게 드세요!"
-        }
-    }
-    
     private func showOrderSucceedAlert(juice: JuiceMaker.Juice) {
-        let message = fetchOrderedAlertMessage(juice: juice)
+        let message = juice.orderSucceedMessage
         let alert = UIAlertController(title: nil,
                                       message: message,
                                       preferredStyle: .alert)

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -78,5 +78,17 @@ class ViewController: UIViewController {
             return "딸바쥬스 나왔습니다! 맛있게 드세요!"
         }
     }
+    
+    func showOrderedAlert(juice: JuiceMaker.Juice) {
+        let message = fetchOrderedAlertMessage(juice: juice)
+        let alert = UIAlertController(title: nil,
+                                      message: message,
+                                      preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "예",
+                                     style: .default)
+        
+        alert.addAction(okAction)
+        present(alert, animated: true)
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -54,7 +54,7 @@ class ViewController: UIViewController {
                     updateStockLabel(of: fruit)
                 })
             } catch JuiceMakerError.outOfStock {
-                showOrderFailedAlert()
+                showOrderFailedAlert(juice: orderedJuice)
             } catch {
                 print("unexpected error: \(error)")
             }
@@ -73,8 +73,8 @@ class ViewController: UIViewController {
         present(alert, animated: true)
     }
     
-    private func showOrderFailedAlert() {
-        let message = "재료가 모자라요. 재고를 수정할까요?"
+    private func showOrderFailedAlert(juice: JuiceMaker.Juice) {
+        let message = juice.orderFailedMessage
         let alert = UIAlertController(title: nil,
                                       message: message,
                                       preferredStyle: .alert)

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -95,13 +95,24 @@ class ViewController: UIViewController {
                                       message: message,
                                       preferredStyle: .alert)
         let okAction = UIAlertAction(title: "예",
-                                     style: .default)
+                                     style: .default) { action in
+            self.presentStockEditViewController()
+        }
         let cancelAction = UIAlertAction(title: "아니요",
                                          style: .default)
         
         alert.addAction(okAction)
         alert.addAction(cancelAction)
         present(alert, animated: true)
+    }
+    
+    func presentStockEditViewController() {
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        let stockEditVC = storyboard.instantiateViewController(identifier: "stockEditNavigation")
+        
+        stockEditVC.modalPresentationStyle = .fullScreen
+        
+        present(stockEditVC, animated: true, completion: nil)
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -114,5 +114,9 @@ class ViewController: UIViewController {
         
         present(stockEditVC, animated: true, completion: nil)
     }
+    
+    @IBAction func stockEditButtonPressed() {
+        presentStockEditViewController()
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -45,7 +45,7 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func touchUpOrderButton(_ sender: UIButton) {
+    @IBAction func juiceOrderButtonPressed(_ sender: UIButton) {
         if let orderedJuice = JuiceMaker.Juice(rawValue: sender.tag) {
             do {
                 try juiceMaker.produce(juice: orderedJuice)

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -17,41 +17,31 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        updateStockLabel()
-        // Do any additional setup after loading the view.
+        
+        updateAllStockLabels()
     }
     
-    func updateStockLabel() {
-        updateStrawberryStockLabel()
-        updateBananaStockLabel()
-        updatePineappleStockLabel()
-        updateKiwiStockLabel()
-        updateMangoStockLabel()
-    }
-
-    func updateStrawberryStockLabel() {
-        let strawberryStock = try! juiceMaker.fetchStock(of: .strawberry)
-        strawberryStockLabel.text = String(strawberryStock)
+    func updateAllStockLabels() {
+        Fruit.allCases.forEach({ fruit in
+            updateStockLabel(of: fruit)
+        })
     }
     
-    func updateBananaStockLabel() {
-        let bananaStock = try! juiceMaker.fetchStock(of: .banana)
-        bananaStockLabel.text = String(bananaStock)
-    }
-    
-    func updatePineappleStockLabel() {
-        let pineappleStock = try! juiceMaker.fetchStock(of: .pineapple)
-        pineappleStockLabel.text = String(pineappleStock)
-    }
-    
-    func updateKiwiStockLabel() {
-        let kiwiStock = try! juiceMaker.fetchStock(of: .kiwi)
-        kiwiStockLabel.text = String(kiwiStock)
-    }
-    
-    func updateMangoStockLabel() {
-        let mangoStock = try! juiceMaker.fetchStock(of: .mango)
-        mangoStockLabel.text = String(mangoStock)
+    func updateStockLabel(of fruit: Fruit) {
+        guard let fruitStock = try? juiceMaker.fetchStock(of: fruit) else { return }
+        
+        switch fruit {
+        case .strawberry:
+            strawberryStockLabel.text = String(fruitStock)
+        case .banana:
+            bananaStockLabel.text = String(fruitStock)
+        case .pineapple:
+            pineappleStockLabel.text = String(fruitStock)
+        case .kiwi:
+            kiwiStockLabel.text = String(fruitStock)
+        case .mango:
+            mangoStockLabel.text = String(fruitStock)
+        }
     }
     
     @IBAction func touchUpOrderButton(_ sender: UIButton) {
@@ -65,7 +55,7 @@ class ViewController: UIViewController {
                 print("unexpected error: \(error)")
             }
         }
-        updateStockLabel()
+        updateAllStockLabels()
     }
     
     func fetchOrderedAlertMessage(juice: JuiceMaker.Juice) -> String {

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -53,5 +53,11 @@ class ViewController: UIViewController {
         let mangoStock = try! juiceMaker.fetchStock(of: .mango)
         mangoStockLabel.text = String(mangoStock)
     }
+    
+    @IBAction func touchUpOrderButton(_ sender: UIButton) {
+        if let orderedJuice = JuiceMaker.Juice(rawValue: sender.tag) {
+            juiceMaker.produce(juice: orderedJuice)
+        }
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -90,5 +90,20 @@ class ViewController: UIViewController {
         alert.addAction(okAction)
         present(alert, animated: true)
     }
+    
+    func showOrderFailedAlert() {
+        let message = "재료가 모자라요. 재고를 수정할까요?"
+        let alert = UIAlertController(title: nil,
+                                      message: message,
+                                      preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "예",
+                                     style: .default)
+        let cancelAction = UIAlertAction(title: "아니요",
+                                         style: .default)
+        
+        alert.addAction(okAction)
+        alert.addAction(cancelAction)
+        present(alert, animated: true)
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -59,5 +59,24 @@ class ViewController: UIViewController {
             juiceMaker.produce(juice: orderedJuice)
         }
     }
+    
+    func fetchOrderedAlertMessage(juice: JuiceMaker.Juice) -> String {
+        switch juice {
+        case .strawberryJuice:
+            return "딸기쥬스 나왔습니다! 맛있게 드세요!"
+        case .bananaJuice:
+            return "바나나쥬스 나왔습니다! 맛있게 드세요!"
+        case .kiwiJuice:
+            return "키위쥬스 나왔습니다! 맛있게 드세요!"
+        case .mangoJuice:
+            return "망고쥬스 나왔습니다! 맛있게 드세요!"
+        case .mangoKiwiJuice:
+            return "망키쥬스 나왔습니다! 맛있게 드세요!"
+        case .pineappleJuice:
+            return "파인애플쥬스 나왔습니다! 맛있게 드세요!"
+        case .strawberryBananaJuice:
+            return "딸바쥬스 나왔습니다! 맛있게 드세요!"
+        }
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -49,7 +49,7 @@ class ViewController: UIViewController {
         if let orderedJuice = JuiceMaker.Juice(rawValue: sender.tag) {
             do {
                 try juiceMaker.produce(juice: orderedJuice)
-                showOrderedAlert(juice: orderedJuice)
+                showOrderSuccessedAlert(juice: orderedJuice)
             } catch JuiceMakerError.outOfStock {
                 showOrderFailedAlert()
             } catch {
@@ -78,7 +78,7 @@ class ViewController: UIViewController {
         }
     }
     
-    private func showOrderedAlert(juice: JuiceMaker.Juice) {
+    private func showOrderSuccessedAlert(juice: JuiceMaker.Juice) {
         let message = fetchOrderedAlertMessage(juice: juice)
         let alert = UIAlertController(title: nil,
                                       message: message,

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -17,9 +17,41 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        updateStockLabel()
         // Do any additional setup after loading the view.
     }
+    
+    func updateStockLabel() {
+        updateStrawberryStockLabel()
+        updateBananaStockLabel()
+        updatePineappleStockLabel()
+        updateKiwiStockLabel()
+        updateMangoStockLabel()
+    }
 
-
+    func updateStrawberryStockLabel() {
+        let strawberryStock = try! juiceMaker.fetchStock(of: .strawberry)
+        strawberryStockLabel.text = String(strawberryStock)
+    }
+    
+    func updateBananaStockLabel() {
+        let bananaStock = try! juiceMaker.fetchStock(of: .banana)
+        bananaStockLabel.text = String(bananaStock)
+    }
+    
+    func updatePineappleStockLabel() {
+        let pineappleStock = try! juiceMaker.fetchStock(of: .pineapple)
+        pineappleStockLabel.text = String(pineappleStock)
+    }
+    
+    func updateKiwiStockLabel() {
+        let kiwiStock = try! juiceMaker.fetchStock(of: .kiwi)
+        kiwiStockLabel.text = String(kiwiStock)
+    }
+    
+    func updateMangoStockLabel() {
+        let mangoStock = try! juiceMaker.fetchStock(of: .mango)
+        mangoStockLabel.text = String(mangoStock)
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -18,6 +18,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        navigationController?.navigationBar.backgroundColor = .systemGray5
         updateAllStockLabels()
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -92,8 +92,6 @@ class ViewController: UIViewController {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let stockEditVC = storyboard.instantiateViewController(identifier: "stockEditNavigation")
         
-        stockEditVC.modalPresentationStyle = .fullScreen
-        
         present(stockEditVC, animated: true, completion: nil)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -8,7 +8,7 @@ import UIKit
 
 class ViewController: UIViewController {
 
-    var juiceMaker: JuiceMaker = JuiceMaker()
+    let juiceMaker: JuiceMaker = JuiceMaker()
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
     @IBOutlet weak var pineappleStockLabel: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -49,7 +49,7 @@ class ViewController: UIViewController {
         if let orderedJuice = JuiceMaker.Juice(rawValue: sender.tag) {
             do {
                 try juiceMaker.produce(juice: orderedJuice)
-                showOrderSuccessedAlert(juice: orderedJuice)
+                showOrderSucceedAlert(juice: orderedJuice)
             } catch JuiceMakerError.outOfStock {
                 showOrderFailedAlert()
             } catch {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,7 +8,7 @@ import Foundation
 
 // 과일 저장소 타입
 class FruitStore {
-    private var fruitStock: [Fruit:Int] = [:]
+    private var fruitStock: [Fruit: Int] = [:]
     
     init() {
         Fruit.allCases.forEach { fruit in
@@ -41,5 +41,12 @@ class FruitStore {
                 throw JuiceMakerError.outOfStock
             }
         }
+    }
+    
+    func fetchStock(of fruit: Fruit) throws -> Int {
+        guard let fruitStock = fruitStock[fruit] else {
+            throw JuiceMakerError.invalidFruit
+        }
+        return fruitStock
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -56,4 +56,8 @@ struct JuiceMaker {
             print("Unexpected error: \(error).")
         }
     }
+    
+    func fetchStock(of fruit: Fruit) throws -> Int {
+        return try fruitStore.fetchStock(of: fruit)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,7 +8,7 @@ import Foundation
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
-    enum Juice {
+    enum Juice: Int {
         case strawberryJuice
         case bananaJuice
         case kiwiJuice

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -39,6 +39,25 @@ struct JuiceMaker {
                 return Recipe(ingredient: [.mango: 2, .kiwi: 1])
             }
         }
+        
+        var orderSucceedMessage: String {
+            switch self {
+            case .strawberryJuice:
+                return "딸기쥬스 나왔습니다! 맛있게 드세요!"
+            case .bananaJuice:
+                return "바나나쥬스 나왔습니다! 맛있게 드세요!"
+            case .kiwiJuice:
+                return "키위쥬스 나왔습니다! 맛있게 드세요!"
+            case .mangoJuice:
+                return "망고쥬스 나왔습니다! 맛있게 드세요!"
+            case .mangoKiwiJuice:
+                return "망키쥬스 나왔습니다! 맛있게 드세요!"
+            case .pineappleJuice:
+                return "파인애플쥬스 나왔습니다! 맛있게 드세요!"
+            case .strawberryBananaJuice:
+                return "딸바쥬스 나왔습니다! 맛있게 드세요!"
+            }
+        }
     }
     
     private let fruitStore = FruitStore()

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -58,6 +58,25 @@ struct JuiceMaker {
                 return "딸바쥬스 나왔습니다! 맛있게 드세요!"
             }
         }
+        
+        var orderFailedMessage: String {
+            switch self {
+            case .strawberryJuice:
+                return "딸기쥬스 재료가 모자라요. 재고를 수정할까요?"
+            case .bananaJuice:
+                return "바나나쥬스 재료가 모자라요. 재고를 수정할까요?"
+            case .kiwiJuice:
+                return "키위쥬스 재료가 모자라요. 재고를 수정할까요?"
+            case .pineappleJuice:
+                return "파인애플쥬스 재료가 모자라요. 재고를 수정할까요?"
+            case .strawberryBananaJuice:
+                return "딸바쥬스 재료가 모자라요. 재고를 수정할까요?"
+            case .mangoJuice:
+                return "망고쥬스 재료가 모자라요. 재고를 수정할까요?"
+            case .mangoKiwiJuice:
+                return "망키쥬스 재료가 모자라요. 재고를 수정할까요?"
+            }
+        }
     }
     
     private let fruitStore = FruitStore()

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -43,17 +43,11 @@ struct JuiceMaker {
     
     private let fruitStore = FruitStore()
     
-    func produce(juice: Juice) {
+    func produce(juice: Juice) throws {
         let recipe = juice.recipe
-        do {
-            try fruitStore.checkStock(for: juice)
-            for (fruit, amount) in recipe.ingredient {
-                fruitStore.use(fruit, amountOf: amount)
-            }
-        } catch JuiceMakerError.outOfStock {
-            print("재고가 없습니다.")
-        } catch {
-            print("Unexpected error: \(error).")
+        try fruitStore.checkStock(for: juice)
+        for (fruit, amount) in recipe.ingredient {
+            fruitStore.use(fruit, amountOf: amount)
         }
     }
     

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -236,7 +236,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
+                            <connections>
+                                <segue destination="Yu1-lM-nqp" kind="presentation" id="0hb-rh-fga"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="m97-bb-dZf"/>
@@ -268,10 +272,10 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--View Controller-->
+        <!--Stock Edit View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" sceneMemberID="viewController">
+                <viewController id="Yu1-lM-nqp" customClass="StockEditViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -400,6 +404,9 @@
             <point key="canvasLocation" x="1637" y="21"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="wH1-3A-cBm"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -217,6 +217,13 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
                     </navigationItem>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="m97-bb-dZf"/>
+                        <outlet property="kiwiStockLabel" destination="FZq-de-TJG" id="WnQ-5g-LEY"/>
+                        <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="eqB-aT-ctz"/>
+                        <outlet property="pineappleStockLabel" destination="ccQ-Dk-PuY" id="i11-S4-pPu"/>
+                        <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="n6f-VU-YXo"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -127,7 +127,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="klY-1b-YqG"/>
+                                                    <action selector="juiceOrderButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Tnj-4a-TVK"/>
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
@@ -142,7 +142,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="o34-tf-YE8"/>
+                                                    <action selector="juiceOrderButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Hu8-i2-Wmi"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -161,7 +161,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UNd-yd-RZB"/>
+                                                            <action selector="juiceOrderButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RT4-v2-evO"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
@@ -172,7 +172,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="3sX-gD-eTa"/>
+                                                            <action selector="juiceOrderButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uuX-Yd-5Rm"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
@@ -183,7 +183,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6fE-DP-MrU"/>
+                                                            <action selector="juiceOrderButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ifa-di-7pM"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
@@ -194,7 +194,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="93I-45-2Od"/>
+                                                            <action selector="juiceOrderButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iHV-AO-kWh"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
@@ -205,7 +205,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="x07-70-zmP"/>
+                                                            <action selector="juiceOrderButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uaz-ta-7DK"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -119,25 +119,31 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
                                         <rect key="frame" x="0.0" y="0.0" width="724" height="66"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                            <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
                                                 <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="klY-1b-YqG"/>
+                                                </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
                                                 <rect key="frame" x="296" y="0.0" width="132" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                            <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
                                                 <rect key="frame" x="444" y="0.0" width="280" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="o34-tf-YE8"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -154,38 +160,53 @@
                                                         <state key="normal" title="딸기쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UNd-yd-RZB"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="3sX-gD-eTa"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6fE-DP-MrU"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="93I-45-2Od"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="x07-70-zmP"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                             </stackView>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" id="0hb-rh-fga"/>
+                                <segue destination="Yu1-lM-nqp" kind="presentation" id="nw5-xg-dWy"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -405,7 +405,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="wH1-3A-cBm"/>
+        <segue reference="nw5-xg-dWy"/>
     </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -13,7 +13,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Main" id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -236,11 +236,7 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
-                            <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" id="nw5-xg-dWy"/>
-                            </connections>
-                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
                     </navigationItem>
                     <connections>
                         <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="m97-bb-dZf"/>
@@ -272,7 +268,7 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--Stock Edit View Controller-->
+        <!--재고 수정-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController id="Yu1-lM-nqp" customClass="StockEditViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
@@ -379,7 +375,7 @@
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <navigationItem key="navigationItem" title="재고 수정" id="g4W-fY-l7r"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
@@ -388,7 +384,7 @@
         <!--Navigation Controller-->
         <scene sceneID="cAf-jL-tPK">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="stockEditNavigation" automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
@@ -404,9 +400,6 @@
             <point key="canvasLocation" x="1637" y="21"/>
         </scene>
     </scenes>
-    <inferredMetricsTieBreakers>
-        <segue reference="nw5-xg-dWy"/>
-    </inferredMetricsTieBreakers>
     <resources>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -236,7 +236,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
+                            <connections>
+                                <action selector="stockEditButtonPressed" destination="BYZ-38-t0r" id="zM0-nV-KNv"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="m97-bb-dZf"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController storyboardIdentifier="Main" id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Main" id="BYZ-38-t0r" customClass="JuiceMakerViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
안녕하세요, @hansangjin96 
토털이, 인호 입니다.

쥬스 메이커 프로그램 step 2 PR입니다!

## 고민했던 부분
### 뷰 컨트롤러에게 private 값 전달 방법
- 지난 스텝에서 `FruitStore`타입의 `fruitStock`프로퍼티와 `JuiceMaker`의 `fruitStore`프로퍼티에 `private` 접근 제어를 추가해 주었습니다.
- 그런데 이번 스텝의 뷰컨트롤러에서 과일 재고량(`fruitStock`)이 필요해서 위 두 타입에 `fetchStock(of fruit: Fruit)`메서드를 구현하여 특정 과일의 재고량을 전달합니다.
### 뷰 컨트롤러에서 과일 재고량을 각 레이블 업데이트
- 앱을 실행시키거나 과일 주문 버튼을 눌러 과일 수량이 변경되었을 때, 각 수량이 레이블에 반영되어야 합니다. 처음에 구현할 때는 과일 하나하나에 값을 업데이트 하는 메서드를 작성했습니다.
```swift
func updateStrawberryStockLabel() {
    let strawberryStock = try juiceMaker.fetchStock(of: .strawberry)
    strawberryStockLabel.text = String(strawberryStock)
}

func updateBananaStockLabel() {
    let bananaStock = try juiceMaker.fetchStock(of: .banana)
    bananaStockLabel.text = String(bananaStock)
}
...
```
- 그런데 위 코드의 반복되는 부분을 어떻게 줄일 지 고민후에 하나의 메서드와 스위치 문을 이용하여 해결하였습니다.
```swift

func updateStockLabel(of fruit: Fruit) {
    guard let fruitStock = try? juiceMaker.fetchStock(of: fruit) else { return }
        
    switch fruit {
    case .strawberry:
        strawberryStockLabel.text = String(fruitStock)
    case .banana:
        bananaStockLabel.text = String(fruitStock)
    ...
    }
}
```
- 그리고 모든 과일의 레이블을 업데이트하는 메서드를 만들고, 그 안에 `Fruit`타입과 `allCases`,`forEach`를 이용하여 업데이트 합니다.
```swift
func updateAllStockLabels() {
    Fruit.allCases.forEach({ fruit in
        updateStockLabel(of: fruit)
    })
}
```
### 과일 주문 버튼 처리하는 방법
- 앱을 실행시켜 보면 총 7개의 과일 주문버튼이 있습니다. 이때 각 버튼에 대한 액션을 일일이 만들어야 할까 고민하다가 버튼의 tag값을 지정해서 하나의 메서드 내에서 사용 가능하도록 구현했습니다. 
```swift
@IBAction func touchUpOrderButton(_ sender: UIButton) {
    if let orderedJuice = JuiceMaker.Juice(rawValue: sender.tag) {
        do {
            try juiceMaker.produce(juice: orderedJuice)
            showOrderedAlert(juice: orderedJuice)
        } catch JuiceMakerError.outOfStock {
            showOrderFailedAlert()
        }
        ...
    }
}
```
- `JuiceMaker.Juice`타입의 rawValue와 버튼의 tag값을 비교해서 주문을 받습니다.

### 화면 전환 방법
- 두번째 뷰 컨트롤러인 `StockEditViewController`로 화면이 전환되는 두가지 경우가 있는데, 
"재고수정"버튼과 주문 실패 시 재고수정 알럿의 "예" 버튼을 누를때 화면이 전환되어야 합니다.
- 그래서 모달로 화면을 보여주는 `presentStockEditViewController`메서드를 만들고 각 버튼을 눌렀을 때 해당 매서드가 호출됩니다.
- 화면 전환을 모달로 구현한 이유는 재고 수정 버튼을 누르는 것이 정보의 흐름과 이어진다기 보다 사용자에게 새로운 화면을 보여준다고 생각했기 때문입니다.

## 조언을 얻고싶은 부분
1. 이번 프로젝트에서 `navigation bar`를 두 화면에 모두 만들어 주기 위해 `navigation controller`를 두 개 사용하였습니다. 초기 프로젝트 파일부터 포함되어 있던 내용이라, 수정하지 않고 그대로 진행하였는데, 과연 이 방법이 맞는지 의문이 듭니다.
현재 앱에는 두개의 뷰가 있어서 하나의 네비게이션 컨트롤러만 있어도 된다고 생각합니다!

    그리고 한편으로는 위에서 작성한 대로 화면이 전환될 때, 정보의 흐름보다는 모달에 가까워서 네비게이션 컨트롤러가 없어도 되지 않을까 싶은 고민도 있었습니다. 
 하비는 어떻게 생각하시나요?

2. 두개의 `Navigation Controller`를 이어주기 위해서, present를 활용하였는데요. 그 과정에서 `StockEditViewController`가 아닌 두번째`Navigation Controller`를 `presentStockEditViewController()` 함수 내에서 연결해 주었습니다. navigation Bar를 유지해주기 위해서였는데, 이 방법이 맞는지 궁금합니다.

3. STEP3에서 `화면사이의 데이터 공유`가 핵심 경험으로 나와있습니다. 화면사이에 데이터를 전달하는 방법은 아주 많은데, 고민이 많습니다. 그 중 적절한 방법을 고르는 팁이 있을까요?

4. 컨트롤러를 작성하다 보면, 컨트롤러가 길어지는데 컨트롤러 속의 메서드들을 어떤 순서로 작성하는지 팁을 얻을 수 있을까요? 보기 좋은 코드로 만들고 싶은데 감이 잡히지 않아 여쭤봅니다!