### PR TITLE
쥬스 메이커 [STEP 2] Ash, 미니

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -8,13 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		1859B77428C6D6A00065AA2A /* ModifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1859B77328C6D6A00065AA2A /* ModifyViewController.swift */; };
+		1859B77628C732310065AA2A /* AlertMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1859B77528C732310065AA2A /* AlertMessages.swift */; };
 		18DBC91328BDEFE40024DC1F /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DBC91228BDEFE40024DC1F /* Juice.swift */; };
 		18DBC91528BDEFFC0024DC1F /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DBC91428BDEFFC0024DC1F /* Fruit.swift */; };
 		18DBC91728BDF0130024DC1F /* StoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DBC91628BDF0130024DC1F /* StoreError.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
+		C73DAF3B255D0CDD00020D38 /* JuiceMakerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */; };
 		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
@@ -23,6 +24,7 @@
 
 /* Begin PBXFileReference section */
 		1859B77328C6D6A00065AA2A /* ModifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyViewController.swift; sourceTree = "<group>"; };
+		1859B77528C732310065AA2A /* AlertMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertMessages.swift; sourceTree = "<group>"; };
 		18DBC91228BDEFE40024DC1F /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
 		18DBC91428BDEFFC0024DC1F /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		18DBC91628BDF0130024DC1F /* StoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreError.swift; sourceTree = "<group>"; };
@@ -30,7 +32,7 @@
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C73DAF3A255D0CDD00020D38 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMakerViewController.swift; sourceTree = "<group>"; };
 		C73DAF3D255D0CDD00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -54,7 +56,7 @@
 			children = (
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
-				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */,
 				1859B77328C6D6A00065AA2A /* ModifyViewController.swift */,
 			);
 			path = Controller;
@@ -68,6 +70,7 @@
 				18DBC91228BDEFE40024DC1F /* Juice.swift */,
 				18DBC91428BDEFFC0024DC1F /* Fruit.swift */,
 				18DBC91628BDF0130024DC1F /* StoreError.swift */,
+				1859B77528C732310065AA2A /* AlertMessages.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -182,7 +185,8 @@
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				18DBC91328BDEFE40024DC1F /* Juice.swift in Sources */,
 				18DBC91728BDF0130024DC1F /* StoreError.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				C73DAF3B255D0CDD00020D38 /* JuiceMakerViewController.swift in Sources */,
+				1859B77628C732310065AA2A /* AlertMessages.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				18DBC91528BDEFFC0024DC1F /* Fruit.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1859B77428C6D6A00065AA2A /* ModifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1859B77328C6D6A00065AA2A /* ModifyViewController.swift */; };
 		1859B77628C732310065AA2A /* AlertMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1859B77528C732310065AA2A /* AlertMessages.swift */; };
+		1859B77928C7346E0065AA2A /* Notification+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1859B77828C7346E0065AA2A /* Notification+.swift */; };
 		18DBC91328BDEFE40024DC1F /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DBC91228BDEFE40024DC1F /* Juice.swift */; };
 		18DBC91528BDEFFC0024DC1F /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DBC91428BDEFFC0024DC1F /* Fruit.swift */; };
 		18DBC91728BDF0130024DC1F /* StoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DBC91628BDF0130024DC1F /* StoreError.swift */; };
@@ -25,6 +26,7 @@
 /* Begin PBXFileReference section */
 		1859B77328C6D6A00065AA2A /* ModifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyViewController.swift; sourceTree = "<group>"; };
 		1859B77528C732310065AA2A /* AlertMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertMessages.swift; sourceTree = "<group>"; };
+		1859B77828C7346E0065AA2A /* Notification+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+.swift"; sourceTree = "<group>"; };
 		18DBC91228BDEFE40024DC1F /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
 		18DBC91428BDEFFC0024DC1F /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		18DBC91628BDF0130024DC1F /* StoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreError.swift; sourceTree = "<group>"; };
@@ -51,6 +53,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1859B77728C734640065AA2A /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				1859B77828C7346E0065AA2A /* Notification+.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		C71CD66D266C7B470038B9CB /* Controller */ = {
 			isa = PBXGroup;
 			children = (
@@ -104,6 +114,7 @@
 		C73DAF35255D0CDD00020D38 /* JuiceMaker */ = {
 			isa = PBXGroup;
 			children = (
+				1859B77728C734640065AA2A /* Extensions */,
 				C71CD66D266C7B470038B9CB /* Controller */,
 				C71CD66F266C7B500038B9CB /* Model */,
 				C71CD671266C7B570038B9CB /* View */,
@@ -183,6 +194,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
+				1859B77928C7346E0065AA2A /* Notification+.swift in Sources */,
 				18DBC91328BDEFE40024DC1F /* Juice.swift in Sources */,
 				18DBC91728BDF0130024DC1F /* StoreError.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* JuiceMakerViewController.swift in Sources */,

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1859B77428C6D6A00065AA2A /* ModifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1859B77328C6D6A00065AA2A /* ModifyViewController.swift */; };
 		18DBC91328BDEFE40024DC1F /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DBC91228BDEFE40024DC1F /* Juice.swift */; };
 		18DBC91528BDEFFC0024DC1F /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DBC91428BDEFFC0024DC1F /* Fruit.swift */; };
 		18DBC91728BDF0130024DC1F /* StoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DBC91628BDF0130024DC1F /* StoreError.swift */; };
@@ -21,6 +22,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1859B77328C6D6A00065AA2A /* ModifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyViewController.swift; sourceTree = "<group>"; };
 		18DBC91228BDEFE40024DC1F /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
 		18DBC91428BDEFFC0024DC1F /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		18DBC91628BDF0130024DC1F /* StoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreError.swift; sourceTree = "<group>"; };
@@ -53,6 +55,7 @@
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				1859B77328C6D6A00065AA2A /* ModifyViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -183,6 +186,7 @@
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				18DBC91528BDEFFC0024DC1F /* Fruit.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
+				1859B77428C6D6A00065AA2A /* ModifyViewController.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -19,11 +19,11 @@ class JuiceMakerViewController: UIViewController {
 		receiveStockChangedNoti()
 	}
 	
-	func receiveStockChangedNoti() {
+	private func receiveStockChangedNoti() {
 		NotificationCenter.default.addObserver(
 			self,
 			selector: #selector(didChangeStocks(noti:)),
-			name: NSNotification.Name("stockChanged"),
+			name: Notification.Name.stockChanged,
 			object: nil
 		)
 	}
@@ -35,7 +35,7 @@ class JuiceMakerViewController: UIViewController {
 		setUpStockLabels(changedStocks: stocks)
 	}
 	
-	func setUpStockLabels(changedStocks: [Fruit: Int]) {
+	private func setUpStockLabels(changedStocks: [Fruit: Int]) {
 		[
 			strawberryStockLabel,
 			bananaStockLabel,
@@ -58,7 +58,7 @@ class JuiceMakerViewController: UIViewController {
 		showAlertController(isSuccess: result, juice: orderedJuice)
 	}
 	
-	func showAlertController(isSuccess: Bool, juice: Juice) {
+	private func showAlertController(isSuccess: Bool, juice: Juice) {
 		let titleMessage = isSuccess ? AlertMessages.successTitle : AlertMessages.failureTitle
 		let message = isSuccess ? "\(juice.description) \(AlertMessages.successMessage)" : AlertMessages.failureMessage
 		let confirmMessage = isSuccess ? AlertMessages.successConfirmMessage : AlertMessages.failureConfirmMessage
@@ -67,7 +67,7 @@ class JuiceMakerViewController: UIViewController {
 		
 		let okAction = UIAlertAction(title: confirmMessage, style: .default) { _ in
 			if !isSuccess {
-				self.performSegue(withIdentifier: "presentModify", sender: nil)
+				self.performSegue(withIdentifier: ModifyViewController.identifier, sender: nil)
 			}
 		}
 		

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -16,6 +16,7 @@ class JuiceMakerViewController: UIViewController {
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
+        setUpStockLabels(changedStocks: Fruit.beginningStock)
 		receiveStockChangedNoti()
 	}
 	
@@ -55,21 +56,21 @@ class JuiceMakerViewController: UIViewController {
 			return
 		}
 		let result = maker.makeJuice(juice: orderedJuice)
-		showAlertController(isSuccess: result, juice: orderedJuice)
+        showAlertControllerBased(on: result, of: orderedJuice)
 	}
 	
-	private func showAlertController(isSuccess: Bool, juice: Juice) {
-		let titleMessage = isSuccess ? AlertMessages.successTitle : AlertMessages.failureTitle
-		let message = isSuccess ? "\(juice.description) \(AlertMessages.successMessage)" : AlertMessages.failureMessage
-		let confirmMessage = isSuccess ? AlertMessages.successConfirmMessage : AlertMessages.failureConfirmMessage
+	private func showAlertControllerBased(on isMaked: Bool, of juice: Juice) {
+		let titleMessage = isMaked ? AlertMessages.successTitle : AlertMessages.failureTitle
+		let message = isMaked ? "\(juice.description) \(AlertMessages.successMessage)" : AlertMessages.failureMessage
+		let confirmMessage = isMaked ? AlertMessages.successConfirmMessage : AlertMessages.failureConfirmMessage
 		let alertController = UIAlertController(title: titleMessage, message: message, preferredStyle: .alert)
 		let okAction = UIAlertAction(title: confirmMessage, style: .default) { _ in
-			if !isSuccess {
+			if !isMaked {
 				self.performSegue(withIdentifier: ModifyViewController.identifier, sender: nil)
 			}
 		}
 		
-		if isSuccess {
+		if isMaked {
 			alertController.addAction(okAction)
 		} else {
 			let cancelAction = UIAlertAction(title: AlertMessages.failureCancelMessage, style: .default)

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -1,11 +1,11 @@
 //
-//  JuiceMaker - ViewController.swift
+//  JuiceMakerViewController - JuiceMakerViewController.swift
 //  Created by Ash, 미니.
 // 
 
 import UIKit
 
-class ViewController: UIViewController {
+class JuiceMakerViewController: UIViewController {
 	private let maker = JuiceMaker()
 	
 	@IBOutlet weak var strawberryStockLabel: UILabel!
@@ -16,6 +16,10 @@ class ViewController: UIViewController {
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
+		receiveStockChangedNoti()
+	}
+	
+	func receiveStockChangedNoti() {
 		NotificationCenter.default.addObserver(
 			self,
 			selector: #selector(didChangeStocks(noti:)),
@@ -55,10 +59,9 @@ class ViewController: UIViewController {
 	}
 	
 	func showAlertController(isSuccess: Bool, juice: Juice) {
-		let titleMessage = isSuccess ? "주문 완료" : "주문 불가"
-		let message = isSuccess ? "\(juice.description) 나왔습니다! 맛있게 드세요!" : "재료가 모자라요. 재고를 수정할까요?"
-		let confirmMessage = isSuccess ? "확인" : "예"
-		let cancelMessage = isSuccess ? "" : "아니요"
+		let titleMessage = isSuccess ? AlertMessages.successTitle : AlertMessages.failureTitle
+		let message = isSuccess ? "\(juice.description) \(AlertMessages.successMessage)" : AlertMessages.failureMessage
+		let confirmMessage = isSuccess ? AlertMessages.successConfirmMessage : AlertMessages.failureConfirmMessage
 		
 		let alertController = UIAlertController(title: titleMessage, message: message, preferredStyle: .alert)
 		
@@ -67,11 +70,11 @@ class ViewController: UIViewController {
 				self.performSegue(withIdentifier: "presentModify", sender: nil)
 			}
 		}
-		let cancelAction = UIAlertAction(title: cancelMessage, style: .default)
 		
 		if isSuccess {
 			alertController.addAction(okAction)
 		} else {
+			let cancelAction = UIAlertAction(title: AlertMessages.failureCancelMessage, style: .default)
 			alertController.addAction(cancelAction)
 			alertController.addAction(okAction)
 		}

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -62,9 +62,7 @@ class JuiceMakerViewController: UIViewController {
 		let titleMessage = isSuccess ? AlertMessages.successTitle : AlertMessages.failureTitle
 		let message = isSuccess ? "\(juice.description) \(AlertMessages.successMessage)" : AlertMessages.failureMessage
 		let confirmMessage = isSuccess ? AlertMessages.successConfirmMessage : AlertMessages.failureConfirmMessage
-		
 		let alertController = UIAlertController(title: titleMessage, message: message, preferredStyle: .alert)
-		
 		let okAction = UIAlertAction(title: confirmMessage, style: .default) { _ in
 			if !isSuccess {
 				self.performSegue(withIdentifier: ModifyViewController.identifier, sender: nil)

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -66,7 +66,7 @@ class JuiceMakerViewController: UIViewController {
 		let alertController = UIAlertController(title: titleMessage, message: message, preferredStyle: .alert)
 		let okAction = UIAlertAction(title: confirmMessage, style: .default) { _ in
 			if !isMaked {
-				self.performSegue(withIdentifier: ModifyViewController.identifier, sender: nil)
+                self.presentModiftController()
 			}
 		}
 		
@@ -80,4 +80,12 @@ class JuiceMakerViewController: UIViewController {
 		
 		present(alertController, animated: true)
 	}
+    
+    @IBAction func didTapEditButton(_ sender: UIButton) {
+        presentModiftController()
+    }
+    
+    func presentModiftController() {
+        self.performSegue(withIdentifier: ModifyViewController.identifier, sender: nil)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
@@ -1,0 +1,20 @@
+//
+//  ModifyViewController.swift
+//  JuiceMaker
+//
+//  Created by 이경민 on 2022/09/06.
+//
+
+import UIKit
+
+class ModifyViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+	
+	@IBAction func didTapDismissButton(_ sender: UIBarButtonItem) {
+		dismiss(animated: true)
+	}
+}
+

--- a/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
@@ -6,6 +6,8 @@
 import UIKit
 
 class ModifyViewController: UIViewController {
+	static let identifier = "presentModify"
+	
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
@@ -16,4 +16,3 @@ class ModifyViewController: UIViewController {
 		dismiss(animated: true)
 	}
 }
-

--- a/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ModifyViewController: UIViewController {
+class ModifyViewController: UINavigationController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 class ModifyViewController: UIViewController {
-	static let identifier = "presentModify"
+	static let identifier = "presentModifyViewController"
 	
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
@@ -1,8 +1,6 @@
 //
-//  ModifyViewController.swift
-//  JuiceMaker
-//
-//  Created by 이경민 on 2022/09/06.
+//  ModifyViewController - ModifyViewController.swift
+//  Created by Ash, 미니.
 //
 
 import UIKit

--- a/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyViewController.swift
@@ -7,8 +7,7 @@
 
 import UIKit
 
-class ModifyViewController: UINavigationController {
-
+class ModifyViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/JuiceMaker/JuiceMaker/Controller/SceneDelegate.swift
+++ b/JuiceMaker/JuiceMaker/Controller/SceneDelegate.swift
@@ -13,4 +13,3 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let _ = (scene as? UIWindowScene) else { return }
     }
 }
-

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -7,7 +7,6 @@ import UIKit
 
 class ViewController: UIViewController {
 	private let maker = JuiceMaker()
-	private let shared = FruitStore.shared
 	
 	@IBOutlet weak var strawberryStockLabel: UILabel!
 	@IBOutlet weak var bananaStockLabel: UILabel!
@@ -17,10 +16,20 @@ class ViewController: UIViewController {
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		setUpStockLabels()
+		NotificationCenter.default.addObserver(self,
+											   selector: #selector(didChangeStocks(noti:)),
+											   name: NSNotification.Name("stockChanged"),
+											   object: nil)
 	}
 	
-	func setUpStockLabels() {
+	@objc func didChangeStocks(noti: Notification) {
+		guard let stocks = noti.userInfo as? [Fruit: Int] else {
+			return
+		}
+		setUpStockLabels(changedStocks: stocks)
+	}
+	
+	func setUpStockLabels(changedStocks: [Fruit: Int]) {
 		[
 			strawberryStockLabel,
 			bananaStockLabel,
@@ -28,8 +37,9 @@ class ViewController: UIViewController {
 			kiwiStockLabel,
 			mangoStockLabel,
 		].compactMap { $0 }.forEach {
-			if let fruit = Fruit(rawValue: $0.tag) {
-				$0.text = shared.inventory[fruit]?.description
+			if let fruit = Fruit(rawValue: $0.tag),
+			   let stock = changedStocks[fruit]?.description {
+				$0.text = stock
 			}
 		}
 	}
@@ -39,6 +49,5 @@ class ViewController: UIViewController {
 			return
 		}
 		maker.makeJuice(juice: orderedJuice)
-		setUpStockLabels()
 	}
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -16,10 +16,12 @@ class ViewController: UIViewController {
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		NotificationCenter.default.addObserver(self,
-											   selector: #selector(didChangeStocks(noti:)),
-											   name: NSNotification.Name("stockChanged"),
-											   object: nil)
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(didChangeStocks(noti:)),
+			name: NSNotification.Name("stockChanged"),
+			object: nil
+		)
 	}
 	
 	@objc func didChangeStocks(noti: Notification) {
@@ -49,5 +51,31 @@ class ViewController: UIViewController {
 			return
 		}
 		maker.makeJuice(juice: orderedJuice)
+		showAlertController(isSuccess: false, juice: orderedJuice)
+	}
+	
+	func showAlertController(isSuccess: Bool, juice: Juice) {
+		let titleMessage = isSuccess ? "주문 완료" : "주문 불가"
+		let message = isSuccess ? "\(juice.description) 나왔습니다! 맛있게 드세요!" : "재료가 모자라요. 재고를 수정할까요?"
+		let confirmMessage = isSuccess ? "확인" : "예"
+		let cancelMessage = isSuccess ? "" : "아니요"
+		
+		let alertController = UIAlertController(title: titleMessage, message: message, preferredStyle: .alert)
+		
+		let okAction = UIAlertAction(title: confirmMessage, style: .default) { action in
+			if !isSuccess {
+				print("is Not Success")
+			}
+		}
+		let cancelAction = UIAlertAction(title: cancelMessage, style: .default)
+		
+		if isSuccess {
+			alertController.addAction(okAction)
+		} else {
+			alertController.addAction(cancelAction)
+			alertController.addAction(okAction)
+		}
+		
+		present(alertController, animated: true)
 	}
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -7,9 +7,31 @@ import UIKit
 
 class ViewController: UIViewController {
 	private let maker = JuiceMaker()
+	private let shared = FruitStore.shared
+	
+	@IBOutlet weak var strawberryStockLabel: UILabel!
+	@IBOutlet weak var bananaStockLabel: UILabel!
+	@IBOutlet weak var pineAppleStockLabel: UILabel!
+	@IBOutlet weak var kiwiStockLabel: UILabel!
+	@IBOutlet weak var mangoStockLabel: UILabel!
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
+		setUpStockLabels()
+	}
+	
+	func setUpStockLabels() {
+		[
+			strawberryStockLabel,
+			bananaStockLabel,
+			pineAppleStockLabel,
+			kiwiStockLabel,
+			mangoStockLabel,
+		].compactMap { $0 }.forEach {
+			if let fruit = Fruit(rawValue: $0.tag) {
+				$0.text = shared.inventory[fruit]?.description
+			}
+		}
 	}
 	
 	@IBAction func didTapJuiceButton(_ sender: UIButton) {
@@ -17,5 +39,6 @@ class ViewController: UIViewController {
 			return
 		}
 		maker.makeJuice(juice: orderedJuice)
+		setUpStockLabels()
 	}
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -62,9 +62,9 @@ class ViewController: UIViewController {
 		
 		let alertController = UIAlertController(title: titleMessage, message: message, preferredStyle: .alert)
 		
-		let okAction = UIAlertAction(title: confirmMessage, style: .default) { action in
+		let okAction = UIAlertAction(title: confirmMessage, style: .default) { _ in
 			if !isSuccess {
-				print("is Not Success")
+				self.performSegue(withIdentifier: "presentModify", sender: nil)
 			}
 		}
 		let cancelAction = UIAlertAction(title: cancelMessage, style: .default)

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -50,8 +50,8 @@ class ViewController: UIViewController {
 		guard let orderedJuice = Juice(rawValue: sender.tag) else {
 			return
 		}
-		maker.makeJuice(juice: orderedJuice)
-		showAlertController(isSuccess: false, juice: orderedJuice)
+		let result = maker.makeJuice(juice: orderedJuice)
+		showAlertController(isSuccess: result, juice: orderedJuice)
 	}
 	
 	func showAlertController(isSuccess: Bool, juice: Juice) {

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -11,4 +11,11 @@ class ViewController: UIViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 	}
+	
+	@IBAction func didTapJuiceButton(_ sender: UIButton) {
+		guard let orderedJuice = Juice(rawValue: sender.tag) else {
+			return
+		}
+		maker.makeJuice(juice: orderedJuice)
+	}
 }

--- a/JuiceMaker/JuiceMaker/Extensions/Notification+.swift
+++ b/JuiceMaker/JuiceMaker/Extensions/Notification+.swift
@@ -1,12 +1,10 @@
 //
 //  Notification+.swift
-//  JuiceMaker
-//
-//  Created by 이경민 on 2022/09/06.
+//  Created by Ash, 미니.
 //
 
 import Foundation
 
 extension Notification.Name {
-	static let stockChanged = NSNotification.Name("stockChanged")
+	static let stockChanged = Notification.Name("stockChanged")
 }

--- a/JuiceMaker/JuiceMaker/Extensions/Notification+.swift
+++ b/JuiceMaker/JuiceMaker/Extensions/Notification+.swift
@@ -1,0 +1,12 @@
+//
+//  Notification+.swift
+//  JuiceMaker
+//
+//  Created by 이경민 on 2022/09/06.
+//
+
+import Foundation
+
+extension Notification.Name {
+	static let stockChanged = NSNotification.Name("stockChanged")
+}

--- a/JuiceMaker/JuiceMaker/Model/AlertMessages.swift
+++ b/JuiceMaker/JuiceMaker/Model/AlertMessages.swift
@@ -1,0 +1,16 @@
+//
+//  AlertMessages.swift
+//  JuiceMaker
+//
+//  Created by 이경민 on 2022/09/06.
+//
+
+enum AlertMessages {
+	static let successTitle: String = "주문 완료"
+	static let failureTitle: String = "주문 완료"
+	static let successMessage: String = "나왔습니다! 맛있게 드세요!"
+	static let failureMessage: String = "재료가 모자라요. 재고를 수정할까요?"
+	static let successConfirmMessage: String = "확인"
+	static let failureConfirmMessage: String = "예"
+	static let failureCancelMessage: String = "아니오"
+}

--- a/JuiceMaker/JuiceMaker/Model/AlertMessages.swift
+++ b/JuiceMaker/JuiceMaker/Model/AlertMessages.swift
@@ -1,13 +1,11 @@
 //
 //  AlertMessages.swift
-//  JuiceMaker
-//
-//  Created by 이경민 on 2022/09/06.
+//  Created by Ash, 미니.
 //
 
 enum AlertMessages {
 	static let successTitle: String = "주문 완료"
-	static let failureTitle: String = "주문 완료"
+	static let failureTitle: String = "주문 오류"
 	static let successMessage: String = "나왔습니다! 맛있게 드세요!"
 	static let failureMessage: String = "재료가 모자라요. 재고를 수정할까요?"
 	static let successConfirmMessage: String = "확인"

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -4,7 +4,7 @@
 //
 
 enum Fruit: Int, CaseIterable {
-	case strawberry = 0
+	case strawberry
 	case banana
 	case pineapple
 	case kiwi

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -3,8 +3,8 @@
 //  Created by Ash, 미니.
 //
 
-enum Fruit: CaseIterable {
-	case strawberry
+enum Fruit: Int, CaseIterable {
+	case strawberry = 0
 	case banana
 	case pineapple
 	case kiwi

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -4,8 +4,9 @@
 //
 
 // 과일 저장소 타입
-class FruitStore {
-	private var inventory: [Fruit: Int] = Fruit.beginningStock
+final class FruitStore {
+	static var shared = FruitStore()
+	var inventory: [Fruit: Int] = Fruit.beginningStock
 	
 	func haveStock(for juice: Juice) throws {
 		let needFruitAndStock = juice.needFruitAndStock

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -3,10 +3,18 @@
 //  Created by Ash, 미니.
 //
 
+import Foundation
+
 // 과일 저장소 타입
 final class FruitStore {
-	static var shared = FruitStore()
-	var inventory: [Fruit: Int] = Fruit.beginningStock
+//	static var shared = FruitStore()
+	var inventory: [Fruit: Int] = Fruit.beginningStock {
+		didSet {
+			NotificationCenter.default.post(name: NSNotification.Name("stockChanged"),
+											object: nil,
+											userInfo: inventory)
+		}
+	}
 	
 	func haveStock(for juice: Juice) throws {
 		let needFruitAndStock = juice.needFruitAndStock

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -6,9 +6,8 @@
 import Foundation
 
 // 과일 저장소 타입
-final class FruitStore {
-//	static var shared = FruitStore()
-	var inventory: [Fruit: Int] = Fruit.beginningStock {
+class FruitStore {
+	private var inventory: [Fruit: Int] = Fruit.beginningStock {
 		didSet {
 			NotificationCenter.default.post(name: NSNotification.Name("stockChanged"),
 											object: nil,

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -9,7 +9,7 @@ import Foundation
 class FruitStore {
 	private var inventory: [Fruit: Int] = Fruit.beginningStock {
 		didSet {
-			NotificationCenter.default.post(name: NSNotification.Name("stockChanged"),
+			NotificationCenter.default.post(name: Notification.Name.stockChanged,
 											object: nil,
 											userInfo: inventory)
 		}

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -3,11 +3,11 @@
 //  Created by Ash, 미니.
 //
 
-enum Juice: CaseIterable {
-	case strawberryJuice
+enum Juice: Int, CaseIterable {
+	case strawberryJuice = 0
 	case bananaJuice
-	case kiwiJuice
 	case pineappleJuice
+	case kiwiJuice
 	case mangoJuice
 	case strawberrybananaJuice
 	case mangokiwiJuice

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -4,7 +4,7 @@
 //
 
 enum Juice: Int, CaseIterable {
-	case strawberryJuice = 0
+	case strawberryJuice
 	case bananaJuice
 	case pineappleJuice
 	case kiwiJuice

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -30,4 +30,23 @@ enum Juice: Int, CaseIterable {
 			return [.mango: -2, .kiwi: -1]
 		}
 	}
+	
+	var description: String {
+		switch self {
+		case .strawberryJuice:
+			return "딸기 주스"
+		case .bananaJuice:
+			return "바나나 주스"
+		case .pineappleJuice:
+			return "파인애플 주스"
+		case .kiwiJuice:
+			return "키위 주스"
+		case .mangoJuice:
+			return "망고 주스"
+		case .strawberrybananaJuice:
+			return "딸기 바나나 주스"
+		case .mangokiwiJuice:
+			return "망고 키위 주스"
+		}
+	}
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,14 +7,14 @@
 struct JuiceMaker {
 	private let fruitStore = FruitStore()
 	
-	func makeJuice(juice: Juice) {
+	func makeJuice(juice: Juice) -> Bool {
 		do {
 			try fruitStore.haveStock(for: juice)
-			print("\(juice) 완성되었습니다.")
+			return true
 		} catch StoreError.outOfStock {
-			print("재고가 부족합니다.")
+			return false
 		} catch {
-			print("알 수 없는 오류가 발생하였습니다.")
+			return false
 		}
 	}
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,11 +5,11 @@
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
-	private let shared = FruitStore.shared
+	private let fruitStore = FruitStore()
 	
 	func makeJuice(juice: Juice) {
 		do {
-			try shared.haveStock(for: juice)
+			try fruitStore.haveStock(for: juice)
 			print("\(juice) 완성되었습니다.")
 		} catch StoreError.outOfStock {
 			print("재고가 부족합니다.")

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -10,6 +10,7 @@ struct JuiceMaker {
 	func makeJuice(juice: Juice) {
 		do {
 			try fruitStore.haveStock(for: juice)
+			print("\(juice) 완성되었습니다.")
 		} catch StoreError.outOfStock {
 			print("재고가 부족합니다.")
 		} catch {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,11 +5,11 @@
 
 // 쥬스 메이커 타입
 struct JuiceMaker {
-	private let fruitStore: FruitStore = FruitStore()
+	private let shared = FruitStore.shared
 	
 	func makeJuice(juice: Juice) {
 		do {
-			try fruitStore.haveStock(for: juice)
+			try shared.haveStock(for: juice)
 			print("\(juice) 완성되었습니다.")
 		} catch StoreError.outOfStock {
 			print("재고가 부족합니다.")

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="JuiceMakerViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="WwV-Td-3Bn" kind="presentation" id="l5G-As-Opg"/>
+                                <segue destination="WwV-Td-3Bn" kind="presentation" id="Xc3-Ya-Fxb"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -377,12 +377,12 @@
                             </stepper>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r">
-                        <barButtonItem key="rightBarButtonItem" title="닫기" style="done" id="PTi-0H-sBb">
+                        <barButtonItem key="rightBarButtonItem" title="닫기" style="plain" id="i1U-sB-jSs">
                             <connections>
-                                <action selector="didTapDismissButton:" destination="Yu1-lM-nqp" id="Tmx-z7-jgA"/>
+                                <action selector="didTapDismissButton:" destination="Yu1-lM-nqp" id="env-Y6-luH"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -396,7 +396,6 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationItem key="navigationItem" id="g97-Jv-eab"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -408,7 +407,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2s5-lS-967" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1367" y="91"/>
+            <point key="canvasLocation" x="1366" y="92"/>
         </scene>
     </scenes>
     <resources>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -215,7 +215,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
+                            <connections>
+                                <segue destination="WwV-Td-3Bn" kind="presentation" id="5Yv-Fa-aiJ"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -240,10 +244,10 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--View Controller-->
+        <!--Modify View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ModifyViewController" id="Yu1-lM-nqp" customClass="ModifyViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -347,7 +351,13 @@
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <navigationItem key="navigationItem" id="g4W-fY-l7r">
+                        <barButtonItem key="rightBarButtonItem" title="닫기" style="done" id="PTi-0H-sBb">
+                            <connections>
+                                <action selector="didTapDismissButton:" destination="Yu1-lM-nqp" id="Tmx-z7-jgA"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="WwV-Td-3Bn" kind="presentation" identifier="presentModify" id="Xc3-Ya-Fxb"/>
+                                <action selector="didTapEditButton:" destination="BYZ-38-t0r" id="P0E-FK-RAZ"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -248,6 +248,7 @@
                         <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="0eh-fV-fiv"/>
                         <outlet property="pineAppleStockLabel" destination="ccQ-Dk-PuY" id="2O5-de-V4a"/>
                         <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="Gsp-UA-3qL"/>
+                        <segue destination="WwV-Td-3Bn" kind="presentation" identifier="presentModifyViewController" id="ceU-jM-LXb"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -396,6 +397,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
+                    <navigationItem key="navigationItem" id="HaJ-8y-woV"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -119,25 +119,31 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
                                         <rect key="frame" x="0.0" y="0.0" width="724" height="66"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                            <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
                                                 <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="VDi-a5-xlP"/>
+                                                </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
                                                 <rect key="frame" x="296" y="0.0" width="132" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                            <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
                                                 <rect key="frame" x="444" y="0.0" width="280" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="didTapJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bYI-lo-V3z"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -154,38 +160,53 @@
                                                         <state key="normal" title="딸기쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="didTapJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="lNJ-za-yZZ"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="didTapJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wil-Cj-qck"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="didTapJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mrk-8g-XB2"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="didTapJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JsB-4E-c59"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                    <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="didTapJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wHI-5y-Ieb"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                             </stackView>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -30,7 +30,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -48,7 +48,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -66,7 +66,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -84,7 +84,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -102,7 +102,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -30,7 +30,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -48,7 +48,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -66,7 +66,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -84,7 +84,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -102,7 +102,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="WwV-Td-3Bn" kind="presentation" id="Xc3-Ya-Fxb"/>
+                                <segue destination="WwV-Td-3Bn" kind="presentation" identifier="presentModify" id="Xc3-Ya-Fxb"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -48,7 +48,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -66,7 +66,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -84,7 +84,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -102,7 +102,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -238,10 +238,17 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="WwV-Td-3Bn" kind="presentation" id="5Yv-Fa-aiJ"/>
+                                <segue destination="WwV-Td-3Bn" kind="presentation" id="l5G-As-Opg"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="m7v-z2-Cqd"/>
+                        <outlet property="kiwiStockLabel" destination="FZq-de-TJG" id="RcE-ra-tTz"/>
+                        <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="0eh-fV-fiv"/>
+                        <outlet property="pineAppleStockLabel" destination="ccQ-Dk-PuY" id="2O5-de-V4a"/>
+                        <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="Gsp-UA-3qL"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
@@ -389,6 +396,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
+                    <navigationItem key="navigationItem" id="g97-Jv-eab"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@
 |<a href="https://github.com/ash-youu"> <center>*@ash-youu*</center></a> | <a href="https://github.com/leegyoungmin"> <center>*@leegyoungmin*</center></a>|
 
 ## 🔖 2. 순서도
-![flowCharts](https://i.imgur.com/r5klH3I.png)
+![flowChart-Step1](https://i.imgur.com/279L9Qw.png)
+
+![flowChart-Step2](https://i.imgur.com/XOEMRv9.png)
+
 
 ## ⏱ 3. 타임라인
 <!-- : 시간 순으로 프로젝트의 주요 진행 척도를 표시 -->
@@ -26,21 +29,47 @@
 	- 공식문서 학습
 
 - **2022.08.30**
+  - STEP1 구현
     ![CommitList](https://i.imgur.com/DaHEL9t.png)
 
 - **2022.08.31**
     - PR 발송 및 공식문서 학습
 
 - **2022.09.01**
-    - `README.md` 작성 및 공식문서 학습
+    - STEP1 `README.md` 작성 및 공식문서 학습
+
+- **2022.09.02**
+  - 추가적인 리뷰에 대한 수정
+    ![CommitList2](https://i.imgur.com/KWYwkEU.png)
+    
+- **2022.09.05**
+    - iOS UI 앱개발 학습
+
+- **2022.09.06**
+    - STEP2 구현
+    ![CommitList3](https://i.imgur.com/PGrs2ex.png)
+
+- **2022.09.07**
+    - STEP2 `README.md` 작성 및 PR 발송
 
 ## 💻 4. 실행 화면(기능 설명)
 ### 📌 STEP 1
 - 쥬스메이커로 `makeJuice(juice:)` 함수 실행
-
-    ![viewController_Code](https://i.imgur.com/IDm4RGe.png)
-
-    ![viewController_Result](https://i.imgur.com/Dm5BJ4s.png)
+    ```swift
+    class ViewController: UIViewController {
+        private let maker = JuiceMaker()
+        
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            
+            for _ in 1...20 {
+                if let juice = Juice.allCases.randomElement() {
+                    maker.makeJuice(juice: juice)
+                }
+            }
+        }
+    }
+    ```
 - `makeJuice(juice:)` 및 `haveStock(of:, over:)`,`increaseStock(of:, by:)` 설명
     ```swift
     func makeJuice(juice: Juice) {
@@ -61,7 +90,6 @@
     - 이 함수는 주스를 만드는 명령을 내리는 함수입니다.
     - 이 함수의 기능은 창고에 재고가 있는지 확인 후 있다고 판단했을 경우에만 창고의 재료를 가져와 음료를 만들 도록 설계하였습니다.
     - 만약, 재고가 없거나 부족한 경우에는 에러를 발생시키도록 하였습니다.
-    
     ```swift
 	func haveStock(of fruits: [Fruit], over stocks: [Int]) throws {
 		for (fruit, stock) in zip(fruits, stocks)  {
@@ -71,6 +99,7 @@
 		}
     }
 	```
+	
     - `haveStock(of:, over:)`은 주스를 만들기 위해서 필요한 재고가 있는지 확인하는 함수입니다.
     - 이 함수를 활용하여서 재고가 없는 경우에 에러를 발생시키도록 구현하였습니다.
     - 만약, 재고가 있다면 함수는 종료되게 되어, 에러를 발생시키지 않기 때문에 `makeJuice(juice:)`함수의 다음 구문이 실행되게 됩니다.
@@ -84,22 +113,90 @@
         }
     }
     ```
-    
     - `increaseStock(of:, by:)`은 재고가 있는 주스를 생성하기 위해서 재료를 꺼내오는 과정을 표현한 함수입니다.
     - 주스에 필요한 재료들과 양을 통해서 현재 창고의 재고를 줄이는 역할을 담당하게 됩니다.
     - 또한, 이는 양수의 값이 들어오게 되면, 재고를 증가시키는 함수로도 활용할 수 있습니다.
-
-
-
+    
 ### 📌 STEP 2
+![FirstScreenGif](https://i.imgur.com/PpPOtS8.gif)
+
+- 음료 주문 및 이를 통해서 변경된 재고에 대한 값 반영
+- 각 버튼은 각각의 음료를 주문하는 버튼이다.
+- 이 버튼을 누르게 되면, 주스를 만들 수 있는 재고를 확인한 후 주스를 만들게 된다.
+- 이때, 주스를 만들고 난 후에는 필요한 재고들을 감소시키게 된다.
+- 또한, 화면에 보여지는 데이터도 바로 업데이트가 된다.
+
 ### 📌 STEP 3
+
 ## 🚀 5. 트러블 슈팅
 ### 📌 STEP 1
+- `makeJuice()` 에서 juice별 함수 호출에 대한 문제
+  - 가변 매개변수를 활용하는 방법과 리스트를 반환하는 방법
+ 
+    ```swift
+    // Before
+    func makeJuice(juice: Juice) {
+         switch juice {
+            ...
+         case .strawberrybananaJuice:
+             if fruitStore.checkStock(fruit: .strawberry, stock: -10) &&
+                 fruitStore.checkStock(fruit: .banana, stock: -1) {
+                 fruitStore.changeStock(fruits: .strawberry, .banana, stocks: -10, -1)
+             }
+         case .mangokiwiJuice:
+             if fruitStore.checkStock(fruit: .mango, stock: -2) &&
+                 fruitStore.checkStock(fruit: .kiwi, stock: -1) {
+                 fruitStore.changeStock(fruits: .mango, .kiwi, stocks: -2, -1)
+             }
+         }
+     }
+
+    // After
+    func makeJuice(juice: Juice) {
+        let juiceNeedFruits = juice.needFruits
+        let juiceNeedStocks = juice.needStocks
+
+        do {
+        try fruitStore.haveStock(of: juiceNeedFruits, over: juiceNeedStocks)
+        fruitStore.increaseStock(of: juiceNeedFruits, by: juiceNeedStocks)
+        } catch StoreError.outOfStock {
+            print("재고가 부족합니다.")
+        } catch {
+            print("알 수 없는 오류가 발생하였습니다.")
+        }
+    }
+    ```
+  - Before과 같이 호출 시 `juice`의 케이스 별로 `haveStock()`과 `increaseStock()`을 각각 호출해줘야 하여 코드의 중복도가 높아지는 문제가 있었습니다.
+  - `Juice` 타입에서 주스 별로 필요한 과일(`needFruits`)과 수량(`needStocks`)을 선언하여  `needFruitAndStock: [Fruit: Int]`의 Dictionary 타입을 `haveStock()`과 `increaseStock()` 내부에서 활용하는 방향으로 수정하였습니다.
+
 ### 📌 STEP 2
+- 객체의 싱글톤화에 대한 고민
+    - 싱글톤의 장점에는 한 번의 Instance만 생성하여서 메모리 낭비를 방지할 수 있습니다. 또한, 다른 자원들과 공유가 쉽다는 장점이 있습니다.
+    - 싱글톤 사용이 절대적으로 장점만 있는 것은 아닙니다. 예를 들어서 메서드의 변경이 이루어 질때 마다 수정을 해야 하는 부분이 많이 생긴다던지, 많은 데이터를 공유할 경우 다른 클래스의 Instance들 간 결합도가 높아지게 됩니다.
+    - 다양한 조건과 프로젝트의 방향성에 대한 논의를 하여서 확장성을 생각하였을 때, 추가적인 창고 Instance가 생성되고, 1호점, 2호점 등과 같은 확장에서 결합도가 높아질 것이라고 판단하여서 싱글톤을 사용하는 것보다는 `JuiceMaker` 타입이 `FruitStore` 타입을 소유하고 있도록 하였습니다.
+
+- NotificationCenter 활용 시 프로퍼티 초기값 설정이 불가한 문제
+    ```swift
+    class FruitStore {
+	    private var inventory: [Fruit: Int] = Fruit.beginningStock {
+		    didSet {
+			    NotificationCenter.default.post(
+                            name: Notification.Name.stockChanged,
+                            object: nil,
+                            userInfo: inventory
+                        )
+		    }
+	      }
+    }
+    ```
+  - `FruitStore`의 `inventory` 값 변화를 프로퍼티 감시자(`didSet`) 내에 NotificationCenter를 사용해 `JuiceMakerViewController`에 전달하는 방식을 사용했습니다.
+  - 이와 같이 진행 시 `inventory` 값이 변할 때에만 NotificationCenter에 `post`하게 되어 `맛있는 쥬스를 만들어 드려요!` View에서 초기값의 반영이 어려운 문제가 있었습니다.
+  - 앱이 새로 켜질 때마다 과일의 수량은 모두 10으로 초기화되기 때문에 View 내에서 과일별 `StockLabel`을 10으로 설정하고, 이후 `inventory`의 값이 변경될 때마다 `didSet`을 통해 `StockLabel.text`가 수정될 수 있도록 했습니다.
+
 ### 📌 STEP 3
+
 ## 📎 6. 참고 링크
-[Swift Language Guide - Functions](https://docs.swift.org/swift-book/LanguageGuide/Functions.html)
-
-[Swift Language Guide - Enumerations](https://docs.swift.org/swift-book/LanguageGuide/Enumerations.html)
-
-[Swift Language Guide - Properties](https://docs.swift.org/swift-book/LanguageGuide/Properties.html)
+- [Swift Language Guide - Functions](https://docs.swift.org/swift-book/LanguageGuide/Functions.html)
+- [Swift Language Guide - Enumerations](https://docs.swift.org/swift-book/LanguageGuide/Enumerations.html)
+- [Swift Language Guide - Properties](https://docs.swift.org/swift-book/LanguageGuide/Properties.html)
+- [왕초보를 위한 iOS 앱개발](https://yagom.net/courses/ios-starter-uikit/)


### PR DESCRIPTION
안녕하세요~ 제임스(@inwoodev)
저희가 오토레이아웃과 화면전환에 대해서 공부를 하다보니까 조금 늦게 보내게 되었네요.
어제 말씀드린 부분과 추가적으로 고민한 부분 담아서 PR 보냅니다! 😃😃😃

고민되었던 부분
- 객체의 싱글톤화에 대한 고민
    - 싱글톤의 장점에는 한 번의 Instance만 생성하여서 메모리 낭비를 방지할 수 있습니다. 또한, 다른 자원들과 공유가 쉽다는 장점이 있습니다.
    - 싱글톤 사용이 절대적으로 장점만 있는 것은 아닙니다. 예를 들어서 메서드의 변경이 이루어 질때 마다 수정을 해야 하는 부분이 많이 생긴다던지, 많은 데이터를 공유할 경우 다른 클래스의 Instance들 간 결합도가 높아지게 됩니다.
    - 다양한 조건과 프로젝트의 방향성에 대한 논의를 하여서 확장성을 생각하였을 때, 추가적인 창고 Instance가 생성되고, 1호점, 2호점 등과 같은 확장에서 결합도가 높아질 것이라고 판단하여서 싱글톤을 사용하는 것보다는 `JuiceMaker` 타입이 `FruitStore` 타입을 소유하고 있도록 하였습니다.

- NotificationCenter 활용 시 프로퍼티 초기값 설정이 불가한 문제
    ```swift
    class FruitStore {
	    private var inventory: [Fruit: Int] = Fruit.beginningStock {
		    didSet {
			    NotificationCenter.default.post(
                            name: Notification.Name.stockChanged,
                            object: nil,
                            userInfo: inventory
                        )
		    }
	      }
    }
    ```
  - `FruitStore`의 `inventory` 값 변화를 프로퍼티 감시자(`didSet`) 내에 NotificationCenter를 사용해 `JuiceMakerViewController`에 전달하는 방식을 사용했습니다.
  - 이와 같이 진행 시 `inventory` 값이 변할 때에만 NotificationCenter에 `post`하게 되어 `맛있는 쥬스를 만들어 드려요!` View에서 초기값의 반영이 어려운 문제가 있었습니다.
  - 앱이 새로 켜질 때마다 과일의 수량은 모두 10으로 초기화되기 때문에 View 내에서 과일별 `StockLabel`을 10으로 설정하고, 이후 `inventory`의 값이 변경될 때마다 `didSet`을 통해 `StockLabel.text`가 수정될 수 있도록 했습니다.
- '재고 추가' 화면으로의 이동 방식
  - Modality와 Navigation 중 어떤 방식으로 화면을 전환해야 할지 고민했습니다. 논의 결과, 재고 추가 화면은 depth를 생성하여 계층적 구조를 나타내는 navigation 방식보다는 기존 쥬스 메이커 화면은 백그라운드에 유지한 채 새로운 화면을 덮는 방식이 더 적절하다고 생각하여 Modality 방식으로 화면을 전환하도록 하였습니다.