### PR TITLE
쥬스 메이커 [Step3] Kyo, 하모

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
+		C73DAF3B255D0CDD00020D38 /* JuiceMakerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */; };
 		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
@@ -32,7 +32,7 @@
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C73DAF3A255D0CDD00020D38 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMakerViewController.swift; sourceTree = "<group>"; };
 		C73DAF3D255D0CDD00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -56,7 +56,7 @@
 			children = (
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
-				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				C73DAF3A255D0CDD00020D38 /* JuiceMakerViewController.swift */,
 				3CDD8D3028C1A6DE00FEE905 /* ModifyStockViewController.swift */,
 			);
 			path = Controller;
@@ -188,7 +188,7 @@
 				3CDD8D3128C1A6DE00FEE905 /* ModifyStockViewController.swift in Sources */,
 				0C89C5FD28C0455C00AAB7CC /* ConstantNameSpace.swift in Sources */,
 				3C32E55028BC73DC00340932 /* Juice.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				C73DAF3B255D0CDD00020D38 /* JuiceMakerViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class JuiceMakerViewController: UIViewController {
     var juiceMaker = JuiceMaker()
     private var fruitLabel: [Fruit : UILabel] = [:]
     
@@ -35,7 +35,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func orderButtonTapped(_ sender: UIButton) {
-        guard let orderedJuice = Juice.findJuiceButtonLocation(tag: sender.tag) else {
+        guard let orderedJuice = Juice.findJuiceButtonTag(location: sender.tag) else {
             return
         }
                 
@@ -85,7 +85,10 @@ class ViewController: UIViewController {
     
     private func setNavigationBar() {
         self.title = ConstantSentence.mainTitle
-        self.navigationController?.navigationBar.backgroundColor = UIColor(red: 242/255, green: 242/255, blue: 242/255, alpha: 1.0)
+        self.navigationController?.navigationBar.backgroundColor = UIColor(red: 242/255,
+                                                                           green: 242/255,
+                                                                           blue: 242/255,
+                                                                           alpha: 1.0)
     }
     
     private func setFruitStockLabelText() {
@@ -96,7 +99,7 @@ class ViewController: UIViewController {
     }
 }
 
-extension ViewController: ModifyStockDelegate {
+extension JuiceMakerViewController: ModifyStockDelegate {
     func changeFruitStock(_ changedStock: [Fruit : Int]) {
         juiceMaker.passingChangedFruitStock(changedStock)
         setFruitStockLabelText()

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -9,13 +9,8 @@ import UIKit
 
 class ModifyStockViewController: UIViewController {
     var fruitStock: [Fruit : Int] = [:]
-    lazy var fruitUIAttribute: [Fruit : (label: UILabel, stepper: UIStepper, isChange: Bool)] =
-                                                     [.strawberry : (strawberryStockLabel, strawberryStepper, false),
-                                                      .banana : (bananaStockLabel, bananaStepper, false),
-                                                      .pineapple : (pineappleStockLabel, pineappleStepper, false),
-                                                      .kiwi : (kiwiStockLabel, kiwiStepper, false),
-                                                      .mango : (mangoStockLabel, mangoStepper, false)]
-
+    private var fruitUIAttribute: [Fruit : (label: UILabel, stepper: UIStepper, isChange: Bool)] = [:]
+                                                     
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
     @IBOutlet weak var pineappleStockLabel: UILabel!
@@ -31,12 +26,14 @@ class ModifyStockViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBar()
+        setFruitUIAttribute()
         setFruitStockLabel()
         setStepperValue()
     }
     
     @IBAction func stepperTapped(_ sender: UIStepper) {
-        guard let changeFruit = Fruit(rawValue: sender.tag) else {
+        let buttonLocation = sender.tag
+        guard let changeFruit = Fruit(rawValue: buttonLocation) else {
             return
         }
         
@@ -46,7 +43,6 @@ class ModifyStockViewController: UIViewController {
     
     @IBAction func saveButtonTapped(_ sender: Any) {
         var changeFruitStock: [Fruit : Int] = [:]
-        
         for (key, value) in fruitUIAttribute {
             guard value.isChange else {
                 continue
@@ -63,18 +59,26 @@ class ModifyStockViewController: UIViewController {
         dismiss(animated: true)
     }
     
-    func setNavigationBar() {
+    private func setFruitUIAttribute() {
+        fruitUIAttribute = [.strawberry : (strawberryStockLabel, strawberryStepper, false),
+                            .banana : (bananaStockLabel, bananaStepper, false),
+                            .pineapple : (pineappleStockLabel, pineappleStepper, false),
+                            .kiwi : (kiwiStockLabel, kiwiStepper, false),
+                            .mango : (mangoStockLabel, mangoStepper, false)]
+    }
+    
+    private func setNavigationBar() {
         self.title = ConstantSentence.modifyStockTitle
         self.navigationController?.navigationBar.backgroundColor = UIColor(red: 242/255, green: 242/255, blue: 242/255, alpha: 1.0)
     }
     
-    func setFruitStockLabel() {
+    private func setFruitStockLabel() {
         for (key, value) in fruitUIAttribute {
             value.label.text = String(fruitStock[key, default: ConstantUsageFruit.invalidFruit])
         }
     }
     
-    func setStepperValue() {
+    private func setStepperValue() {
         for (key, value) in fruitUIAttribute {
             value.stepper.value = Double(fruitStock[key, default: ConstantUsageFruit.invalidFruit])
         }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -37,8 +37,7 @@ class ModifyStockViewController: UIViewController {
     }
     
     @IBAction func stepperTapped(_ sender: UIStepper) {
-        let buttonLocation = sender.tag
-        guard let changeFruit = Fruit(rawValue: buttonLocation) else {
+        guard let changeFruit = Fruit.findFruiteStepperTag(location: sender.tag) else {
             return
         }
         
@@ -74,7 +73,10 @@ class ModifyStockViewController: UIViewController {
     
     private func setNavigationBar() {
         self.title = ConstantSentence.modifyStockTitle
-        self.navigationController?.navigationBar.backgroundColor = UIColor(red: 242/255, green: 242/255, blue: 242/255, alpha: 1.0)
+        self.navigationController?.navigationBar.backgroundColor = UIColor(red: 242/255,
+                                                                           green: 242/255,
+                                                                           blue: 242/255,
+                                                                           alpha: 1.0)
     }
     
     private func setFruitStockLabel() {

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -13,8 +13,6 @@ class ModifyStockViewController: UIViewController {
         super.viewDidLoad()
     }
     
-    
-    
     @IBAction func cancelButtonTapped(_ sender: Any) {
         dismiss(animated: true)
     }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -22,12 +22,11 @@ class ModifyStockViewController: UIViewController {
     @IBOutlet weak var kiwiStepper: UIStepper!
     @IBOutlet weak var mangoStepper: UIStepper!
     
-    lazy var fruitLabel: [(label: UILabel, stepper: UIStepper)] = [(strawberryStockLabel, strawberryStepper),
-        (bananaStockLabel, bananaStepper),
-        (pineappleStockLabel, pineappleStepper),
-        (kiwiStockLabel, kiwiStepper),
-        (mangoStockLabel, mangoStepper),
-        ]
+    lazy var fruitLabel: [Fruit : (label: UILabel, isChange: Bool)] = [.strawberry : (strawberryStockLabel, false),
+                                                                       .banana : (bananaStockLabel, false),
+                                                                       .pineapple : (pineappleStockLabel, false),
+                                                                       .kiwi : (kiwiStockLabel, false),
+                                                                       .mango : (mangoStockLabel, false)]
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -37,7 +36,26 @@ class ModifyStockViewController: UIViewController {
     }
     
     @IBAction func stepperTapped(_ sender: UIStepper) {
-        fruitLabel[sender.tag].label.text = Int(sender.value).description
+        guard let changeFruit = Fruit(rawValue: sender.tag) else {
+            return
+        }
+        
+        fruitLabel[changeFruit]?.label.text = Int(sender.value).description
+        fruitLabel[changeFruit]?.isChange = true
+    }
+    
+    @IBAction func saveButtonTapped(_ sender: Any) {
+        var changeFruitStock: [Fruit : Int] = [:]
+        
+        for (key, value) in fruitLabel {
+            guard value.isChange else {
+                continue
+            }
+            
+            changeFruitStock[key] = Int(value.label.text ?? String(ConstantUsageFruit.invalidFruit))
+        }
+        NotificationCenter.default.post(name: Notification.Name.stock, object: nil, userInfo: changeFruitStock)
+        dismiss(animated: true)
     }
     
     @IBAction func cancelButtonTapped(_ sender: Any) {

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -7,9 +7,14 @@
 
 import UIKit
 
+protocol ModifyStockDelegate: AnyObject {
+    func changeFruitStock(_ changedStock: [Fruit : Int])
+}
+
 class ModifyStockViewController: UIViewController {
     var fruitStock: [Fruit : Int] = [:]
     private var fruitUIAttribute: [Fruit : (label: UILabel, stepper: UIStepper, isChange: Bool)] = [:]
+    weak var delegate: ModifyStockDelegate?
                                                      
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
@@ -51,7 +56,7 @@ class ModifyStockViewController: UIViewController {
             changeFruitStock[key] = Int(value.label.text ?? String(ConstantUsageFruit.invalidFruit))
         }
         
-        NotificationCenter.default.post(name: Notification.Name.stock, object: nil, userInfo: changeFruitStock)
+        delegate?.changeFruitStock(changeFruitStock)
         dismiss(animated: true)
     }
     
@@ -83,8 +88,4 @@ class ModifyStockViewController: UIViewController {
             value.stepper.value = Double(fruitStock[key, default: ConstantUsageFruit.invalidFruit])
         }
     }
-}
-
-extension Notification.Name {
-    static let stock = Notification.Name("stock")
 }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class ModifyStockViewController: UIViewController {
     var fruitStock: [Fruit : Int] = [:]
-    lazy var fruitLabel: [Fruit : (label: UILabel, stepper: UIStepper, isChange: Bool)] =
+    lazy var fruitUIAttribute: [Fruit : (label: UILabel, stepper: UIStepper, isChange: Bool)] =
                                                      [.strawberry : (strawberryStockLabel, strawberryStepper, false),
                                                       .banana : (bananaStockLabel, bananaStepper, false),
                                                       .pineapple : (pineappleStockLabel, pineappleStepper, false),
@@ -40,14 +40,14 @@ class ModifyStockViewController: UIViewController {
             return
         }
         
-        fruitLabel[changeFruit]?.label.text = Int(sender.value).description
-        fruitLabel[changeFruit]?.isChange = true
+        fruitUIAttribute[changeFruit]?.label.text = Int(sender.value).description
+        fruitUIAttribute[changeFruit]?.isChange = true
     }
     
     @IBAction func saveButtonTapped(_ sender: Any) {
         var changeFruitStock: [Fruit : Int] = [:]
         
-        for (key, value) in fruitLabel {
+        for (key, value) in fruitUIAttribute {
             guard value.isChange else {
                 continue
             }
@@ -69,13 +69,13 @@ class ModifyStockViewController: UIViewController {
     }
     
     func setFruitStockLabel() {
-        for (key, value) in fruitLabel {
+        for (key, value) in fruitUIAttribute {
             value.label.text = String(fruitStock[key, default: ConstantUsageFruit.invalidFruit])
         }
     }
     
     func setStepperValue() {
-        for (key, value) in fruitLabel {
+        for (key, value) in fruitUIAttribute {
             value.stepper.value = Double(fruitStock[key, default: ConstantUsageFruit.invalidFruit])
         }
     }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 class ModifyStockViewController: UIViewController {
+    var fruitStock: [Fruit : Int] = [:]
     
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
@@ -15,9 +16,28 @@ class ModifyStockViewController: UIViewController {
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
     
+    @IBOutlet weak var strawberryStepper: UIStepper!
+    @IBOutlet weak var bananaStepper: UIStepper!
+    @IBOutlet weak var pineappleStepper: UIStepper!
+    @IBOutlet weak var kiwiStepper: UIStepper!
+    @IBOutlet weak var mangoStepper: UIStepper!
+    
+    lazy var fruitLabel: [(label: UILabel, stepper: UIStepper)] = [(strawberryStockLabel, strawberryStepper),
+        (bananaStockLabel, bananaStepper),
+        (pineappleStockLabel, pineappleStepper),
+        (kiwiStockLabel, kiwiStepper),
+        (mangoStockLabel, mangoStepper),
+        ]
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBar()
+        settingFruitStockLabel()
+        settingStepperValue()
+    }
+    
+    @IBAction func stepperTapped(_ sender: UIStepper) {
+        fruitLabel[sender.tag].label.text = Int(sender.value).description
     }
     
     @IBAction func cancelButtonTapped(_ sender: Any) {
@@ -29,4 +49,23 @@ class ModifyStockViewController: UIViewController {
         self.navigationController?.navigationBar.backgroundColor = .lightGray
     }
     
+    func settingFruitStockLabel() {
+        strawberryStockLabel.text = String(fruitStock[.strawberry, default: ConstantUsageFruit.invalidFruit])
+        bananaStockLabel.text = String(fruitStock[.banana, default: ConstantUsageFruit.invalidFruit])
+        pineappleStockLabel.text = String(fruitStock[.pineapple, default: ConstantUsageFruit.invalidFruit])
+        kiwiStockLabel.text = String(fruitStock[.kiwi, default: ConstantUsageFruit.invalidFruit])
+        mangoStockLabel.text = String(fruitStock[.mango, default: ConstantUsageFruit.invalidFruit])
+    }
+    
+    func settingStepperValue() {
+        strawberryStepper.value = Double(fruitStock[.strawberry, default: ConstantUsageFruit.invalidFruit])
+        bananaStepper.value = Double(fruitStock[.banana, default: ConstantUsageFruit.invalidFruit])
+        pineappleStepper.value = Double(fruitStock[.pineapple, default: ConstantUsageFruit.invalidFruit])
+        kiwiStepper.value = Double(fruitStock[.kiwi, default: ConstantUsageFruit.invalidFruit])
+        mangoStepper.value = Double(fruitStock[.mango, default: ConstantUsageFruit.invalidFruit])
+    }
+}
+
+extension Notification.Name {
+    static let stock = Notification.Name("stock")
 }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -11,10 +11,16 @@ class ModifyStockViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setNavigationBar()
     }
     
     @IBAction func cancelButtonTapped(_ sender: Any) {
         dismiss(animated: true)
+    }
+    
+    func setNavigationBar() {
+        self.title = ConstantSentence.modifyStockTitle
+        self.navigationController?.navigationBar.backgroundColor = .lightGray
     }
     
 }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -8,7 +8,13 @@
 import UIKit
 
 class ModifyStockViewController: UIViewController {
-
+    
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var mangoStockLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBar()

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -2,14 +2,20 @@
 //  ModifyStockViewController.swift
 //  JuiceMaker
 //
-//  Created by parkhyo on 2022/09/02.
+//  Created by Kyo, Hamo on 2022/09/02.
 //
 
 import UIKit
 
 class ModifyStockViewController: UIViewController {
     var fruitStock: [Fruit : Int] = [:]
-    
+    lazy var fruitLabel: [Fruit : (label: UILabel, stepper: UIStepper, isChange: Bool)] =
+                                                     [.strawberry : (strawberryStockLabel, strawberryStepper, false),
+                                                      .banana : (bananaStockLabel, bananaStepper, false),
+                                                      .pineapple : (pineappleStockLabel, pineappleStepper, false),
+                                                      .kiwi : (kiwiStockLabel, kiwiStepper, false),
+                                                      .mango : (mangoStockLabel, mangoStepper, false)]
+
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
     @IBOutlet weak var pineappleStockLabel: UILabel!
@@ -22,17 +28,11 @@ class ModifyStockViewController: UIViewController {
     @IBOutlet weak var kiwiStepper: UIStepper!
     @IBOutlet weak var mangoStepper: UIStepper!
     
-    lazy var fruitLabel: [Fruit : (label: UILabel, isChange: Bool)] = [.strawberry : (strawberryStockLabel, false),
-                                                                       .banana : (bananaStockLabel, false),
-                                                                       .pineapple : (pineappleStockLabel, false),
-                                                                       .kiwi : (kiwiStockLabel, false),
-                                                                       .mango : (mangoStockLabel, false)]
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBar()
-        settingFruitStockLabel()
-        settingStepperValue()
+        setFruitStockLabel()
+        setStepperValue()
     }
     
     @IBAction func stepperTapped(_ sender: UIStepper) {
@@ -54,6 +54,7 @@ class ModifyStockViewController: UIViewController {
             
             changeFruitStock[key] = Int(value.label.text ?? String(ConstantUsageFruit.invalidFruit))
         }
+        
         NotificationCenter.default.post(name: Notification.Name.stock, object: nil, userInfo: changeFruitStock)
         dismiss(animated: true)
     }
@@ -64,23 +65,19 @@ class ModifyStockViewController: UIViewController {
     
     func setNavigationBar() {
         self.title = ConstantSentence.modifyStockTitle
-        self.navigationController?.navigationBar.backgroundColor = .lightGray
+        self.navigationController?.navigationBar.backgroundColor = UIColor(red: 242/255, green: 242/255, blue: 242/255, alpha: 1.0)
     }
     
-    func settingFruitStockLabel() {
-        strawberryStockLabel.text = String(fruitStock[.strawberry, default: ConstantUsageFruit.invalidFruit])
-        bananaStockLabel.text = String(fruitStock[.banana, default: ConstantUsageFruit.invalidFruit])
-        pineappleStockLabel.text = String(fruitStock[.pineapple, default: ConstantUsageFruit.invalidFruit])
-        kiwiStockLabel.text = String(fruitStock[.kiwi, default: ConstantUsageFruit.invalidFruit])
-        mangoStockLabel.text = String(fruitStock[.mango, default: ConstantUsageFruit.invalidFruit])
+    func setFruitStockLabel() {
+        for (key, value) in fruitLabel {
+            value.label.text = String(fruitStock[key, default: ConstantUsageFruit.invalidFruit])
+        }
     }
     
-    func settingStepperValue() {
-        strawberryStepper.value = Double(fruitStock[.strawberry, default: ConstantUsageFruit.invalidFruit])
-        bananaStepper.value = Double(fruitStock[.banana, default: ConstantUsageFruit.invalidFruit])
-        pineappleStepper.value = Double(fruitStock[.pineapple, default: ConstantUsageFruit.invalidFruit])
-        kiwiStepper.value = Double(fruitStock[.kiwi, default: ConstantUsageFruit.invalidFruit])
-        mangoStepper.value = Double(fruitStock[.mango, default: ConstantUsageFruit.invalidFruit])
+    func setStepperValue() {
+        for (key, value) in fruitLabel {
+            value.stepper.value = Double(fruitStock[key, default: ConstantUsageFruit.invalidFruit])
+        }
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -18,16 +18,16 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setNavigation()
+        setNavigationBar()
         settingFruitStockLabel()
     }
     
     @IBAction func modifyStockButtonTapped(_ sender: Any) {
-        guard let modifyStockVC = storyboard?.instantiateViewController(withIdentifier: "ModifyVC") as? ModifyStockViewController else {
+        guard let modifyStockNC = storyboard?.instantiateViewController(withIdentifier: "ToModifyStockNavi") as? UINavigationController else {
             return
         }
-
-        present(modifyStockVC, animated: true, completion: nil)
+        
+        present(modifyStockNC, animated: true, completion: nil)
     }
     
     @IBAction func orderButtonTapped(_ sender: UIButton) {
@@ -75,8 +75,8 @@ class ViewController: UIViewController {
         self.present(alert, animated: true)
     }
     
-    func setNavigation() {
-        self.title = ConstantSentence.navigationTitle
+    func setNavigationBar() {
+        self.title = ConstantSentence.mainTitle
         self.navigationController?.navigationBar.backgroundColor = .lightGray
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -25,7 +25,11 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBar()
-        settingFruitStockLabel()
+        setFruitStockLabel()
+        setNotification()
+    }
+    
+    func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateStockLabel), name: Notification.Name.stock, object: nil)
         juiceMaker.addNotficationObserver()
     }
@@ -37,7 +41,6 @@ class ViewController: UIViewController {
         
         for (key, value) in changeFruitStock {
             self.fruitLabel[key]?.text = String(value)
-            
         }
     }
     
@@ -47,9 +50,7 @@ class ViewController: UIViewController {
         }
         
         modifyStockVC.fruitStock = juiceMaker.fruitStore.fruitStock
-        
         let moveToStockNC = UINavigationController(rootViewController: modifyStockVC)
-        
         present(moveToStockNC, animated: true, completion: nil)
     }
     
@@ -59,20 +60,18 @@ class ViewController: UIViewController {
         }
         
         orderedJuice = orderedJuice.replacingOccurrences(of: " 주문", with: "")
-        
         guard let juice = Juice(rawValue: orderedJuice) else {
             return
         }
                 
         let isMadeJuice =  juiceMaker.manufactureJuice(menu: juice)
-        
         guard isMadeJuice else {
             showFailedAlert(message: ConstantSentence.failedAlertMent)
             return
         }
         
         showSuccessAlert(message: juice.rawValue + ConstantSentence.successAlertMent)
-        settingFruitStockLabel()
+        setFruitStockLabel()
     }
 
     func showSuccessAlert(message: String) {
@@ -88,10 +87,9 @@ class ViewController: UIViewController {
             guard let modifyStockVC = self.storyboard?.instantiateViewController(withIdentifier: "ModifyVC") as? ModifyStockViewController else {
                 return
             }
+            
             modifyStockVC.fruitStock = self.juiceMaker.fruitStore.fruitStock
-            
             let moveToStockNC = UINavigationController(rootViewController: modifyStockVC)
-            
             self.present(moveToStockNC, animated: true, completion: nil)
         }
         
@@ -103,15 +101,13 @@ class ViewController: UIViewController {
     
     func setNavigationBar() {
         self.title = ConstantSentence.mainTitle
-        self.navigationController?.navigationBar.backgroundColor = .lightGray
+        self.navigationController?.navigationBar.backgroundColor = UIColor(red: 242/255, green: 242/255, blue: 242/255, alpha: 1.0)
     }
     
-    func settingFruitStockLabel() {
+    func setFruitStockLabel() {
         let fruitStore = juiceMaker.fruitStore
-        self.strawberryStockLabel.text = String(fruitStore.bringValidFruitStock(.strawberry))
-        self.bananaStockLabel.text = String(fruitStore.bringValidFruitStock(.banana))
-        self.pineappleStockLabel.text = String(fruitStore.bringValidFruitStock(.pineapple))
-        self.kiwiStockLabel.text = String(fruitStore.bringValidFruitStock(.kiwi))
-        self.mangoStockLabel.text = String(fruitStore.bringValidFruitStock(.mango))
+        for (key, value) in fruitLabel {
+            value.text = String(fruitStore.bringValidFruitStock(key))
+        }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -27,6 +27,7 @@ class ViewController: UIViewController {
         setNavigationBar()
         settingFruitStockLabel()
         NotificationCenter.default.addObserver(self, selector: #selector(updateStockLabel), name: Notification.Name.stock, object: nil)
+        juiceMaker.addNotficationObserver()
     }
     
     @objc func updateStockLabel(noti: Notification) {
@@ -44,6 +45,7 @@ class ViewController: UIViewController {
         guard let modifyStockVC = storyboard?.instantiateViewController(withIdentifier: "ModifyVC") as? ModifyStockViewController else {
             return
         }
+        
         modifyStockVC.fruitStock = juiceMaker.fruitStore.fruitStock
         
         let moveToStockNC = UINavigationController(rootViewController: modifyStockVC)

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -16,6 +16,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
     
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBar()
@@ -23,11 +24,14 @@ class ViewController: UIViewController {
     }
     
     @IBAction func modifyStockButtonTapped(_ sender: Any) {
-        guard let modifyStockNC = storyboard?.instantiateViewController(withIdentifier: "ToModifyStockNavi") as? UINavigationController else {
+        guard let modifyStockVC = storyboard?.instantiateViewController(withIdentifier: "ModifyVC") as? ModifyStockViewController else {
             return
         }
+        modifyStockVC.fruitStock = juiceMaker.fruitStore.fruitStock
         
-        present(modifyStockNC, animated: true, completion: nil)
+        let moveToStockNC = UINavigationController(rootViewController: modifyStockVC)
+        
+        present(moveToStockNC, animated: true, completion: nil)
     }
     
     @IBAction func orderButtonTapped(_ sender: UIButton) {
@@ -62,11 +66,14 @@ class ViewController: UIViewController {
     func showFailedAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let confirmAction = UIAlertAction(title: "예", style: .default) { _ in
-            guard let modifyStockNC = self.storyboard?.instantiateViewController(withIdentifier: "ToModifyStockNavi") as? UINavigationController else {
+            guard let modifyStockVC = self.storyboard?.instantiateViewController(withIdentifier: "ModifyVC") as? ModifyStockViewController else {
                 return
             }
+            modifyStockVC.fruitStock = self.juiceMaker.fruitStore.fruitStock
             
-            self.present(modifyStockNC, animated: true, completion: nil)
+            let moveToStockNC = UINavigationController(rootViewController: modifyStockVC)
+            
+            self.present(moveToStockNC, animated: true, completion: nil)
         }
         
         let cancleAction = UIAlertAction(title: "아니오", style: .cancel)

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -21,30 +21,6 @@ class ViewController: UIViewController {
         setNavigationBar()
         setFruitLabel()
         setFruitStockLabelText()
-        setNotification()
-    }
-    
-    private func setFruitLabel() {
-        fruitLabel = [.strawberry : strawberryStockLabel,
-                      .banana : bananaStockLabel,
-                      .pineapple : pineappleStockLabel,
-                      .kiwi : kiwiStockLabel,
-                      .mango : mangoStockLabel]
-    }
-    
-    private func setNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(updateStockLabel), name: Notification.Name.stock, object: nil)
-        juiceMaker.addNotficationObserver()
-    }
-    
-    @objc func updateStockLabel(noti: Notification) {
-        guard let changeFruitStock = noti.userInfo as? [Fruit : Int] else {
-            return
-        }
-        
-        for (key, value) in changeFruitStock {
-            self.fruitLabel[key]?.text = String(value)
-        }
     }
     
     @IBAction func modifyStockButtonTapped(_ sender: Any) {
@@ -53,6 +29,7 @@ class ViewController: UIViewController {
         }
         
         modifyStockVC.fruitStock = juiceMaker.fruitStore.fruitStock
+        modifyStockVC.delegate = self
         let moveToStockNC = UINavigationController(rootViewController: modifyStockVC)
         present(moveToStockNC, animated: true, completion: nil)
     }
@@ -87,6 +64,7 @@ class ViewController: UIViewController {
             }
             
             modifyStockVC.fruitStock = self.juiceMaker.fruitStore.fruitStock
+            modifyStockVC.delegate = self
             let moveToStockNC = UINavigationController(rootViewController: modifyStockVC)
             self.present(moveToStockNC, animated: true, completion: nil)
         }
@@ -95,6 +73,14 @@ class ViewController: UIViewController {
         alert.addAction(confirmAction)
         alert.addAction(cancleAction)
         self.present(alert, animated: true)
+    }
+    
+    private func setFruitLabel() {
+        fruitLabel = [.strawberry : strawberryStockLabel,
+                      .banana : bananaStockLabel,
+                      .pineapple : pineappleStockLabel,
+                      .kiwi : kiwiStockLabel,
+                      .mango : mangoStockLabel]
     }
     
     private func setNavigationBar() {
@@ -107,5 +93,12 @@ class ViewController: UIViewController {
         for (key, value) in fruitLabel {
             value.text = String(fruitStore.bringValidFruitStock(key))
         }
+    }
+}
+
+extension ViewController: ModifyStockDelegate {
+    func changeFruitStock(_ changedStock: [Fruit : Int]) {
+        juiceMaker.passingChangedFruitStock(changedStock)
+        setFruitStockLabelText()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -62,11 +62,11 @@ class ViewController: UIViewController {
     func showFailedAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let confirmAction = UIAlertAction(title: "예", style: .default) { _ in
-            guard let modifyStockVC = self.storyboard?.instantiateViewController(withIdentifier: "ModifyVC") as? ModifyStockViewController else {
+            guard let modifyStockNC = self.storyboard?.instantiateViewController(withIdentifier: "ToModifyStockNavi") as? UINavigationController else {
                 return
             }
             
-            self.present(modifyStockVC, animated: true, completion: nil)
+            self.present(modifyStockNC, animated: true, completion: nil)
         }
         
         let cancleAction = UIAlertAction(title: "아니오", style: .cancel)

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -15,12 +15,29 @@ class ViewController: UIViewController {
     @IBOutlet weak var pineappleStockLabel: UILabel!
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
-    
+
+    lazy var fruitLabel: [Fruit : UILabel] = [.strawberry : strawberryStockLabel,
+                                              .banana : bananaStockLabel,
+                                              .pineapple : pineappleStockLabel,
+                                              .kiwi : kiwiStockLabel,
+                                              .mango : mangoStockLabel]
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBar()
         settingFruitStockLabel()
+        NotificationCenter.default.addObserver(self, selector: #selector(updateStockLabel), name: Notification.Name.stock, object: nil)
+    }
+    
+    @objc func updateStockLabel(noti: Notification) {
+        guard let changeFruitStock = noti.userInfo as? [Fruit : Int] else {
+            return
+        }
+        
+        for (key, value) in changeFruitStock {
+            self.fruitLabel[key]?.text = String(value)
+            
+        }
     }
     
     @IBAction func modifyStockButtonTapped(_ sender: Any) {

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -7,8 +7,8 @@
 import UIKit
 
 class ViewController: UIViewController {
-
     var juiceMaker = JuiceMaker()
+    private var fruitLabel: [Fruit : UILabel] = [:]
     
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
@@ -16,20 +16,23 @@ class ViewController: UIViewController {
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
 
-    lazy var fruitLabel: [Fruit : UILabel] = [.strawberry : strawberryStockLabel,
-                                              .banana : bananaStockLabel,
-                                              .pineapple : pineappleStockLabel,
-                                              .kiwi : kiwiStockLabel,
-                                              .mango : mangoStockLabel]
-
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBar()
-        setFruitStockLabel()
+        setFruitLabel()
+        setFruitStockLabelText()
         setNotification()
     }
     
-    func setNotification() {
+    private func setFruitLabel() {
+        fruitLabel = [.strawberry : strawberryStockLabel,
+                      .banana : bananaStockLabel,
+                      .pineapple : pineappleStockLabel,
+                      .kiwi : kiwiStockLabel,
+                      .mango : mangoStockLabel]
+    }
+    
+    private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateStockLabel), name: Notification.Name.stock, object: nil)
         juiceMaker.addNotficationObserver()
     }
@@ -55,33 +58,28 @@ class ViewController: UIViewController {
     }
     
     @IBAction func orderButtonTapped(_ sender: UIButton) {
-        guard var orderedJuice = sender.currentTitle else {
-            return
-        }
-        
-        orderedJuice = orderedJuice.replacingOccurrences(of: " 주문", with: "")
-        guard let juice = Juice(rawValue: orderedJuice) else {
+        guard let orderedJuice = Juice.findJuiceButtonLocation(tag: sender.tag) else {
             return
         }
                 
-        let isMadeJuice =  juiceMaker.manufactureJuice(menu: juice)
+        let isMadeJuice =  juiceMaker.manufactureJuice(menu: orderedJuice)
         guard isMadeJuice else {
             showFailedAlert(message: ConstantSentence.failedAlertMent)
             return
         }
         
-        showSuccessAlert(message: juice.rawValue + ConstantSentence.successAlertMent)
-        setFruitStockLabel()
+        showSuccessAlert(message: orderedJuice.rawValue + ConstantSentence.successAlertMent)
+        setFruitStockLabelText()
     }
 
-    func showSuccessAlert(message: String) {
+    private func showSuccessAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let confirmAction = UIAlertAction(title: "예", style: .default)
         alert.addAction(confirmAction)
         self.present(alert, animated: true)
     }
     
-    func showFailedAlert(message: String) {
+    private func showFailedAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let confirmAction = UIAlertAction(title: "예", style: .default) { _ in
             guard let modifyStockVC = self.storyboard?.instantiateViewController(withIdentifier: "ModifyVC") as? ModifyStockViewController else {
@@ -99,12 +97,12 @@ class ViewController: UIViewController {
         self.present(alert, animated: true)
     }
     
-    func setNavigationBar() {
+    private func setNavigationBar() {
         self.title = ConstantSentence.mainTitle
         self.navigationController?.navigationBar.backgroundColor = UIColor(red: 242/255, green: 242/255, blue: 242/255, alpha: 1.0)
     }
     
-    func setFruitStockLabel() {
+    private func setFruitStockLabelText() {
         let fruitStore = juiceMaker.fruitStore
         for (key, value) in fruitLabel {
             value.text = String(fruitStore.bringValidFruitStock(key))

--- a/JuiceMaker/JuiceMaker/Model/ConstantNameSpace.swift
+++ b/JuiceMaker/JuiceMaker/Model/ConstantNameSpace.swift
@@ -17,7 +17,8 @@ enum ConstantUsageFruit {
 }
 
 enum ConstantSentence {
-    static let navigationTitle: String =  "맛있는 주스를 만들어 드려요!"
+    static let mainTitle: String =  "맛있는 주스를 만들어 드려요!"
     static let successAlertMent: String = " 나왔습니다! 맛있게 드세요!"
     static let failedAlertMent: String = "재료가 모자라요. 재고를 수정할까요?"
+    static let modifyStockTitle: String = "재고 추가"
 }

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -5,10 +5,10 @@
 //  Created by Kyo, TaeLee on 2022/08/29.
 //
 
-enum Fruit: CaseIterable {
-    case strawberry
-    case banana
-    case pineapple
-    case kiwi
-    case mango
+enum Fruit: Int, CaseIterable {
+    case strawberry = 0
+    case banana = 1
+    case pineapple = 2
+    case kiwi = 3
+    case mango = 4
 }

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -5,10 +5,27 @@
 //  Created by Kyo, TaeLee on 2022/08/29.
 //
 
-enum Fruit: Int, CaseIterable {
-    case strawberry = 0
-    case banana = 1
-    case pineapple = 2
-    case kiwi = 3
-    case mango = 4
+enum Fruit: CaseIterable {
+    case strawberry
+    case banana
+    case pineapple
+    case kiwi
+    case mango
+    
+    static func findFruiteStepperTag(location: Int) -> Fruit? {
+        switch location {
+        case 0:
+            return .strawberry
+        case 1:
+            return .banana
+        case 2:
+            return .pineapple
+        case 3:
+            return .kiwi
+        case 4:
+            return .mango
+        default:
+            return nil
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -5,7 +5,7 @@
 //
 
 class FruitStore {
-    private var fruitStock: [Fruit : Int] = [:]
+    private(set) var fruitStock: [Fruit : Int] = [:]
     
     init(defaultStock: Int = 10) {
         for fruit in Fruit.allCases {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -7,9 +7,7 @@
 class FruitStore {
     private var fruitStock: [Fruit : Int] = [:]
     
-    static let shared = FruitStore()
-    
-    private init(defaultStock: Int = 10) {
+    init(defaultStock: Int = 10) {
         for fruit in Fruit.allCases {
             fruitStock.updateValue(defaultStock, forKey: fruit)
         }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -7,7 +7,9 @@
 class FruitStore {
     private var fruitStock: [Fruit : Int] = [:]
     
-    init(defaultStock: Int = 10) {
+    static let shared = FruitStore()
+    
+    private init(defaultStock: Int = 10) {
         for fruit in Fruit.allCases {
             fruitStock.updateValue(defaultStock, forKey: fruit)
         }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -17,6 +17,7 @@ final class FruitStore {
         guard let fruitAmount = fruitStock[fruit] else {
             throw JuiceMakerError.invalidFruit
         }
+        
         return fruitAmount
     }
     
@@ -29,7 +30,6 @@ final class FruitStore {
     func substractFruits(juice: Juice) {
         for fruit in juice.recipe {
             var fruitAmount = bringValidFruitStock(fruit.name)
-            
             fruitAmount -= fruit.count
             fruitStock[fruit.name] = fruitAmount
         }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -4,7 +4,7 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
-class FruitStore {
+final class FruitStore {
     private(set) var fruitStock: [Fruit : Int] = [:]
     
     init(defaultStock: Int = 10) {
@@ -20,11 +20,10 @@ class FruitStore {
         return fruitAmount
     }
     
-    func addFruits(fruit: Fruit, amount: Int) {
-        var fruitAmount = bringValidFruitStock(fruit)
-        
-        fruitAmount += amount
-        fruitStock[fruit] = fruitAmount
+    func updateFruits(_ updateStock: [Fruit : Int]) {
+        for (key, value) in updateStock {
+            fruitStock[key] = value
+        }
     }
     
     func substractFruits(juice: Juice) {

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -36,4 +36,25 @@ enum Juice: String {
                     (name: .kiwi, count: ConstantUsageFruit.mangoKiwi.kiwi)]
         }
     }
+    
+    static func findJuiceButtonLocation(tag: Int) -> Juice? {
+        switch tag {
+        case 0:
+            return .strawberryJuice
+        case 1:
+            return .bananaJuice
+        case 2:
+            return .pineappleJuice
+        case 3:
+            return .kiwiJuice
+        case 4:
+            return .mangoJuice
+        case 5:
+            return .strawberryBananaJuice
+        case 6:
+            return .mangoKiwiJuice
+        default:
+            return nil
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -37,8 +37,8 @@ enum Juice: String {
         }
     }
     
-    static func findJuiceButtonLocation(tag: Int) -> Juice? {
-        switch tag {
+    static func findJuiceButtonTag(location: Int) -> Juice? {
+        switch location {
         case 0:
             return .strawberryJuice
         case 1:

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -18,7 +18,7 @@ struct JuiceMaker {
         return true
     }
     
-    func checkEnoughStock(juice: Juice) throws -> Bool {
+    private func checkEnoughStock(juice: Juice) throws -> Bool {
         for fruit in juice.recipe {
             let stock = fruitStore.bringValidFruitStock(fruit.name)
             guard stock != ConstantUsageFruit.invalidFruit else {
@@ -33,7 +33,7 @@ struct JuiceMaker {
         return true
     }
     
-    func canManufactureJuice(juice: Juice) -> Bool {
+    private func canManufactureJuice(juice: Juice) -> Bool {
         var isEnoughStock: Bool = false
         
         do {
@@ -48,13 +48,7 @@ struct JuiceMaker {
         return isEnoughStock
     }
     
-    func addNotficationObserver() {
-        NotificationCenter.default.addObserver(forName: NSNotification.Name.stock, object: nil, queue: nil) { notification in
-            guard let updateStock = notification.userInfo as? [Fruit : Int] else {
-                return
-            }
-            
-            fruitStore.updateFruits(updateStock)
-        }
+    func passingChangedFruitStock(_ changedStock: [Fruit : Int]) {
+        fruitStore.updateFruits(changedStock)
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,7 +5,7 @@
 //
 
 struct JuiceMaker {
-    let fruitStore = FruitStore()
+    let fruitStore = FruitStore.shared
     
     func manufactureJuice(menu juice: Juice) -> Bool {
         guard canManufactureJuice(juice: juice) else {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -4,7 +4,7 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 struct JuiceMaker {
     let fruitStore = FruitStore()
@@ -21,7 +21,6 @@ struct JuiceMaker {
     func checkEnoughStock(juice: Juice) throws -> Bool {
         for fruit in juice.recipe {
             let stock = fruitStore.bringValidFruitStock(fruit.name)
-            
             guard stock != ConstantUsageFruit.invalidFruit else {
                 return false
             }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,7 +5,7 @@
 //
 
 struct JuiceMaker {
-    let fruitStore = FruitStore.shared
+    let fruitStore = FruitStore()
     
     func manufactureJuice(menu juice: Juice) -> Bool {
         guard canManufactureJuice(juice: juice) else {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -4,6 +4,8 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
+import UIKit
+
 struct JuiceMaker {
     let fruitStore = FruitStore()
     
@@ -45,5 +47,15 @@ struct JuiceMaker {
         }
         
         return isEnoughStock
+    }
+    
+    func addNotficationObserver() {
+        NotificationCenter.default.addObserver(forName: NSNotification.Name.stock, object: nil, queue: nil) { notification in
+            guard let updateStock = notification.userInfo as? [Fruit : Int] else {
+                return
+            }
+            
+            fruitStore.updateFruits(updateStock)
+        }
     }
 }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="JuiceMakerViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -301,6 +301,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="0.0" y="120.66666666666669" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="stepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="H0E-PU-uL3"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -320,8 +323,11 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                            <stepper opaque="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="0.0" y="120.66666666666669" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="stepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="MMf-7x-Eax"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -341,8 +347,11 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                            <stepper opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="0.0" y="120.66666666666669" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="stepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="XCI-M9-cQs"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -362,8 +371,11 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                            <stepper opaque="NO" tag="3" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="0.0" y="120.66666666666669" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="stepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="X30-kv-ij8"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -383,8 +395,11 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                            <stepper opaque="NO" tag="4" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="0.0" y="120.66666666666669" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="stepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="yR7-eb-i7W"/>
+                                                </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
@@ -417,10 +432,15 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="6eP-O2-Sry"/>
                         <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="4OC-hx-b8d"/>
+                        <outlet property="kiwiStepper" destination="klA-59-Nu4" id="deQ-QH-lzm"/>
                         <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="xYe-5M-Tk6"/>
+                        <outlet property="mangoStepper" destination="xbn-6P-grO" id="38N-yi-hJs"/>
                         <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="YIB-vP-zKV"/>
+                        <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="je3-RZ-pQq"/>
                         <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="QSA-JZ-q2O"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="8ZT-u7-VOl"/>
                         <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="EcW-ic-ucH"/>
                     </connections>
                 </viewController>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -401,17 +401,28 @@
                     <navigationItem key="navigationItem" id="g4W-fY-l7r">
                         <leftBarButtonItems>
                             <barButtonItem id="ob8-xG-OjC"/>
-                            <barButtonItem title="Item" image="xmark" catalog="system" id="PmZ-aE-VUh"/>
+                            <barButtonItem title="Item" image="xmark" catalog="system" id="PmZ-aE-VUh">
+                                <connections>
+                                    <action selector="cancelButtonTapped:" destination="Yu1-lM-nqp" id="IMM-8I-kJT"/>
+                                </connections>
+                            </barButtonItem>
                         </leftBarButtonItems>
                         <barButtonItem key="rightBarButtonItem" style="plain" id="B0E-1N-bgf">
                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="aRK-95-iTx">
-                                <rect key="frame" x="730.33333333333337" y="0.0" width="73" height="32"/>
+                                <rect key="frame" x="711" y="0.0" width="73" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="저장"/>
                             </button>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="4OC-hx-b8d"/>
+                        <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="xYe-5M-Tk6"/>
+                        <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="YIB-vP-zKV"/>
+                        <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="QSA-JZ-q2O"/>
+                        <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="EcW-ic-ucH"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -280,59 +280,59 @@
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="JY6-Fi-9xG">
-                                <rect key="frame" x="167" y="118.66666666666667" width="510" height="152.66666666666663"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalCentering" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="JY6-Fi-9xG">
+                                <rect key="frame" x="167" y="119.66666666666667" width="510" height="150.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="ls4-4u-Jk9">
-                                        <rect key="frame" x="0.0" y="0.0" width="94" height="152.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="150.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="85.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="0.0" y="91.666666666666671" width="94" height="23"/>
+                                                <rect key="frame" x="0.0" y="89.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="0.0" y="120.66666666666669" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="118.66666666666669" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="stepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="H0E-PU-uL3"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="jla-Wh-PDY">
-                                        <rect key="frame" x="104" y="0.0" width="94" height="152.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="jla-Wh-PDY">
+                                        <rect key="frame" x="104" y="0.0" width="94" height="150.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="91.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="0.0" y="94.666666666666671" width="94" height="23"/>
+                                                <rect key="frame" x="0.0" y="89.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="0.0" y="120.66666666666669" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="118.66666666666669" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="stepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="MMf-7x-Eax"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="WYA-wM-gO8">
-                                        <rect key="frame" x="208" y="0.0" width="94" height="152.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="WYA-wM-gO8">
+                                        <rect key="frame" x="208" y="0.0" width="94" height="150.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
                                                 <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
@@ -341,22 +341,22 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="0.0" y="90.666666666666671" width="94" height="23"/>
+                                                <rect key="frame" x="0.0" y="89.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="0.0" y="120.66666666666669" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="118.66666666666669" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="stepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="XCI-M9-cQs"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="cIY-u0-sNx">
-                                        <rect key="frame" x="312" y="0.0" width="94" height="152.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="cIY-u0-sNx">
+                                        <rect key="frame" x="312" y="0.0" width="94" height="150.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
                                                 <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
@@ -365,22 +365,22 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="0.0" y="90.666666666666671" width="94" height="23"/>
+                                                <rect key="frame" x="0.0" y="89.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="3" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="0.0" y="120.66666666666669" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="118.66666666666669" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="stepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="X30-kv-ij8"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="8ub-eu-zMP">
-                                        <rect key="frame" x="416" y="0.0" width="94" height="152.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="8ub-eu-zMP">
+                                        <rect key="frame" x="416" y="0.0" width="94" height="150.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
                                                 <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
@@ -389,14 +389,14 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="0.0" y="90.666666666666671" width="94" height="23"/>
+                                                <rect key="frame" x="0.0" y="89.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="4" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="0.0" y="120.66666666666669" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="118.66666666666669" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="stepperTapped:" destination="Yu1-lM-nqp" eventType="valueChanged" id="yR7-eb-i7W"/>
                                                 </connections>
@@ -409,8 +409,8 @@
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="JY6-Fi-9xG" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="8mh-GK-JRE"/>
                             <constraint firstItem="JY6-Fi-9xG" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="mZS-qo-KXu"/>
+                            <constraint firstItem="JY6-Fi-9xG" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="nxV-kN-Hjj"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r">

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -119,7 +119,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
                                         <rect key="frame" x="0.0" y="0.0" width="724" height="66"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                            <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
                                                 <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -134,7 +134,7 @@
                                                 <rect key="frame" x="296" y="0.0" width="132" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                            <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
                                                 <rect key="frame" x="444" y="0.0" width="280" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -164,7 +164,7 @@
                                                             <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1Jc-KW-e60"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -175,7 +175,7 @@
                                                             <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dko-zs-XfM"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -186,7 +186,7 @@
                                                             <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gOo-fr-u1M"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -197,7 +197,7 @@
                                                             <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4IB-sV-gYc"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                    <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -156,7 +156,7 @@
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
                                                         <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="15"/>
                                                         <state key="normal" title="딸기쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
@@ -280,20 +280,20 @@
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="38" translatesAutoresizingMaskIntoConstraints="NO" id="JY6-Fi-9xG">
-                                <rect key="frame" x="111" y="118.66666666666667" width="622" height="152.66666666666663"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="JY6-Fi-9xG">
+                                <rect key="frame" x="167" y="118.66666666666667" width="510" height="152.66666666666663"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="ls4-4u-Jk9">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="ls4-4u-Jk9">
                                         <rect key="frame" x="0.0" y="0.0" width="94" height="152.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="9.6666666666666714" y="0.0" width="75" height="85.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="85.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="41.333333333333343" y="91.666666666666671" width="11.666666666666664" height="23"/>
+                                                <rect key="frame" x="0.0" y="91.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -304,17 +304,17 @@
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="jla-Wh-PDY">
-                                        <rect key="frame" x="132" y="0.0" width="94" height="152.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="jla-Wh-PDY">
+                                        <rect key="frame" x="104" y="0.0" width="94" height="152.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="9.6666666666666572" y="0.0" width="75" height="91.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="91.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="41.333333333333314" y="94.666666666666671" width="11.666666666666664" height="23"/>
+                                                <rect key="frame" x="0.0" y="94.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -325,17 +325,17 @@
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="WYA-wM-gO8">
-                                        <rect key="frame" x="264" y="0.0" width="94" height="152.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="WYA-wM-gO8">
+                                        <rect key="frame" x="208" y="0.0" width="94" height="152.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="9.6666666666666856" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="41.333333333333314" y="90.666666666666671" width="11.666666666666664" height="23"/>
+                                                <rect key="frame" x="0.0" y="90.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -346,17 +346,17 @@
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="cIY-u0-sNx">
-                                        <rect key="frame" x="396" y="0.0" width="94" height="152.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="cIY-u0-sNx">
+                                        <rect key="frame" x="312" y="0.0" width="94" height="152.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="41.333333333333371" y="90.666666666666671" width="11.666666666666664" height="23"/>
+                                                <rect key="frame" x="0.0" y="90.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -367,17 +367,17 @@
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="8ub-eu-zMP">
-                                        <rect key="frame" x="528" y="0.0" width="94" height="152.66666666666666"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="8ub-eu-zMP">
+                                        <rect key="frame" x="416" y="0.0" width="94" height="152.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="9.6666666666666288" y="0.0" width="75" height="83.666666666666671"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="41.333333333333371" y="90.666666666666671" width="11.666666666666664" height="23"/>
+                                                <rect key="frame" x="0.0" y="90.666666666666671" width="94" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -390,33 +390,27 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BwK-TO-yeN">
-                                <rect key="frame" x="40" y="20" width="42.666666666666657" height="30.666666666666671"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" image="xmark" catalog="system" title=""/>
-                                <connections>
-                                    <action selector="cancelButtonTapped:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="JTV-e6-3NR"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aRK-95-iTx">
-                                <rect key="frame" x="755.66666666666663" y="20" width="48.333333333333371" height="31"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="저장"/>
-                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="BwK-TO-yeN" firstAttribute="top" secondItem="tKV-4l-Vtc" secondAttribute="top" constant="20" id="5Qq-zH-hKn"/>
-                            <constraint firstItem="JY6-Fi-9xG" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="Bhc-eo-Rhd"/>
-                            <constraint firstAttribute="trailing" secondItem="aRK-95-iTx" secondAttribute="trailing" constant="40" id="bSN-bP-Z3I"/>
-                            <constraint firstItem="JY6-Fi-9xG" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="mQk-gJ-AUU"/>
-                            <constraint firstItem="aRK-95-iTx" firstAttribute="top" secondItem="tKV-4l-Vtc" secondAttribute="top" constant="20" id="rdr-bf-Ufy"/>
-                            <constraint firstItem="BwK-TO-yeN" firstAttribute="leading" secondItem="tKV-4l-Vtc" secondAttribute="leading" constant="40" id="y0E-b3-EF6"/>
+                            <constraint firstItem="JY6-Fi-9xG" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="8mh-GK-JRE"/>
+                            <constraint firstItem="JY6-Fi-9xG" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="mZS-qo-KXu"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r">
-                        <barButtonItem key="leftBarButtonItem" id="ob8-xG-OjC"/>
+                        <leftBarButtonItems>
+                            <barButtonItem id="ob8-xG-OjC"/>
+                            <barButtonItem title="Item" image="xmark" catalog="system" id="PmZ-aE-VUh"/>
+                        </leftBarButtonItems>
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="B0E-1N-bgf">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="aRK-95-iTx">
+                                <rect key="frame" x="730.33333333333337" y="0.0" width="73" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="저장"/>
+                            </button>
+                        </barButtonItem>
                     </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
@@ -426,7 +420,7 @@
         <!--Navigation Controller-->
         <scene sceneID="dUS-Gz-xU7">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="xDg-eo-vF4" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="ToModifyStockNavi" automaticallyAdjustsScrollViewInsets="NO" id="xDg-eo-vF4" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ygr-aF-2Km">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -428,6 +428,9 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="저장"/>
+                                <connections>
+                                    <action selector="saveButtonTapped:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="Wa0-K9-EMW"/>
+                                </connections>
                             </button>
                         </barButtonItem>
                     </navigationItem>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <action selector="toModifyStockView:" destination="BYZ-38-t0r" id="TLD-z6-ikG"/>
+                                <action selector="modifyStockButtonTapped:" destination="BYZ-38-t0r" id="LjD-5g-tMR"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>


### PR DESCRIPTION
@Monsteel 
안녕하세요 토니! Kyo와 하모가 열심히 최종 Step3를 진행했습니다..!
리뷰 잘 부탁드립니다👍👍👍

### 진행 단계 : Step3
## ⭐️ 구현한 기능

- ViewController
    - `fruitLabel`: Dictionary타입으로 key값은 Fruit타입, value에는 각각 과일에 매칭되는 UILable인 Property
    - `setNotification()`: ViewController의 observer를 추가하는 메서드
    - `@objc updateStockLabel()`: notification이 왔을 때 실행고 재고가 변경된 과일의 label을 수정해주는 메서드
- ModifyStockViewController
    - `fruitUIAttribute`: Dictionary타입으로 key값은 Fruit타입, value에는 각각 과일에 매칭되는 UILable, UIStepper, 재고변경여부를 확인하기 위한 isChange를 추가한 Property.
    - `stepperTapped()`: 각각 과일에 매칭되는 Stepper의 +,- 클릭 시 Label에 변경을 주었고, 변경여부를 바꿔주는 메서드
    - `saveButtonTapped()`: NotificationCenterf를 통해서 변경된 재고를 post 시켜주는 메서드
    - `setNavigationBar()`: 네비게이션 타이틀을 기입하고 색상을 변경
    - `setFruitStockLabel()`: fruitLabel들을 `fruitUIAttribute`에 맞게 셋팅해주는 메서드
    - `setStepperValue()`: Stepper의 기본 value를 셋팅해주는 메서드
    - `saveButtonTapped()`: 저장버튼을 누르면 전체과일의 재고가 아닌 변경된 과일들의 재고만이 post되는 메서드
- FruitStore 클래스
    - `updateFruits()`: 수정된 재고를 Dictionary 타입으로 받아서 fruitStock을 업데이트하는 메서드
- JuiceMaker 구조체
    - `addNotficationObserver()`: ModifyStockViewController에서 post한 notificaiotn을 감지하기 위한 observer를 추가하는 메서드 (클로저 이용)

## ⭐️ 코드를 작성할 때 고민되었던 점
- Singleton패턴 사용에 대한 고민
    - 솔직히 Singleton패턴을 사용해서 구현을 해보았을 때 굉장히 편했습니다. 하지만 Singleton을 사용하면 여러 군데에서 접근이 가능해져 의존성에 문제가 있을 수 있다는 것을 느꼈습니다. 어디서나 Singleton에 접근할 수 있었기 때문에 조금이라도 의존성을 줄이고 필요한곳에서만 데이터에 대한 접근이 가능하도록 Notification을 사용하게 되었습니다.

- 요구사항조건에는 없었지만 재고수정 모달에 닫기 버튼을 추가로 생성한 것에 대한 고민
    - 요구사항에는 네비게이션바에 버튼이 닫기 버튼만 존재하였는데 WWDC2022 영상을 공부하였을 때 정보의 변경이 모달 view에서 생기게 되면 닫기와 저장 두가지 버튼을 제공하는 것을 권장하였습니다. 그리고 닫기 버튼만 있는 경우는 단순히 정보를 보여주기만 하는 상황에서 권장하였습니다. 따라서 두가지 버튼을 구현하였습니다.
    
- Notification을 통해서 데이터를 전달할 때 어떤 객체에 전달할지에 대한 3가지 고민
    - 1. `ViewController`에만 전달하여 ViewController의 Label변경하고, FruitStore의 재고를 변경하기위해 변경된 값을 JuiecMaker에 전달하는 방법.
    - 2. `JuiceMaker`에만 전달하여 FruitStore의 재고를 변경하고 ViewController에 변경된 재고를 전달하는 방법 
    - 3. `ViewController`와 `JuiceMaker` 모두에 전달하여 변경된 값으로 ViewController의 Label, JuiceMaker의 FruitStore에 대한 데이터 변경을 하는 방법
    - 최종적으로 3번의 방법을 채택하였습니다. 이유는 Notification의 특징이 다수의 객체들에게 동시에 이벤트의 발생을 알려준다는 점인데 이러한 점을 직접 구현해보며 느껴보고 싶었고, 의존성에 대한 부분은 1번,2번,3번 모두 동일한 영향을 가질 것이라고 생각했습니다.

- Outlet으로 연결된 요소들의 값 설정에 대한 고민
    - 직접 설정해주면 코드의 가독성이 떨어지고 불필요하게 중복코드가 많아져서 Dictionary로 묶어서 해결하였습니다. 코드를 처음보는 사람이 가독성이 떨어질 것 같긴하지만 코드의 중복성을 상당히 줄일 수 있었습니다. 또한 이러한 아이디어를 통해서 전체 재고의 update가아닌 바뀐 재고만을 update하는 방식도 구현가능하였습니다.
## ⭐️ 해결이 되지 않은 점
아쉽게도 없습니다..!

## ⭐️ 조언을 얻고 싶은 부분 
- 모달창에 네비게이션바를 사용하기 위해 네비게이션 컨트롤러를 사용해야하는지에 대한 고민 
    - Hamo: 모달로 화면전환을 하였을 때 네비게이션 바를 구현하기 위해서 직접적으로 버튼과 레이블을 넣는 방법 / 그리고 UINavigationController의 rootViewController로 해당 viewController 지정해 주는 방법이 있었습니다. UINavigationController를 사용했을 때 장점은 자동으로 상단의 Bar가 embed된다는 점, 자동으로 위치를 설정 해준다는 점이라고 생각됩니다. 근데 굳이 사용할 필요성이 있는지는 잘모르겠습니다. 토니의 생각은 어떤가요 조언받고 싶습니다!!

- Notification에 대한 고민
    - Kyo: 위에 고민되었던 점에서 Notification에 대한 방법을 많이 고민을 했는데 저희가 채택한 방법이 큰프로젝트라고 가정했을 경우 한군데에서만 observer를 사용했을 때보다 어떻게 보면 2군데에서 받기 때문에 추적이 까다로울것같다는 생각을 했습니다..저희가 생각한 방향성이 맞는지, 보완점은 없는지, 더 고민해봐야하는가에 대해서 조언을 받고 싶습니다.

- 가독성에 대한 고민
    - Hamo, Kyo : 위에 Outlet으로 연결된 요소들의 값 설정에 대해서 Dictionary로 묶었을 때 가독성이 조금 떨어지는 경향이 있었습니다. Tony라면 가독성이 우선인지..갓 Tony의 의견이 궁금합니다..
