### PR TITLE
쥬스 메이커 [STEP 2] 써니쿠키, 써머캣 

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		410EC49628C6127B00B37BBC /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410EC49528C6127B00B37BBC /* Fruit.swift */; };
+		410EC49828C612B300B37BBC /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410EC49728C612B300B37BBC /* Juice.swift */; };
 		690BE1C528BDA8FB00E44432 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		690BE1C628BDA8FD00E44432 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
 		690BE1C728BDA90F00E44432 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
@@ -19,6 +21,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		410EC49528C6127B00B37BBC /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
+		410EC49728C612B300B37BBC /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
 		690BE1CA28BDAA5100E44432 /* JuiceMakerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMakerError.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -59,6 +63,8 @@
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				690BE1CA28BDAA5100E44432 /* JuiceMakerError.swift */,
+				410EC49528C6127B00B37BBC /* Fruit.swift */,
+				410EC49728C612B300B37BBC /* Juice.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -174,7 +180,9 @@
 				690BE1C628BDA8FD00E44432 /* SceneDelegate.swift in Sources */,
 				690BE1C528BDA8FB00E44432 /* AppDelegate.swift in Sources */,
 				690BE1CB28BDAA5100E44432 /* JuiceMakerError.swift in Sources */,
+				410EC49628C6127B00B37BBC /* Fruit.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
+				410EC49828C612B300B37BBC /* Juice.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		690BE1C928BDA91400E44432 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
 		690BE1CB28BDAA5100E44432 /* JuiceMakerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690BE1CA28BDAA5100E44432 /* JuiceMakerError.swift */; };
 		690BE1CC28BDB0A200E44432 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
+		6986DA5A28C615B100F104B3 /* FruitStockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6986DA5928C615B100F104B3 /* FruitStockViewController.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
 /* End PBXBuildFile section */
@@ -24,6 +25,7 @@
 		410EC49528C6127B00B37BBC /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		410EC49728C612B300B37BBC /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
 		690BE1CA28BDAA5100E44432 /* JuiceMakerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMakerError.swift; sourceTree = "<group>"; };
+		6986DA5928C615B100F104B3 /* FruitStockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStockViewController.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -53,6 +55,7 @@
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				6986DA5928C615B100F104B3 /* FruitStockViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -177,6 +180,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				690BE1CC28BDB0A200E44432 /* ViewController.swift in Sources */,
+				6986DA5A28C615B100F104B3 /* FruitStockViewController.swift in Sources */,
 				690BE1C628BDA8FD00E44432 /* SceneDelegate.swift in Sources */,
 				690BE1C528BDA8FB00E44432 /* AppDelegate.swift in Sources */,
 				690BE1CB28BDAA5100E44432 /* JuiceMakerError.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -2,13 +2,24 @@ import UIKit
 
 class FruitStockViewController: UIViewController {
 
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var mangoStockLabel: UILabel!
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        strawberryStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.strawberry))
+        bananaStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.banana))
+        pineappleStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.pineapple))
+        kiwiStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.kiwi))
+        mangoStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.mango))
     }
     
-
+    
+    
     /*
     // MARK: - Navigation
 

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+class FruitStockViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -10,24 +10,5 @@ class FruitStockViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        strawberryStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.strawberry))
-        bananaStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.banana))
-        pineappleStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.pineapple))
-        kiwiStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.kiwi))
-        mangoStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.mango))
     }
-    
-    
-    
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -7,9 +7,11 @@
 import UIKit
 
 class ViewController: UIViewController {
+    let juiceMaker = JuiceMaker()
+    
     @IBOutlet weak var changeFruitStockButton: UIBarButtonItem!
     
-    @IBOutlet weak var strawberryBannaJuiceButton: UIButton!
+    @IBOutlet weak var strawberryBananaJuiceButton: UIButton!
     @IBOutlet weak var mangoKiwiJuiceButton: UIButton!
     @IBOutlet weak var strawberryJuiceButton: UIButton!
     @IBOutlet weak var bananaJuiceButton: UIButton!
@@ -21,6 +23,31 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         
     }
+    
+    @IBAction func orderJuice(sender: UIButton) {
+        switch sender {
+        case strawberryBananaJuiceButton:
+            juiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
+        case mangoKiwiJuiceButton:
+            juiceMaker.makeJuice(.mangoKiwiJuice, total: 1)
+        case strawberryJuiceButton:
+            juiceMaker.makeJuice(.strawberryJuice, total: 1)
+        case bananaJuiceButton:
+            juiceMaker.makeJuice(.bananaJuice, total: 1)
+        case pineappleJuiceButton:
+            juiceMaker.makeJuice(.pineappleJuice, total: 1)
+        case kiwiJuiceButton:
+            juiceMaker.makeJuice(.kiwiJuice, total: 1)
+        case mangoJuiceButton:
+            juiceMaker.makeJuice(.mangoJuice, total: 1)
+        default:
+            return
+        }
+    }
+    
+    
+    
+    
 
     func moveToFruitStockVC() {
         guard let fruitStoreStockViewController =

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -28,19 +28,11 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        strawberryStockLabel.text = String(validateStock(.strawberry))
-        bananaStockLabel.text = String(validateStock(.banana))
-        pineappleStockLabel.text = String(validateStock(.pineapple))
-        kiwiStockLabel.text = String(validateStock(.kiwi))
-        mangoStockLabel.text = String(validateStock(.mango))
-    }
-    
-    func validateStock(_ fruit: Fruit) -> Int {
-        guard let stock = FruitStore.sharedFruitStore.fetchStockOf(fruit) else {
-            return 0
-        }
-        
-        return stock
+        strawberryStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.strawberry))
+        bananaStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.banana))
+        pineappleStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.pineapple))
+        kiwiStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.kiwi))
+        mangoStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.mango))
     }
     
     @IBAction func orderJuice(sender: UIButton) {
@@ -79,31 +71,31 @@ class ViewController: UIViewController {
     
     func showSuccessAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-               let okAction = UIAlertAction(title: "예", style: .default, handler : nil)
-               
-               alert.addAction(okAction)
-               present(alert, animated: true, completion: nil)
+        let okAction = UIAlertAction(title: "예", style: .default, handler : nil)
+        
+        alert.addAction(okAction)
+        present(alert, animated: true, completion: nil)
     }
     
     func showFailureAlert(message: String) {
-        let alert = UIAlertController(title: nil, message: message,preferredStyle: .alert)
-              let okAction = UIAlertAction(title: "예", style: .default) { _ in
-                  self.moveToFruitStockVC()
-              }
-              let noAction = UIAlertAction(title: "아니오", style: .destructive, handler: nil)
-              
-              alert.addAction(noAction)
-              alert.addAction(okAction)
-              present(alert, animated: true, completion: nil)
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "예", style: .default) { _ in
+            self.moveToFruitStockVC()
+        }
+        let noAction = UIAlertAction(title: "아니오", style: .destructive, handler: nil)
+        
+        alert.addAction(noAction)
+        alert.addAction(okAction)
+        present(alert, animated: true, completion: nil)
     }
-
+    
     func moveToFruitStockVC() {
         guard let fruitStoreStockViewController =
                 self.storyboard?.instantiateViewController(withIdentifier: "fruitStoreStock") else { return }
         self.present(fruitStoreStockViewController, animated: true, completion: nil)
     }
-
-    @IBAction func touchUpChangeFruitStockButton(_ sender: Any) {
+    
+    @IBAction func touchUpChangeFruitStockButton(_ sender: UIBarButtonItem) {
         moveToFruitStockVC()
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -11,6 +11,12 @@ class ViewController: UIViewController {
     
     @IBOutlet weak var changeFruitStockButton: UIBarButtonItem!
     
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var mangoStockLabel: UILabel!
+    
     @IBOutlet weak var strawberryBananaJuiceButton: UIButton!
     @IBOutlet weak var mangoKiwiJuiceButton: UIButton!
     @IBOutlet weak var strawberryJuiceButton: UIButton!
@@ -22,32 +28,55 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        strawberryStockLabel.text = String(validateStock(.strawberry))
+        bananaStockLabel.text = String(validateStock(.banana))
+        pineappleStockLabel.text = String(validateStock(.pineapple))
+        kiwiStockLabel.text = String(validateStock(.kiwi))
+        mangoStockLabel.text = String(validateStock(.mango))
+    }
+    
+    func validateStock(_ fruit: Fruit) -> Int {
+        guard let stock = FruitStore.sharedFruitStore.fetchStockOf(fruit) else {
+            return 0
+        }
+        
+        return stock
     }
     
     @IBAction func orderJuice(sender: UIButton) {
+        var result: Result<String, Error>
+        
         switch sender {
         case strawberryBananaJuiceButton:
-            juiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
+            result = juiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
         case mangoKiwiJuiceButton:
-            juiceMaker.makeJuice(.mangoKiwiJuice, total: 1)
+            result = juiceMaker.makeJuice(.mangoKiwiJuice, total: 1)
         case strawberryJuiceButton:
-            juiceMaker.makeJuice(.strawberryJuice, total: 1)
+            result = juiceMaker.makeJuice(.strawberryJuice, total: 1)
         case bananaJuiceButton:
-            juiceMaker.makeJuice(.bananaJuice, total: 1)
+            result = juiceMaker.makeJuice(.bananaJuice, total: 1)
         case pineappleJuiceButton:
-            juiceMaker.makeJuice(.pineappleJuice, total: 1)
+            result = juiceMaker.makeJuice(.pineappleJuice, total: 1)
         case kiwiJuiceButton:
-            juiceMaker.makeJuice(.kiwiJuice, total: 1)
+            result = juiceMaker.makeJuice(.kiwiJuice, total: 1)
         case mangoJuiceButton:
-            juiceMaker.makeJuice(.mangoJuice, total: 1)
+            result = juiceMaker.makeJuice(.mangoJuice, total: 1)
         default:
             return
         }
+        
+        switch result {
+        case .success(let message):
+            showSuccessAlert(message: message)
+            viewDidLoad()
+        case .failure(let error):
+            showFailureAlert(message: error.errorDescription)
+        }
     }
     
-    
-    
-    
+    func getresult() {
+        
+    }
 
     func moveToFruitStockVC() {
         guard let fruitStoreStockViewController =

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -10,12 +10,10 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
         
         let myJuiceMaker = JuiceMaker()
         myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
         myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
-        
         
     }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -25,19 +25,26 @@ class ViewController: UIViewController {
     @IBOutlet weak var kiwiJuiceButton: UIButton!
     @IBOutlet weak var mangoJuiceButton: UIButton!
     
+    lazy var fruitLabel: [Fruit: UILabel] = [
+        .strawberry: strawberryStockLabel,
+        .banana: bananaStockLabel,
+        .pineapple: pineappleStockLabel,
+        .kiwi: kiwiStockLabel,
+        .mango: mangoStockLabel
+    ]
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let fruitLabel: [UILabel: Fruit] = [
-            strawberryStockLabel: .strawberry,
-            bananaStockLabel: .banana,
-            pineappleStockLabel: .pineapple,
-            kiwiStockLabel: .kiwi,
-            mangoStockLabel: .mango,
-        ]
-        
-        for (label, fruit) in fruitLabel {
+        for (fruit, label) in fruitLabel {
             label.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
+        }
+    }
+    
+    func updateFruitStockLabelUsedFor(_ juice: Juice) {
+        for fruit in juice.recipe.keys {
+            guard let validLabel = fruitLabel[fruit] else { return }
+            validLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
         }
     }
     
@@ -59,20 +66,23 @@ class ViewController: UIViewController {
         switch result {
         case.success(let message):
             showAlert(result: result, message: message)
+            updateFruitStockLabelUsedFor(juice)
         case .failure(let error):
             var message: String
+            
             if let juiceMakerError = error as? JuiceMakerError {
                 message = juiceMakerError.errorDescription
             } else {
                 message = error.localizedDescription
             }
+            
             showAlert(result: result, message: message)
         }
     }
     
     func showAlert(result: Result<String, Error>, message: String) {
-        var okAction: UIAlertAction
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        var okAction: UIAlertAction
         
         switch result {
         case .success:
@@ -81,6 +91,7 @@ class ViewController: UIViewController {
             okAction = UIAlertAction(title: "예", style: .default) { _ in
                 self.moveToFruitStockVC()
             }
+            
             let noAction = UIAlertAction(title: "아니오", style: .destructive, handler: nil)
             
             alert.addAction(noAction)

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -64,8 +64,7 @@ class ViewController: UIViewController {
             guard let juiceMakerError = error as? JuiceMakerError else {
                 return showFailureAlert(message: error.localizedDescription)
             }
-            
-            showFailureAlert(message: juiceMakerError.errorDescription )
+            showFailureAlert(message: juiceMakerError.errorDescription)
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -28,34 +28,33 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        strawberryStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.strawberry))
-        bananaStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.banana))
-        pineappleStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.pineapple))
-        kiwiStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.kiwi))
-        mangoStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.mango))
+        let fruitLabel: [UILabel: Fruit] = [
+            strawberryStockLabel: .strawberry,
+            bananaStockLabel: .banana,
+            pineappleStockLabel: .pineapple,
+            kiwiStockLabel: .kiwi,
+            mangoStockLabel: .mango,
+        ]
+        
+        for (label, fruit) in fruitLabel {
+            label.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
+        }
     }
     
     @IBAction func orderJuice(sender: UIButton) {
-        var result: Result<String, Error>
+        let juiceButton: [UIButton: Juice] = [
+            strawberryBananaJuiceButton: .strawberryBananaJuice,
+            mangoKiwiJuiceButton: .mangoKiwiJuice,
+            strawberryJuiceButton: .strawberryJuice,
+            bananaJuiceButton: .bananaJuice,
+            pineappleJuiceButton: .pineappleJuice,
+            kiwiJuiceButton: .kiwiJuice,
+            mangoJuiceButton: .mangoJuice,
+        ]
         
-        switch sender {
-        case strawberryBananaJuiceButton:
-            result = juiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
-        case mangoKiwiJuiceButton:
-            result = juiceMaker.makeJuice(.mangoKiwiJuice, total: 1)
-        case strawberryJuiceButton:
-            result = juiceMaker.makeJuice(.strawberryJuice, total: 1)
-        case bananaJuiceButton:
-            result = juiceMaker.makeJuice(.bananaJuice, total: 1)
-        case pineappleJuiceButton:
-            result = juiceMaker.makeJuice(.pineappleJuice, total: 1)
-        case kiwiJuiceButton:
-            result = juiceMaker.makeJuice(.kiwiJuice, total: 1)
-        case mangoJuiceButton:
-            result = juiceMaker.makeJuice(.mangoJuice, total: 1)
-        default:
-            return
-        }
+        guard let juice = juiceButton[sender] else { return }
+        
+        let result = juiceMaker.makeJuice(juice, total: 1)
         
         switch result {
         case .success(let message):
@@ -65,27 +64,33 @@ class ViewController: UIViewController {
             guard let juiceMakerError = error as? JuiceMakerError else {
                 return showFailureAlert(message: error.localizedDescription)
             }
+            
             showFailureAlert(message: juiceMakerError.errorDescription )
         }
     }
     
     func showSuccessAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        
         let okAction = UIAlertAction(title: "예", style: .default, handler : nil)
         
         alert.addAction(okAction)
+        
         present(alert, animated: true, completion: nil)
     }
     
     func showFailureAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        
         let okAction = UIAlertAction(title: "예", style: .default) { _ in
             self.moveToFruitStockVC()
         }
+        
         let noAction = UIAlertAction(title: "아니오", style: .destructive, handler: nil)
         
         alert.addAction(noAction)
         alert.addAction(okAction)
+        
         present(alert, animated: true, completion: nil)
     }
     
@@ -98,6 +103,5 @@ class ViewController: UIViewController {
     @IBAction func touchUpChangeFruitStockButton(_ sender: UIBarButtonItem) {
         moveToFruitStockVC()
     }
-    
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -1,21 +1,36 @@
 //
 //  JuiceMaker - ViewController.swift
-//  Created by yagom. 
+//  Created by 써니쿠키, 써머캣
 //  Copyright © yagom academy. All rights reserved.
 // 
 
 import UIKit
 
 class ViewController: UIViewController {
-
+    @IBOutlet weak var changeFruitStockButton: UIBarButtonItem!
+    
+    @IBOutlet weak var strawberryBannaJuiceButton: UIButton!
+    @IBOutlet weak var mangoKiwiJuiceButton: UIButton!
+    @IBOutlet weak var strawberryJuiceButton: UIButton!
+    @IBOutlet weak var bananaJuiceButton: UIButton!
+    @IBOutlet weak var pineappleJuiceButton: UIButton!
+    @IBOutlet weak var kiwiJuiceButton: UIButton!
+    @IBOutlet weak var mangoJuiceButton: UIButton!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let myJuiceMaker = JuiceMaker()
-        myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
-        myJuiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
-        
     }
 
+    func moveToFruitStockVC() {
+        guard let fruitStoreStockViewController =
+                self.storyboard?.instantiateViewController(withIdentifier: "fruitStoreStock") else { return }
+        self.present(fruitStoreStockViewController, animated: true, completion: nil)
+    }
+
+    @IBAction func touchUpChangeFruitStockButton(_ sender: Any) {
+        moveToFruitStockVC()
+    }
+    
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -70,12 +70,31 @@ class ViewController: UIViewController {
             showSuccessAlert(message: message)
             viewDidLoad()
         case .failure(let error):
-            showFailureAlert(message: error.errorDescription)
+            guard let juiceMakerError = error as? JuiceMakerError else {
+                return showFailureAlert(message: error.localizedDescription)
+            }
+            showFailureAlert(message: juiceMakerError.errorDescription )
         }
     }
     
-    func getresult() {
-        
+    func showSuccessAlert(message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+               let okAction = UIAlertAction(title: "예", style: .default, handler : nil)
+               
+               alert.addAction(okAction)
+               present(alert, animated: true, completion: nil)
+    }
+    
+    func showFailureAlert(message: String) {
+        let alert = UIAlertController(title: nil, message: message,preferredStyle: .alert)
+              let okAction = UIAlertAction(title: "예", style: .default) { _ in
+                  self.moveToFruitStockVC()
+              }
+              let noAction = UIAlertAction(title: "아니오", style: .destructive, handler: nil)
+              
+              alert.addAction(noAction)
+              alert.addAction(okAction)
+              present(alert, animated: true, completion: nil)
     }
 
     func moveToFruitStockVC() {

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -62,42 +62,50 @@ class ViewController: UIViewController {
         guard let juice = juiceButton[sender] else { return }
         
         let result = juiceMaker.makeJuice(juice, total: 1)
+        showAlert(result: result, juice: juice)
+    }
+    
+    func createAlertFor(
+        result: Result<String, Error>,
+        juice: Juice
+    ) -> (message: String, okAction: UIAlertAction, noAction: UIAlertAction?){
+        var okAction: UIAlertAction
+        var noAction: UIAlertAction?
+        var message: String
         
         switch result {
-        case.success(let message):
-            showAlert(result: result, message: message)
+        case.success(let successMesssage):
+            okAction = UIAlertAction(title: "예", style: .default, handler : nil)
+            noAction = nil
+            message = successMesssage
             updateFruitStockLabelUsedFor(juice)
         case .failure(let error):
-            var message: String
-            
             if let juiceMakerError = error as? JuiceMakerError {
                 message = juiceMakerError.errorDescription
             } else {
                 message = error.localizedDescription
             }
-            
-            showAlert(result: result, message: message)
-        }
-    }
-    
-    func showAlert(result: Result<String, Error>, message: String) {
-        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        var okAction: UIAlertAction
-        
-        switch result {
-        case .success:
-            okAction = UIAlertAction(title: "예", style: .default, handler : nil)
-        case .failure:
             okAction = UIAlertAction(title: "예", style: .default) { _ in
                 self.moveToFruitStockVC()
             }
-            
-            let noAction = UIAlertAction(title: "아니오", style: .destructive, handler: nil)
-            
-            alert.addAction(noAction)
+            noAction = UIAlertAction(title: "아니오", style: .destructive, handler: nil)
         }
         
+        return (message: message, okAction: okAction, noAction: noAction)
+    }
+    
+    func showAlert(result: Result<String, Error>, juice: Juice) {
+        let message = createAlertFor(result: result, juice: juice).message
+        let okAction = createAlertFor(result: result, juice: juice).okAction
+        let noAction = createAlertFor(result: result, juice: juice).noAction
+        
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        
         alert.addAction(okAction)
+
+        if let validNoAction = noAction {
+            alert.addAction(validNoAction)
+        }
         
         present(alert, animated: true, completion: nil)
     }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -57,37 +57,35 @@ class ViewController: UIViewController {
         let result = juiceMaker.makeJuice(juice, total: 1)
         
         switch result {
-        case .success(let message):
-            showSuccessAlert(message: message)
-            viewDidLoad()
+        case.success(let message):
+            showAlert(result: result, message: message)
         case .failure(let error):
-            guard let juiceMakerError = error as? JuiceMakerError else {
-                return showFailureAlert(message: error.localizedDescription)
+            var message: String
+            if let juiceMakerError = error as? JuiceMakerError {
+                message = juiceMakerError.errorDescription
+            } else {
+                message = error.localizedDescription
             }
-            showFailureAlert(message: juiceMakerError.errorDescription)
+            showAlert(result: result, message: message)
         }
     }
     
-    func showSuccessAlert(message: String) {
+    func showAlert(result: Result<String, Error>, message: String) {
+        var okAction: UIAlertAction
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         
-        let okAction = UIAlertAction(title: "예", style: .default, handler : nil)
-        
-        alert.addAction(okAction)
-        
-        present(alert, animated: true, completion: nil)
-    }
-    
-    func showFailureAlert(message: String) {
-        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        
-        let okAction = UIAlertAction(title: "예", style: .default) { _ in
-            self.moveToFruitStockVC()
+        switch result {
+        case .success:
+            okAction = UIAlertAction(title: "예", style: .default, handler : nil)
+        case .failure:
+            okAction = UIAlertAction(title: "예", style: .default) { _ in
+                self.moveToFruitStockVC()
+            }
+            let noAction = UIAlertAction(title: "아니오", style: .destructive, handler: nil)
+            
+            alert.addAction(noAction)
         }
         
-        let noAction = UIAlertAction(title: "아니오", style: .destructive, handler: nil)
-        
-        alert.addAction(noAction)
         alert.addAction(okAction)
         
         present(alert, animated: true, completion: nil)

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -1,0 +1,7 @@
+enum Fruit {
+    case strawberry
+    case banana
+    case pineapple
+    case kiwi
+    case mango
+}

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -8,6 +8,7 @@ import Foundation
 
 class FruitStore {
     static let sharedFruitStore = FruitStore()
+    
     private init() {}
     
     private var fruitStock: Dictionary<Fruit, Int> = [
@@ -19,17 +20,19 @@ class FruitStore {
     ]
     
     func changeStockOf(fruit: Fruit, by quantity: Int) {
-        let currentStock = fruitStock[fruit, default: 0]
+        guard let currentStock = fruitStock[fruit] else {
+            return
+        }
         
         fruitStock[fruit] = currentStock + quantity
     }
     
     func checkStockOf(_ ingredient: Fruit, total: Int) throws {
-        guard let curStock = fruitStock[ingredient] else {
+        guard let currentStock = fruitStock[ingredient] else {
             return
         }
         
-        guard curStock >= total else {
+        guard currentStock >= total else {
             throw JuiceMakerError.stockShortage
         }
     }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -26,11 +26,15 @@ class FruitStore {
     
     func checkStockOf(_ ingredient: Fruit, total: Int) throws {
         guard let curStock = fruitStock[ingredient] else {
-            throw JuiceMakerError.noSuchFruit
+            return
         }
         
         guard curStock >= total else {
             throw JuiceMakerError.stockShortage
         }
+    }
+    
+    func fetchStockOf(_ ingredient: Fruit) -> Int? {
+        return fruitStock[ingredient] ?? nil
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -34,7 +34,7 @@ class FruitStore {
         }
     }
     
-    func fetchStockOf(_ ingredient: Fruit) -> Int? {
-        return fruitStock[ingredient] ?? nil
+    func fetchStockOf(_ ingredient: Fruit) -> Int {
+        return fruitStock[ingredient] ?? 0
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -7,13 +7,8 @@
 import Foundation
 
 class FruitStore {
-    enum Fruit {
-        case strawberry
-        case banana
-        case pineapple
-        case kiwi
-        case mango
-    }
+    static let sharedFruitStore = FruitStore()
+    private init() {}
     
     private var fruitStock: Dictionary<Fruit, Int> = [
         .strawberry : 10,

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -1,0 +1,32 @@
+enum Juice: String {
+    case strawberryJuice = "딸기쥬스"
+    case bananaJuice = "바나나쥬스"
+    case kiwiJuice = "키위쥬스"
+    case pineappleJuice = "파인애플쥬스"
+    case strawberryBananaJuice = "딸바쥬스"
+    case mangoJuice = "망고쥬스"
+    case mangoKiwiJuice = "망키쥬스"
+    
+    var juiceName: String {
+        return self.rawValue
+    }
+    
+    var recipe: Dictionary<Fruit, Int> {
+        switch self {
+        case .strawberryJuice:
+            return [.strawberry: 16]
+        case .bananaJuice:
+            return [.banana: 2]
+        case .kiwiJuice:
+            return [.kiwi: 3]
+        case .pineappleJuice:
+            return [.pineapple: 2]
+        case .strawberryBananaJuice:
+            return [.strawberry: 10, .banana: 1]
+        case .mangoJuice:
+            return [.mango: 3]
+        case .mangoKiwiJuice:
+            return [.mango: 2, .kiwi: 1]
+        }
+    }
+}

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,20 +7,16 @@
 import Foundation
 
 struct JuiceMaker {
-    func makeJuice(_ juice: Juice, total: Int) {
+    func makeJuice(_ juice: Juice, total: Int) -> Result<String, Error> {
         do {
             try checkFruitStore(for: juice, total: total)
+            useFruit(juice, total: total)
+            return .success("\(juice.juiceName) 나왔습니다! 맛있게 드세요!")
         } catch let error as JuiceMakerError {
-            print(error.errorDescription)
-            return
+            return .failure(error)
         } catch {
-            print("\(error)")
-            return
+            return .failure(error)
         }
-        
-        useFruit(juice, total: total)
-        
-        print("\(juice.juiceName) \(total)잔 완성")
     }
     
     private func checkFruitStore(for juice: Juice, total: Int) throws {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,56 +7,6 @@
 import Foundation
 
 struct JuiceMaker {
-    private let fruitStore = FruitStore()
-    
-    enum Juice {
-        case strawberryJuice
-        case bananaJuice
-        case kiwiJuice
-        case pineappleJuice
-        case strawberryBananaJuice
-        case mangoJuice
-        case mangoKiwiJuice
-        
-        var juiceName: String {
-            switch self {
-            case .strawberryJuice:
-                return "딸기쥬스"
-            case .bananaJuice:
-                return "바나나쥬스"
-            case .kiwiJuice:
-                return "키위쥬스"
-            case .pineappleJuice:
-                return "파인애플쥬스"
-            case .strawberryBananaJuice:
-                return "딸바쥬스"
-            case .mangoJuice:
-                return "망고쥬스"
-            case .mangoKiwiJuice:
-                return "망키쥬스"
-            }
-        }
-        
-        var recipe: Dictionary<FruitStore.Fruit, Int> {
-            switch self {
-            case .strawberryJuice:
-                return [.strawberry: 16]
-            case .bananaJuice:
-                return [.banana: 2]
-            case .kiwiJuice:
-                return [.kiwi: 3]
-            case .pineappleJuice:
-                return [.pineapple: 2]
-            case .strawberryBananaJuice:
-                return [.strawberry: 10, .banana: 1]
-            case .mangoJuice:
-                return [.mango: 3]
-            case .mangoKiwiJuice:
-                return [.mango: 2, .kiwi: 1]
-            }
-        }
-    }
-    
     func makeJuice(_ juice: Juice, total: Int) {
         do {
             try checkFruitStore(for: juice, total: total)
@@ -75,13 +25,13 @@ struct JuiceMaker {
     
     private func checkFruitStore(for juice: Juice, total: Int) throws {
         for (ingredient, quantity) in juice.recipe {
-            try fruitStore.checkStockOf(ingredient, total: quantity * total)
+            try FruitStore.sharedFruitStore.checkStockOf(ingredient, total: quantity * total)
         }
     }
     
     private func useFruit(_ juice: Juice, total: Int) {
         for (ingredient, quantity) in juice.recipe {
-            fruitStore.changeStockOf(fruit: ingredient, by: -quantity * total)
+            FruitStore.sharedFruitStore.changeStockOf(fruit: ingredient, by: -quantity * total)
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
@@ -1,14 +1,12 @@
 enum JuiceMakerError: Error {
-    case stockShortage, noSuchFruit
+    case stockShortage
 }
 
 extension JuiceMakerError {
     var errorDescription: String {
         switch self {
         case .stockShortage:
-            return "재고 부족"
-        case .noSuchFruit:
-            return "해당 과일은 취급하지 않음"
+            return "재료가 모자라요. 재고를 수정할까요?"
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMakerError.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 enum JuiceMakerError: Error {
     case stockShortage, noSuchFruit
 }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -244,13 +244,18 @@
                     </navigationItem>
                     <connections>
                         <outlet property="bananaJuiceButton" destination="y2A-PH-DJY" id="QGY-ap-m2a"/>
+                        <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="AHI-IH-P4c"/>
                         <outlet property="changeFruitStockButton" destination="C3q-Te-cNT" id="3iP-fO-5zj"/>
                         <outlet property="kiwiJuiceButton" destination="wcW-7H-RXw" id="5k7-P6-22y"/>
+                        <outlet property="kiwiStockLabel" destination="FZq-de-TJG" id="SJ0-tk-zUt"/>
                         <outlet property="mangoJuiceButton" destination="q6G-4X-bVm" id="fXj-Ug-eSh"/>
                         <outlet property="mangoKiwiJuiceButton" destination="ngP-kF-Yii" id="ql1-wJ-bgJ"/>
+                        <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="1Av-zB-e5J"/>
                         <outlet property="pineappleJuiceButton" destination="BFb-ka-wGA" id="SLf-rE-EaM"/>
+                        <outlet property="pineappleStockLabel" destination="ccQ-Dk-PuY" id="4UE-JY-sNy"/>
                         <outlet property="strawberryBananaJuiceButton" destination="hrc-2F-fzl" id="5Xy-MX-Znq"/>
                         <outlet property="strawberryJuiceButton" destination="avd-o5-3JM" id="roH-DV-rXI"/>
+                        <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="7jo-CP-usZ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -280,10 +280,10 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--View Controller-->
+        <!--재고 수정 화면-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController storyboardIdentifier="fruitStoreStock" id="Yu1-lM-nqp" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="fruitStoreStock" id="Yu1-lM-nqp" customClass="FruitStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -387,7 +387,16 @@
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <navigationItem key="navigationItem" title="재고 수정 화면" leftItemsSupplementBackButton="YES" id="g4W-fY-l7r">
+                        <barButtonItem key="backBarButtonItem" title="뒤로가기" id="usK-5H-c0b"/>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="5bv-5c-P8w"/>
+                        <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="3Ep-dK-tg2"/>
+                        <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="JUT-pg-5Eq"/>
+                        <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="A7V-wg-z4g"/>
+                        <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="nV2-YG-qLB"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -215,8 +215,22 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
+                            <connections>
+                                <action selector="touchUpChangeFruitStockButton:" destination="BYZ-38-t0r" id="SfT-9o-4Nw"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="bananaJuiceButton" destination="y2A-PH-DJY" id="QGY-ap-m2a"/>
+                        <outlet property="changeFruitStockButton" destination="C3q-Te-cNT" id="3iP-fO-5zj"/>
+                        <outlet property="kiwiJuiceButton" destination="wcW-7H-RXw" id="5k7-P6-22y"/>
+                        <outlet property="mangoJuiceButton" destination="q6G-4X-bVm" id="fXj-Ug-eSh"/>
+                        <outlet property="mangoKiwiJuiceButton" destination="ngP-kF-Yii" id="ql1-wJ-bgJ"/>
+                        <outlet property="pineappleJuiceButton" destination="BFb-ka-wGA" id="SLf-rE-EaM"/>
+                        <outlet property="strawberryBannaJuiceButton" destination="hrc-2F-fzl" id="5Xy-MX-Znq"/>
+                        <outlet property="strawberryJuiceButton" destination="avd-o5-3JM" id="roH-DV-rXI"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
@@ -243,7 +257,7 @@
         <!--View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="fruitStoreStock" id="Yu1-lM-nqp" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -126,6 +126,9 @@
                                                 <state key="normal" title="딸바쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fdf-f4-kl9"/>
+                                                </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
                                                 <rect key="frame" x="296" y="0.0" width="132" height="66"/>
@@ -138,6 +141,9 @@
                                                 <state key="normal" title="망키쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MCM-9G-HkD"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -154,6 +160,9 @@
                                                         <state key="normal" title="딸기쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Xqv-2V-Gjy"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
@@ -162,6 +171,9 @@
                                                         <state key="normal" title="바나나쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5DB-Qh-3jr"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
@@ -170,6 +182,9 @@
                                                         <state key="normal" title="파인애플쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mbj-Qy-off"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
@@ -178,6 +193,9 @@
                                                         <state key="normal" title="키위쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="K3a-wl-4mD"/>
+                                                        </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
@@ -186,6 +204,9 @@
                                                         <state key="normal" title="망고쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pZs-Cq-9oP"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                             </stackView>
@@ -228,7 +249,7 @@
                         <outlet property="mangoJuiceButton" destination="q6G-4X-bVm" id="fXj-Ug-eSh"/>
                         <outlet property="mangoKiwiJuiceButton" destination="ngP-kF-Yii" id="ql1-wJ-bgJ"/>
                         <outlet property="pineappleJuiceButton" destination="BFb-ka-wGA" id="SLf-rE-EaM"/>
-                        <outlet property="strawberryBannaJuiceButton" destination="hrc-2F-fzl" id="5Xy-MX-Znq"/>
+                        <outlet property="strawberryBananaJuiceButton" destination="hrc-2F-fzl" id="5Xy-MX-Znq"/>
                         <outlet property="strawberryJuiceButton" destination="avd-o5-3JM" id="roH-DV-rXI"/>
                     </connections>
                 </viewController>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,174 @@
+# README(1) **쥬스 메이커**
+
+---
+
+### 1. 🍹 프로젝트 소개 (STEP 1)
+
+- JuiceMaker는 FruitStore의 과일을 이용해 juice를 제작합니다.
+- Juice별 Recipe에 따라 FruitStore의 과일 재고를 파악하고 재고가 충분할 때만 Juice를 제작할 수 있습니다.
+
+
+---
+
+### 2. 🧑‍🤝‍🧑 팀원
+
+
+|SummerCat|SunnyCookie|
+|------|---|
+|<img width="180px" src="https://i.imgur.com/TVKv7PD.png">|  <img width="180" src="https://i.imgur.com/z4FjnKX.png">
+
+---
+
+### 3. ✏️ 프로젝트 구조
+
+#### `FruitStore`
+- `FruitStore`는 `enum` 타입의 `Fruit`를 통해 취급하는 과일을 명시합니다.
+- 각 과일의 재고는 `[Fruit: Int]` 형태의 딕셔너리 `fruitStock` 프로퍼티에서 관리합니다.
+    ```swift=
+    private var fruitStock: Dictionary<Fruit, Int> = [
+            .strawberry : 10,
+            .banana : 10,
+            .pineapple : 10,
+            .kiwi : 10,
+            .mango : 10,
+        ]
+    ```
+    - `fruitStock` 딕셔너리 작성 시 마지막 Element 뒤에 `,`를 붙인 이유
+        - [구글의 Swift 컨벤션](https://google.github.io/swift/#braces)
+        - array와 dictionary의 각 element가 한 줄에 하나씩 작성되었을 경우, 뒤에 꼭 `,`를 붙여야 한다. 이렇게 해야 나중에 항목이 추가되었을 때 더 명확하게 차이를 알 수 있다.
+     ![](https://i.imgur.com/LXCgkly.png)
+      - 접근제어자를 `private`으로 설정한 이유: 과일가게의 과일의 재고 값을 외부에서 마음대로 바꾸지 못하도록 해야 한다고 생각해서 `private`을 사용해 `FruitStore` 내에서만 접근이 가능하도록 설정했습니다. 
+
+- `changeStockOf` 함수
+    - `FruitStore`가 가지고 있는 과일의 재고의 수량을 변경하는 함수입니다.
+    ```swift
+    func changeStockOf(fruit: Fruit, by quantity: Int) {
+            guard let currentStock = fruitStock[fruit] else {
+                return
+            }
+
+            fruitStock[fruit] = currentStock + quantity
+        }
+    ```
+    - `guard`문을 사용해 현재의 재고 수량을 옵셔널 바인딩 해서 `currentStock`에 넣은 후, 조정한 수량만큼 `fruitStock[fruit]`에 넣어줍니다.
+    - `fruitStock[fruit] = currentStock = quantity`에서 옵셔널 바인딩이 필요하지 않은 이유는, `fuitStock[fruit]`의 값이 존재하지 않더라도, `currentStock + quantity`의 값을 새로 할당해주기 때문입니다.
+
+-  `checkStockOf` 함수
+    - `JuiceMaker`가 요청한 과일의 수량을 확인하는 함수입니다.
+    - 요청이 들어온 과일이 존재하지 않을 경우, `noSuchFruit` 에러를 반환합니다.
+    - 요청이 들어온 과일의 수량이 부족할 경우, `stockShortage` 에러를 반환합니다.
+
+#### `JuiceMaker`
+- `JuiceMaker`는 `FruitStore`를 소유하기 위해 `fruitStore`라는 `FruitStore`의 인스턴스를 갖습니다.
+- `JuiceMaker`는 `enum` 타입의 `Juice`를 통해 취급하는 쥬스를 명시합니다. `enum` 타입 안에 `juiceName` 프로퍼티를 만들어 각 쥬스의 한글이름을 반환할 수 있도록 하고,  `recipe` 프로퍼티에 사용하는 과일과 갯수를 딕셔너리로 정리해 주었습니다.
+    - 딕셔너리를 사용해서 `recipe`를 작성한 이유: **고민한 부분**에 작성
+- `makeJuice` 메서드는 쥬스 제작이 가능한지 확인하기 위해 `checkFruitStore` 메서드를 통해 레시피에 맞는 과일갯수를 체크하고, 사용한 과일만큼 `useFruitStore` 메서드를 통해 `fruitStore`의 과일 재고를 조정합니다. 
+    - 이 과정중 do - try - catch 구문을 사용하여 error를 처리합니다.
+    - `JuiceMakerError`로 다운캐스팅 된 `error` 상수를 catch에서 정의해, `errorDescription`으로 에러 메시지를 불러옵니다.
+    - error가 catch 될 시에 음료제작을 중단하기 위해 return처리 됩니다. 
+- `checkFruitStore` 메서드는 `recipe`에서 필요한 과일의 개수와 `fruitStore`의 재고를 비교하기 위해 `FruitStore`의 `checkStockOf` 메서드를 이용합니다. `checkStockOf`에 과일의 종류와, 해당 과일의 필요한 총량을 전달합니다. 딕셔너리의 key값을 이용하기 위해 for - in 구문을 이용했습니다.
+    - `JuiceMaker`의 `changeStockOf`에서 던진 오류를 `checkFruitStore`에서 처리할 수도 있지만, 그렇게 작성할 경우 함수의 depth가 깊어져 가독성이 떨어진다고 판단해 오류를 한번 더 던져서 `makeJuice`에서 오류를 처리하도록 했습니다.
+
+- `useFruit` 메서드는 `fruitStore`의 과일의 재고를 조정합니다.
+
+
+#### `JuiceMakerError`
+- `JuiceMakerError`에서는 `Error` 프로토콜을 채택한 `enum`타입을 이용해 에러를 case별로 정리했습니다.
+- `extension`을 이용해 do-catch구문에서 에러메세지로 이용할 구문을 `errorDescription` 프로퍼티에 정리했습니다. 사용시에는 as로 다운캐스팅하여 `errorDescription`을 이용해 에러메세지를 출력할 수 있도록 하였습니다.
+    - `LocalizedError` 프로토콜에 이미 `errorDescription`이 구현되어 있지만 `LocalizedError`를 채택하지 않은 이유는, `LocalizedError`에 구현되어 있는 `errorDescription`의 반환값이 `String?`이기 때문입니다.
+    - 정의된 유형의 에러가 발생했을 때에만 `errorDescription`을 내보내는 방향으로 설계했기 때문에 옵셔널 타입으로 반환할 필요가 없다고 생각해, `String`을 반환하는 `errorDescription`을 `extension`에 새로 정의해서 사용했습니다.
+
+
+---
+
+### 4. 👩🏻‍💻 실행 화면(기능 설명)
+    
+| 코드 | 출력 |
+|------|---|
+|<img width="350" src="https://i.imgur.com/DuDhrbk.png"> |<img width="350" src="https://i.imgur.com/82VzY4r.png">|
+
+- `딸바쥬스`를 만들고 난 후`딸기`의 재고가 0이기 때문에, 이후에 `딸바쥬스`를 만들어달라고 요청한 경우 쥬스를 만들지 않고 `재고 부족` 메시지를 출력합니다.
+    - 이 때, 두 과일(`딸기`, `바나나`) 중 하나라도 재고가 부족한 경우 쥬스를 만들지 않고 두 과일의 재고 모두 조정되지 않습니다.
+
+---
+
+### 5. 🔥 트러블 슈팅
+
+#### `enum Juice` 타입에서 사용하는 과일의 종류, 갯수 연결하기
+열거형으로 정리한 쥬스타입의 case마다 레시피로 사용되는 각 과일의 갯수를 연관지어 지정해놓고 싶었습니다. 예를 들어, 딸기바나나쥬스는 딸기 10개 바나나 1개를 사용하기 때문에 `case 딸기바나나쥬스` 에는 딸기 10개, 바나나 1개를 연결하고 싶었습니다.
+- **시도1 : 연관값(Associated Values) 사용**
+    ```swift
+    case strawberryBananaJuice(strawberry: 10, banana: 1)
+    ```
+    - 연관값을 사용할 경우, 만들 쥬스를 고르기 위해 case를 불러올 때 연관값을 반드시 초기화(할당)해야 해서 최초에 할당한 연관값이 사용되지 않는 문제가 있었습니다.
+
+ - **시도2 : 튜플을 리턴해주는 메서드, 프로퍼티 사용**
+     ```swift
+        enum Juice {
+            case bananaJuice
+            case strawberryBananaJuice
+
+            var ingredient: (first: FruitStore.Fruit, second: FruitStore.Fruit?) {
+                switch self {
+               case .bananaJuice:
+                    return (.banana, nil)
+               case .strawberryBananaJuice:
+                    return (.strawberry, .banana)
+                }
+            }
+
+            func ingredientsCount() -> (first: Int, second: Int) {
+                switch self {
+                case .bananaJuice:
+                    return (2,0)
+                case .strawberryBananaJuice:
+                    return (10, 1)
+
+                }
+            }
+
+    //사용 시
+    let firstfruitType = Juice.ingredient.first 
+    let firstfruitCount = Juice.ingredients.first         
+    let secondfruitType = Juice.ingredient.second //옵셔널바인딩 포함
+    let secondruitCount = Juice.ingredients.socond       
+    ```
+    - 과일타입과 갯수를 튜플로 묶어 리턴하는 방법을 시도했지만, 과일이름과 갯수를 서로 다른 프로퍼티와 메서드에서 따로 리턴해주기 때문에 코드를 읽는 사람입장에서 어떤 과일이 몇개가 쓰이는지 연결짓기가 어려울 것 같다고 생각했습니다. 
+    - 한개의 튜플에 라벨을 달아 과일명과 갯수를 같이 넣어주는 방법도 있지만 튜플은 그 크기가 정해져있기에 과일을 한 개만 사용하는 쥬스와 두 개를 사용하는 쥬스를 프로퍼티(혹은 메서드)한 곳에 같이 담기가 어려워 사용하지 않았습니다.
+
+- **시도 3. 딕셔너리 타입을 리턴해주는 프로퍼티 사용**
+    ```swift
+     var recipe: Dictionary<FruitStore.Fruit, Int> {
+                switch self {
+                case .strawberryJuice:
+                    return [.strawberry: 16]
+                case .strawberryBananaJuice:
+                    return [.strawberry: 10, .banana: 1]
+                }
+     }
+    ```
+    - `recipe` 프로퍼티에 과일 종류와 개수를 딕셔너리로 반환시켜주는 컨셉을 채택했습니다. 과일 종류와 개수를 명확히 보여줄 수 있고, 그 크기도 정해져있지 않고 순서도 중요하지 않기 때문에 딕셔너리를 사용하는게 베스트라고 생각했습니다.
+
+---
+
+### 6. 👆🏻 추가로 수정해보고 싶은 내용
+#### `Recipe` 구현 방식 수정
+- [다른 조의 리뷰 내용](https://github.com/yagom-academy/ios-juice-maker/pull/248#discussion_r959716917)을 보니, `Recipe`를 dictionary가 아닌 tuple, struct, class 등 다른 타입으로 구현했을 때 어떤 장단점이 있을 지 생각해 보면 좋을 것 같다는 내용이 있었다. 
+- class나 struct로 구현해보면 좋을 것 같다는 생각이 들어서 STEP 2를 진행하면서 한번 도전해 보려고 한다!
+#### `makeJuice` 메서드의 반환값 설정
+- 현재는 반환값이 없는 함수인데, STEP 2의 내용을 확인해보니 쥬스 만들기 성공/실패에 따른 반환값이 필요해 보인다. 크게 `Result` 타입을 반환하는 방법, `Bool` 타입을 반환하는 방법 두 가지가 있을 것 같다.
+#### 아직 해결되지 않은 고민
+- `enum Juice`와 `enum Fruit`를 각각 `JuiceMaker`와 `FruitStore`안에 정의했는데, 처음에는 각 쥬스 메이커와 과일 가게가 그 타입을 소유한다고 생각해서 그렇게 작성했었다(공부해야 할 내용에 `Nested Type`이 있기도 했고).
+- `enum Juice`와 `enum Fruit`을 분리해서 별도의 파일에 정의하는 것이 좋을까??? 리뷰어님한테 질문해보자..!
+
+---
+
+### 7. 🔗 참고 링크
+
+- [Swift Language Guide - Access Control
+](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html)
+- [Swift Language Guide - Nested Types
+](https://docs.swift.org/swift-book/LanguageGuide/NestedTypes.html)
+- [Swift Language Guide - Enumerations](https://docs.swift.org/swift-book/LanguageGuide/Enumerations.html)
+- [Swift Language Guide - Error Handling](https://docs.swift.org/swift-book/LanguageGuide/ErrorHandling.html)
+


### PR DESCRIPTION
@SungPyo
웨더 안녕하세요! 
STEP2 PR드립니다!
조금이라도 "왜 이렇게 썼지?" 라는 생각이 드시는 부분이 있다면 코멘트로 남겨주세요!
질책도 환영합니다 🙇🏻‍♀️🥊 

---

## 1. 프로젝트 구성

사용자가 쥬스를 주문하는 버튼을 누르면, `ViewController`의 `orderJuice` 메서드에서 `makeJuice`를 호출합니다. `makeJuice`가 반환한 결과값이 `.success`일 경우 성공 alert을 화면에 표시하고, `.failure`일 경우 오류 메시지를 출력합니다.
  - 이 과정에서 기존에 `JuiceMaker`에 구현한 `makeJuice`의 반환 타입을 `Void`에서 `Result<String, Error>`로 변경하고, `JuiceMakerError`의 `errorDescription`을 제조 실패 시 alert에 출력할 메시지로 변경하였습니다. `Result<String, Error>`로 변경한 이유는 `.success`에서 전달한 문자열을 그대로 성공 alert의 `message`로 전달해 사용하고, `.falure`일 경우 전달받은 `error`의 `errorDescription`을 실패 alert의 `message`로 전달해 사용하기 위해서 입니다.

```swift
func makeJuice(_ juice: Juice, total: Int) -> Result<String, Error> {
    do {
        try checkFruitStore(for: juice, total: total)
        useFruit(juice, total: total)
        return .success("\(juice.juiceName) 나왔습니다! 맛있게 드세요!")
    } catch let error as JuiceMakerError {
        return .failure(error)
    } catch {
        return .failure(error)
    }
}
```

```swift
extension JuiceMakerError {
    var errorDescription: String {
        switch self {
        case .stockShortage:
            return "재료가 모자라요. 재고를 수정할까요?"
        }
    }
}
```
쥬스를 성공적으로 제조한 경우, `viewDidLoad()` 메서드를 호출해 화면에 보이는 과일의 잔여 재고 수량을 갱신합니다. 쥬스 제조에 실패한 경우에는 갱신하지 않습니다.
```swift=
switch result {
    case .success(let message):
        showSuccessAlert(message: message)
        viewDidLoad()
    case .failure(let error):
        guard let juiceMakerError = error as? JuiceMakerError else {
            return showFailureAlert(message: error.localizedDescription)
        }
            
        showFailureAlert(message: juiceMakerError.errorDescription)
}
```

---

## 2. 실행 예시
<img width = 500, src = "https://i.imgur.com/Dn6hyiB.gif" >

사용자가 쥬스 주문 버튼을 탭 하면
- **쥬스 레시피별 과일 재고 있을 때** : 
제작 완료 alert을 띄운 후 사용량 만큼 과일의 재고 감소를 반영합니다.
- **쥬스 레시피별 과일 재고 부족할 때** : 
재료 부족 alert을 띄운 후 재고수정을 원하는지 물어봅니다. `아니오` 버튼을 탭하면 alert이 닫히고, `예` 버튼을 탭하면 재고수정 뷰로 이동합니다. 

<img width = 500, src = "https://i.imgur.com/yihXfid.gif" >

사용자가 재고수정 버튼을 탭하면 재고수정 뷰로 이동합니다.

---

## 3. 고민한 부분

### 3-1 `재고수정` 버튼을 통해 `재고 추가` 화면으로 이동할 때, 내비게이션 방식과 모달 방식 중 어느 것을 쓸 것인가?

`내비게이션 방식`은 현재 화면의 연장선상으로 세부사항을 열어보거나 다음 step으로 넘어갈 때 사용합니다.
`모달 방식`은 지금 화면에서 조금 벗어나 잠시 다른 일을 처리하거나, 연장선을 벗어나 새로운 갈래로 나갈 때 사용합니다.

쥬스를 주문하는 현재 화면에서 재고를 변경해주는 화면으로 이동할 때는 쥬스 주문과는 별개로 잠시 연장선상을 벗어나 다른 일을 처리한 후 돌아온다고 생각하여 화면 전환 방식으로 모달 방식을 채택했습니다. 

### 3-2 과일 재고의 개수를 메인 `ViewController`와 `FruitStockViewController`간에 공유하게 하는 방법

검색을 통해 프로퍼티로 직접 전달하는 방법, delegation을 이용하는 방법 등 다양한 방법이 있다는 것을 알게 되었지만, 활동학습 시간에 배운 Singleton Pattern을 이용하기로 했습니다.

그 이유는 이 프로젝트가 매우 단순한 구조의 프로젝트이기 때문이기도 하고, 현재 구조체로 정의되어 있는 `JuiceMaker`가 프로퍼티로 클래스 `FruitStore`의 인스턴스를 `private`으로 가지고 있었기 때문에, 클래스로 되어있는 `FruitStore`에 싱글톤 패턴을 적용하는 편이 낫다고 생각했습니다.
`FruitStore`에 싱글톤 패턴을 적용할 경우, `JuiceMaker`, `ViewController`, `FruitStockViewController`에서 모두 하나의 인스턴스에 접근이 가능하기 때문입니다.
(현재는 step2 요구사항에 `FruitStockViewController`에 재고 수량을 반영하는 부분이 기재되어 있지 않아 그 부분은 구현하지 않았습니다.)

### 3-3 `UILabel`과 `UIButton`을 다룰 때, 코드에서 중복되는 부분을 줄일 방법

처음에는 각 `label`과 `button`을 일일이 직접 매핑하거나 `switch case`로 구분하도록 작성했었습
니다. 하지만 두 가지 경우 모두 각 케이스마다 중복되는 코드가 많아 중복되는 코드를 줄일 방법을 고민(구글링)해 보았고, 아래의 글을 참고해 개선해 보았습니다.
(참고: https://stackoverflow.com/questions/52548196/shorten-long-switch-case)

`label`의 경우, `.text = String(FruitStore.sharedFruitStore.fetchStockOf(.strawberry))`부분이 `.strawberry`라는 과일 값만 빼고는 모두 똑같이 중복되고 있습니다.

```swift
// 최초에 작성한 코드 - label을 일일이 매핑
strawberryStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.strawberry))
        bananaStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.banana))
        pineappleStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.pineapple))
        kiwiStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.kiwi))
        mangoStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.mango))
```


아래와 같이 `[UILabel: Fruit]` 딕셔너리를 생성하고, `for-in`을 사용해 딕셔너리를 순회하면서 값을 `label`에 넣어주도록 수정해 보았습니다.


```swift
// 최종 수정한 코드
let fruitLabel: [UILabel: Fruit] = [
    strawberryStockLabel: .strawberry,
    bananaStockLabel: .banana,
    pineappleStockLabel: .pineapple,
    kiwiStockLabel: .kiwi,
    mangoStockLabel: .mango,
    ]
        
    for (label, fruit) in fruitLabel {
    label.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
    }
```

`button`을 식별해서 `switch case`를 이용해 `juiceMaker.makeJuice(Juice, total: Int)`에 넣어주는 부분 역시 `makeJuice` 메서드를 호출해서 `result`에 넣어주는 부분이 반복되고 있었습니다.

```swift
// 최초에 작성한 코드 - button을 switch case로 구분
 @IBAction func orderJuice(sender: UIButton) {
    switch sender {
        case strawberryBananaJuiceButton:
            result = juiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
        case mangoKiwiJuiceButton:
            result = juiceMaker.makeJuice(.mangoKiwiJuice, total: 1)
        case strawberryJuiceButton:
            result = juiceMaker.makeJuice(.strawberryJuice, total: 1)
        case bananaJuiceButton:
            result = juiceMaker.makeJuice(.bananaJuice, total: 1)
        case pineappleJuiceButton:
            result = juiceMaker.makeJuice(.pineappleJuice, total: 1)
        case kiwiJuiceButton:
            result = juiceMaker.makeJuice(.kiwiJuice, total: 1)
        case mangoJuiceButton:
            result = juiceMaker.makeJuice(.mangoJuice, total: 1)
        default:
            return
        }
     ...
 }
```

이 부분도 아래와 같이 `[UIButton: Juice]` 딕셔너리를 생성하고, `juiceButton[sender]`의 값을 `juice`에 할당해 옵셔널 바인딩 해주니 `result`를 생성하는 `makeJuice()` 메서드를 한 번만 호출하도록 개선할 수 있었습니다.

```swift
 @IBAction func orderJuice(sender: UIButton) {
    let juiceButton: [UIButton: Juice] = [
        strawberryBananaJuiceButton: .strawberryBananaJuice,
        mangoKiwiJuiceButton: .mangoKiwiJuice,
        strawberryJuiceButton: .strawberryJuice,
        bananaJuiceButton: .bananaJuice,
        pineappleJuiceButton: .pineappleJuice,
        kiwiJuiceButton: .kiwiJuice,
        mangoJuiceButton: .mangoJuice,
        ]

    guard let juice = juiceButton[sender] else { return }

    let result = juiceMaker.makeJuice(juice, total: 1)
    ...
 }
```

---

## 4. 궁금한 점

### 4-1 ViewController의 함수에 접근제어를 설정

ViewController에 구현한 함수에도 접근제어를 설정해야 하는지 고민했습니다.

ViewController 파일에서 `showSuccessAlert(message:)`, `showFailureAlert(message:)`, `moveToFruitStockVC()` 와 같은 함수들과 화면과 연동되어있는 `@IBAction 함수`, `@IBOulet 프로퍼티` 도 `private`으로 처리를 해줘야 하는지 궁금합니다.

`private`으로 설정해도 시뮬레이션은 정상 작동됨을 확인했는데, 뷰 컨트롤러 내부의 요소들에 접근 제어를 설정하는 것이 불필요한 사항인지 필수사항인지 개념이 잡히지 않아 현재는 접근 제어를 설정하지 않고 PR드렸습니다..

### 4-2 화면 전환 방식 (함수가 구현되어있을 때 segue를 이용하는지)

화면을 전환하는 함수가 구현되어 있어도 segue를 이용하시는지 궁금합니다.

이번 step2에서는 모달 view로 넘어가는 경로가 두 개였습니다. 첫 번째는 `재고수정` 버튼을 눌렀을때이고 두 번째는 쥬스제조시 재고가 부족하다는 alert에서 `예`를 눌렀을 때입니다.

`예`를 눌렀을 경우를 위해 화면전환 함수를 코드로 구현했는데, 이럴 때 `재고수정` 버튼에도 같은 함수를 이용해 통일을 하는게 나을지 segue 방식을 사용해도 되는지 현업에서는 어떻게 하는지 궁금합니다.