### PR TITLE
쥬스메이커 [STEP 3] 메네, 드래곤

### DIFF
--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -17,9 +17,37 @@ class ChangeInventoryViewController: UIViewController {
     @IBOutlet weak private var kiwiStockLabel: UILabel!
     @IBOutlet weak private var mangoStockLabel: UILabel!
     
-    @IBAction private func CloseButton(_ sender: UIButton) {
+    @IBOutlet weak var strawberryStepper: UIStepper!
+    @IBOutlet weak var bananaStepper: UIStepper!
+    @IBOutlet weak var pineappleStepper: UIStepper!
+    @IBOutlet weak var kiwiStepper: UIStepper!
+    @IBOutlet weak var mangoStepper: UIStepper!
+    
+    @IBAction func actionStepper(_ sender: UIStepper) {
+        guard let fruitLabel = takeFruitLabel(of: sender) else { return }
+        fruitLabel.text = Int(sender.value).description
+    }
+    
+    @IBAction private func closeButton(_ sender: UIButton) {
         dismiss(animated: true,
                 completion: nil)
+    }
+    
+    func takeFruitLabel(of sender: UIStepper) -> UILabel? {
+        switch sender {
+        case strawberryStepper:
+            return strawberryStockLabel
+        case bananaStepper:
+            return bananaStockLabel
+        case pineappleStepper:
+            return pineappleStockLabel
+        case kiwiStepper:
+            return kiwiStockLabel
+        case mangoStepper:
+            return mangoStockLabel
+        default:
+            return nil
+        }
     }
     
     private func checkInventory() {

--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -17,64 +17,52 @@ class ChangeInventoryViewController: UIViewController {
     @IBOutlet weak private var kiwiStockLabel: UILabel!
     @IBOutlet weak private var mangoStockLabel: UILabel!
     
-    @IBOutlet weak private var strawberryStepper: UIStepper!
-    @IBOutlet weak private var bananaStepper: UIStepper!
-    @IBOutlet weak private var pineappleStepper: UIStepper!
-    @IBOutlet weak private var kiwiStepper: UIStepper!
-    @IBOutlet weak private var mangoStepper: UIStepper!
-    
     @IBAction private func closeButton(_ sender: UIButton) {
         dismiss(animated: true,
                 completion: nil)
     }
     
     @IBAction private func setFruitStock(_ sender: UIStepper) {
-        guard let fruit = takeFruit(of: sender) else { return }
-        guard let fruitLabel = takeFruitLabel(of: sender) else { return }
-        fruitLabel.text = Int(sender.value).description
-        juiceMaker.store.inventory[fruit] = Int(sender.value)
-    }
-    
-    private func takeFruitLabel(of sender: UIStepper) -> UILabel? {
-        switch sender {
-        case strawberryStepper:
-            return strawberryStockLabel
-        case bananaStepper:
-            return bananaStockLabel
-        case pineappleStepper:
-            return pineappleStockLabel
-        case kiwiStepper:
-            return kiwiStockLabel
-        case mangoStepper:
-            return mangoStockLabel
+        switch sender.tag {
+        case 1:
+            strawberryStockLabel.text = Int(sender.value).description
+            juiceMaker.store.inventory[.strawberry] = Int(sender.value)
+        case 2:
+            bananaStockLabel.text = Int(sender.value).description
+            juiceMaker.store.inventory[.banana] = Int(sender.value)
+        case 3:
+            pineappleStockLabel.text = Int(sender.value).description
+            juiceMaker.store.inventory[.pineapple] = Int(sender.value)
+        case 4:
+            kiwiStockLabel.text = Int(sender.value).description
+            juiceMaker.store.inventory[.kiwi] = Int(sender.value)
+        case 5:
+            mangoStockLabel.text = Int(sender.value).description
+            juiceMaker.store.inventory[.mango] = Int(sender.value)
         default:
-            return nil
+            break
         }
     }
     
-    private func takeFruit(of sender: UIStepper) -> Fruit? {
-        switch sender {
-        case strawberryStepper:
-            return .strawberry
-        case bananaStepper:
-            return .banana
-        case pineappleStepper:
-            return .pineapple
-        case kiwiStepper:
-            return .kiwi
-        case mangoStepper:
-            return .mango
-        default:
-            return nil
+    private func setFruitStepper(number stepper: Int) -> Array<UIStepper> {
+        var fruitStepperArray:Array<UIStepper> = []
+        
+        for tagNumber in 1...stepper {
+            guard let fruitStepper = self.view.viewWithTag(tagNumber) as? UIStepper
+            else { break }
+            fruitStepperArray.append(fruitStepper)
         }
+        
+        return fruitStepperArray
     }
     
     private func checkStepperValue() {
-        strawberryStepper.value = Double(juiceMaker.store.inventory[.strawberry] ?? 0)
-        bananaStepper.value = Double(juiceMaker.store.inventory[.banana] ?? 0)
-        pineappleStepper.value = Double(juiceMaker.store.inventory[.pineapple] ?? 0)
-        kiwiStepper.value = Double(juiceMaker.store.inventory[.kiwi] ?? 0)
-        mangoStepper.value = Double(juiceMaker.store.inventory[.mango] ?? 0)
+        var fruitStepper:Array<UIStepper> = setFruitStepper(number: 5)
+        
+        for fruit in Fruit.allCases {
+            let stepper = fruitStepper.removeFirst()
+            stepper.value = Double(juiceMaker.store.inventory[fruit] ?? 0)
+        }
     }
     
     private func checkInventory() {

--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -26,6 +26,7 @@ class ChangeInventoryViewController: UIViewController {
     @IBAction func actionStepper(_ sender: UIStepper) {
         guard let fruitLabel = takeFruitLabel(of: sender) else { return }
         fruitLabel.text = Int(sender.value).description
+        checkStepperValue(of: sender)
     }
     
     @IBAction private func closeButton(_ sender: UIButton) {
@@ -50,6 +51,22 @@ class ChangeInventoryViewController: UIViewController {
         }
     }
     
+    func checkStepperValue(of sender: UIStepper) {
+//        guard let strawberryValue = Double(juiceMaker.checkStock(of: .strawBerry) ?? "0") else { return }
+//        guard let bananaValue = Double(juiceMaker.checkStock(of: .banana) ?? "0") else { return }
+//        guard let pineAppleValue = Double(juiceMaker.checkStock(of: .pineApple) ?? "0") else { return }
+//        guard let kiwiValue = Double(juiceMaker.checkStock(of: .kiwi) ?? "0") else { return }
+//        guard let mangoValue = Double(juiceMaker.checkStock(of: .mango) ?? "0") else { return }
+//        strawberryStepper.value = strawberryValue
+//        bananaStepper.value = bananaValue
+//        pineappleStepper.value = pineAppleValue
+//        kiwiStepper.value = kiwiValue
+//        mangoStepper.value = mangoValue
+   
+        guard let fruitValue = Double(takeFruitLabel(of: sender)?.text ?? "99" ) else { return }
+        sender.value = fruitValue
+    }
+    
     private func checkInventory() {
         strawberryStockLabel.text = juiceMaker.checkStock(of: .strawBerry)
         bananaStockLabel.text = juiceMaker.checkStock(of: .banana)
@@ -62,5 +79,4 @@ class ChangeInventoryViewController: UIViewController {
         super.viewDidLoad()
         checkInventory()
     }
-
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -32,7 +32,7 @@ class ChangeInventoryViewController: UIViewController {
         guard let fruit = takeFruit(of: sender) else { return }
         guard let fruitLabel = takeFruitLabel(of: sender) else { return }
         fruitLabel.text = Int(sender.value).description
-        JuiceMaker.store.inventory[fruit] = Int(sender.value)
+        juiceMaker.store.inventory[fruit] = Int(sender.value)
     }
     
     private func takeFruitLabel(of sender: UIStepper) -> UILabel? {
@@ -70,11 +70,11 @@ class ChangeInventoryViewController: UIViewController {
     }
     
     private func checkStepperValue() {
-        strawberryStepper.value = Double(JuiceMaker.store.inventory[.strawBerry] ?? 0)
-        bananaStepper.value = Double(JuiceMaker.store.inventory[.banana] ?? 0)
-        pineappleStepper.value = Double(JuiceMaker.store.inventory[.pineApple] ?? 0)
-        kiwiStepper.value = Double(JuiceMaker.store.inventory[.kiwi] ?? 0)
-        mangoStepper.value = Double(JuiceMaker.store.inventory[.mango] ?? 0)
+        strawberryStepper.value = Double(juiceMaker.store.inventory[.strawBerry] ?? 0)
+        bananaStepper.value = Double(juiceMaker.store.inventory[.banana] ?? 0)
+        pineappleStepper.value = Double(juiceMaker.store.inventory[.pineApple] ?? 0)
+        kiwiStepper.value = Double(juiceMaker.store.inventory[.kiwi] ?? 0)
+        mangoStepper.value = Double(juiceMaker.store.inventory[.mango] ?? 0)
     }
     
     private func checkInventory() {

--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -55,11 +55,11 @@ class ChangeInventoryViewController: UIViewController {
     private func takeFruit(of sender: UIStepper) -> Fruit? {
         switch sender {
         case strawberryStepper:
-            return .strawBerry
+            return .strawberry
         case bananaStepper:
             return .banana
         case pineappleStepper:
-            return .pineApple
+            return .pineapple
         case kiwiStepper:
             return .kiwi
         case mangoStepper:
@@ -70,17 +70,17 @@ class ChangeInventoryViewController: UIViewController {
     }
     
     private func checkStepperValue() {
-        strawberryStepper.value = Double(juiceMaker.store.inventory[.strawBerry] ?? 0)
+        strawberryStepper.value = Double(juiceMaker.store.inventory[.strawberry] ?? 0)
         bananaStepper.value = Double(juiceMaker.store.inventory[.banana] ?? 0)
-        pineappleStepper.value = Double(juiceMaker.store.inventory[.pineApple] ?? 0)
+        pineappleStepper.value = Double(juiceMaker.store.inventory[.pineapple] ?? 0)
         kiwiStepper.value = Double(juiceMaker.store.inventory[.kiwi] ?? 0)
         mangoStepper.value = Double(juiceMaker.store.inventory[.mango] ?? 0)
     }
     
     private func checkInventory() {
-        strawberryStockLabel.text = juiceMaker.checkStock(of: .strawBerry)
+        strawberryStockLabel.text = juiceMaker.checkStock(of: .strawberry)
         bananaStockLabel.text = juiceMaker.checkStock(of: .banana)
-        pineappleStockLabel.text = juiceMaker.checkStock(of: .pineApple)
+        pineappleStockLabel.text = juiceMaker.checkStock(of: .pineapple)
         kiwiStockLabel.text = juiceMaker.checkStock(of: .kiwi)
         mangoStockLabel.text = juiceMaker.checkStock(of: .mango)
     }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -26,10 +26,11 @@ class ChangeInventoryViewController: UIViewController {
     @IBAction func actionStepper(_ sender: UIStepper) {
         guard let fruitLabel = takeFruitLabel(of: sender) else { return }
         fruitLabel.text = Int(sender.value).description
-        checkStepperValue(of: sender)
+//        checkStepperValue(of: sender)
     }
     
     @IBAction private func closeButton(_ sender: UIButton) {
+        updateInventory()
         dismiss(animated: true,
                 completion: nil)
     }
@@ -51,20 +52,34 @@ class ChangeInventoryViewController: UIViewController {
         }
     }
     
-    func checkStepperValue(of sender: UIStepper) {
-//        guard let strawberryValue = Double(juiceMaker.checkStock(of: .strawBerry) ?? "0") else { return }
-//        guard let bananaValue = Double(juiceMaker.checkStock(of: .banana) ?? "0") else { return }
-//        guard let pineAppleValue = Double(juiceMaker.checkStock(of: .pineApple) ?? "0") else { return }
-//        guard let kiwiValue = Double(juiceMaker.checkStock(of: .kiwi) ?? "0") else { return }
-//        guard let mangoValue = Double(juiceMaker.checkStock(of: .mango) ?? "0") else { return }
-//        strawberryStepper.value = strawberryValue
-//        bananaStepper.value = bananaValue
-//        pineappleStepper.value = pineAppleValue
-//        kiwiStepper.value = kiwiValue
-//        mangoStepper.value = mangoValue
+    func checkStepperValue() {
+        guard let strawberryValue = Double(juiceMaker.checkStock(of: .strawBerry) ?? "0") else { return }
+        guard let bananaValue = Double(juiceMaker.checkStock(of: .banana) ?? "0") else { return }
+        guard let pineAppleValue = Double(juiceMaker.checkStock(of: .pineApple) ?? "0") else { return }
+        guard let kiwiValue = Double(juiceMaker.checkStock(of: .kiwi) ?? "0") else { return }
+        guard let mangoValue = Double(juiceMaker.checkStock(of: .mango) ?? "0") else { return }
+        strawberryStepper.value = strawberryValue
+        bananaStepper.value = bananaValue
+        pineappleStepper.value = pineAppleValue
+        kiwiStepper.value = kiwiValue
+        mangoStepper.value = mangoValue
    
-        guard let fruitValue = Double(takeFruitLabel(of: sender)?.text ?? "99" ) else { return }
-        sender.value = fruitValue
+//        guard let fruitValue = Double(takeFruitLabel(of: sender)?.text ?? "99" ) else { return }
+//        sender.value = fruitValue
+    }
+    
+    func updateInventory() {
+        guard let strawberryAmount = Int(strawberryStockLabel.text ?? "0") else { return }
+        guard let bananaAmount = Int(bananaStockLabel.text ?? "0") else { return }
+        guard let pineappleAmount = Int(pineappleStockLabel.text ?? "0") else { return }
+        guard let kiwiAmount = Int(kiwiStockLabel.text ?? "0") else { return }
+        guard let mangoAmount = Int(mangoStockLabel.text ?? "0") else { return }
+        
+        JuiceMaker.store.inventory[.strawBerry] = strawberryAmount
+        JuiceMaker.store.inventory[.banana] = bananaAmount
+        JuiceMaker.store.inventory[.pineApple] = pineappleAmount
+        JuiceMaker.store.inventory[.kiwi] = kiwiAmount
+        JuiceMaker.store.inventory[.mango] = mangoAmount
     }
     
     private func checkInventory() {
@@ -78,5 +93,6 @@ class ChangeInventoryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         checkInventory()
+        checkStepperValue()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -24,15 +24,15 @@ class ChangeInventoryViewController: UIViewController {
     @IBOutlet weak var mangoStepper: UIStepper!
     
     @IBAction func closeButton(_ sender: UIButton) {
-        updateInventory()
         dismiss(animated: true,
                 completion: nil)
     }
     
-    @IBAction func actionStepper(_ sender: UIStepper) {
+    @IBAction func setFruitStock(_ sender: UIStepper) {
+        guard let fruit = takeFruit(of: sender) else { return }
         guard let fruitLabel = takeFruitLabel(of: sender) else { return }
         fruitLabel.text = Int(sender.value).description
-        //        checkStepperValue(of: sender)
+        JuiceMaker.store.inventory[fruit] = Int(sender.value)
     }
     
     func takeFruitLabel(of sender: UIStepper) -> UILabel? {
@@ -70,33 +70,11 @@ class ChangeInventoryViewController: UIViewController {
     }
     
     func checkStepperValue() {
-        guard let strawberryValue = Double(juiceMaker.checkStock(of: .strawBerry) ?? "0") else { return }
-        guard let bananaValue = Double(juiceMaker.checkStock(of: .banana) ?? "0") else { return }
-        guard let pineAppleValue = Double(juiceMaker.checkStock(of: .pineApple) ?? "0") else { return }
-        guard let kiwiValue = Double(juiceMaker.checkStock(of: .kiwi) ?? "0") else { return }
-        guard let mangoValue = Double(juiceMaker.checkStock(of: .mango) ?? "0") else { return }
-        strawberryStepper.value = strawberryValue
-        bananaStepper.value = bananaValue
-        pineappleStepper.value = pineAppleValue
-        kiwiStepper.value = kiwiValue
-        mangoStepper.value = mangoValue
-        
-        //        guard let fruitValue = Double(takeFruitLabel(of: sender)?.text ?? "99" ) else { return }
-        //        sender.value = fruitValue
-    }
-    
-    func updateInventory() {
-        guard let strawberryAmount = Int(strawberryStockLabel.text ?? "0") else { return }
-        guard let bananaAmount = Int(bananaStockLabel.text ?? "0") else { return }
-        guard let pineappleAmount = Int(pineappleStockLabel.text ?? "0") else { return }
-        guard let kiwiAmount = Int(kiwiStockLabel.text ?? "0") else { return }
-        guard let mangoAmount = Int(mangoStockLabel.text ?? "0") else { return }
-        
-        JuiceMaker.store.inventory[.strawBerry] = strawberryAmount
-        JuiceMaker.store.inventory[.banana] = bananaAmount
-        JuiceMaker.store.inventory[.pineApple] = pineappleAmount
-        JuiceMaker.store.inventory[.kiwi] = kiwiAmount
-        JuiceMaker.store.inventory[.mango] = mangoAmount
+        strawberryStepper.value = Double(JuiceMaker.store.inventory[.strawBerry] ?? 0)
+        bananaStepper.value = Double(JuiceMaker.store.inventory[.banana] ?? 0)
+        pineappleStepper.value = Double(JuiceMaker.store.inventory[.pineApple] ?? 0)
+        kiwiStepper.value = Double(JuiceMaker.store.inventory[.kiwi] ?? 0)
+        mangoStepper.value = Double(JuiceMaker.store.inventory[.mango] ?? 0)
     }
     
     private func checkInventory() {

--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -29,7 +29,7 @@ class ChangeInventoryViewController: UIViewController {
 //        checkStepperValue(of: sender)
     }
     
-    @IBAction private func closeButton(_ sender: UIButton) {
+    @IBAction func closeButton(_ sender: UIButton) {
         updateInventory()
         dismiss(animated: true,
                 completion: nil)

--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class ChangeInventoryViewController: UIViewController {
-    
     private let juiceMaker = JuiceMaker()
     
     @IBOutlet weak private var strawberryStockLabel: UILabel!
@@ -44,8 +43,8 @@ class ChangeInventoryViewController: UIViewController {
         }
     }
     
-    private func setFruitStepper(number stepper: Int) -> Array<UIStepper> {
-        var fruitStepperArray:Array<UIStepper> = []
+    private func setFruitStepper(number stepper: Int) -> [UIStepper] {
+        var fruitStepperArray: [UIStepper] = []
         
         for tagNumber in 1...stepper {
             guard let fruitStepper = self.view.viewWithTag(tagNumber) as? UIStepper
@@ -57,7 +56,7 @@ class ChangeInventoryViewController: UIViewController {
     }
     
     private func checkStepperValue() {
-        var fruitStepper:Array<UIStepper> = setFruitStepper(number: 5)
+        var fruitStepper: [UIStepper] = setFruitStepper(number: 5)
         
         for fruit in Fruit.allCases {
             let stepper = fruitStepper.removeFirst()

--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -9,14 +9,30 @@ import UIKit
 
 class ChangeInventoryViewController: UIViewController {
     
+    private let juiceMaker = JuiceMaker()
+    
+    @IBOutlet weak private var strawberryStockLabel: UILabel!
+    @IBOutlet weak private var bananaStockLabel: UILabel!
+    @IBOutlet weak private var pineappleStockLabel: UILabel!
+    @IBOutlet weak private var kiwiStockLabel: UILabel!
+    @IBOutlet weak private var mangoStockLabel: UILabel!
+    
     @IBAction private func CloseButton(_ sender: UIButton) {
         dismiss(animated: true,
                 completion: nil)
     }
     
+    private func checkInventory() {
+        strawberryStockLabel.text = juiceMaker.checkStock(of: .strawBerry)
+        bananaStockLabel.text = juiceMaker.checkStock(of: .banana)
+        pineappleStockLabel.text = juiceMaker.checkStock(of: .pineApple)
+        kiwiStockLabel.text = juiceMaker.checkStock(of: .kiwi)
+        mangoStockLabel.text = juiceMaker.checkStock(of: .mango)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        checkInventory()
     }
 
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -17,25 +17,25 @@ class ChangeInventoryViewController: UIViewController {
     @IBOutlet weak private var kiwiStockLabel: UILabel!
     @IBOutlet weak private var mangoStockLabel: UILabel!
     
-    @IBOutlet weak var strawberryStepper: UIStepper!
-    @IBOutlet weak var bananaStepper: UIStepper!
-    @IBOutlet weak var pineappleStepper: UIStepper!
-    @IBOutlet weak var kiwiStepper: UIStepper!
-    @IBOutlet weak var mangoStepper: UIStepper!
+    @IBOutlet weak private var strawberryStepper: UIStepper!
+    @IBOutlet weak private var bananaStepper: UIStepper!
+    @IBOutlet weak private var pineappleStepper: UIStepper!
+    @IBOutlet weak private var kiwiStepper: UIStepper!
+    @IBOutlet weak private var mangoStepper: UIStepper!
     
-    @IBAction func closeButton(_ sender: UIButton) {
+    @IBAction private func closeButton(_ sender: UIButton) {
         dismiss(animated: true,
                 completion: nil)
     }
     
-    @IBAction func setFruitStock(_ sender: UIStepper) {
+    @IBAction private func setFruitStock(_ sender: UIStepper) {
         guard let fruit = takeFruit(of: sender) else { return }
         guard let fruitLabel = takeFruitLabel(of: sender) else { return }
         fruitLabel.text = Int(sender.value).description
         JuiceMaker.store.inventory[fruit] = Int(sender.value)
     }
     
-    func takeFruitLabel(of sender: UIStepper) -> UILabel? {
+    private func takeFruitLabel(of sender: UIStepper) -> UILabel? {
         switch sender {
         case strawberryStepper:
             return strawberryStockLabel
@@ -52,7 +52,7 @@ class ChangeInventoryViewController: UIViewController {
         }
     }
     
-    func takeFruit(of sender: UIStepper) -> Fruit? {
+    private func takeFruit(of sender: UIStepper) -> Fruit? {
         switch sender {
         case strawberryStepper:
             return .strawBerry
@@ -69,7 +69,7 @@ class ChangeInventoryViewController: UIViewController {
         }
     }
     
-    func checkStepperValue() {
+    private func checkStepperValue() {
         strawberryStepper.value = Double(JuiceMaker.store.inventory[.strawBerry] ?? 0)
         bananaStepper.value = Double(JuiceMaker.store.inventory[.banana] ?? 0)
         pineappleStepper.value = Double(JuiceMaker.store.inventory[.pineApple] ?? 0)

--- a/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeInventoryViewController.swift
@@ -23,16 +23,16 @@ class ChangeInventoryViewController: UIViewController {
     @IBOutlet weak var kiwiStepper: UIStepper!
     @IBOutlet weak var mangoStepper: UIStepper!
     
-    @IBAction func actionStepper(_ sender: UIStepper) {
-        guard let fruitLabel = takeFruitLabel(of: sender) else { return }
-        fruitLabel.text = Int(sender.value).description
-//        checkStepperValue(of: sender)
-    }
-    
     @IBAction func closeButton(_ sender: UIButton) {
         updateInventory()
         dismiss(animated: true,
                 completion: nil)
+    }
+    
+    @IBAction func actionStepper(_ sender: UIStepper) {
+        guard let fruitLabel = takeFruitLabel(of: sender) else { return }
+        fruitLabel.text = Int(sender.value).description
+        //        checkStepperValue(of: sender)
     }
     
     func takeFruitLabel(of sender: UIStepper) -> UILabel? {
@@ -52,6 +52,23 @@ class ChangeInventoryViewController: UIViewController {
         }
     }
     
+    func takeFruit(of sender: UIStepper) -> Fruit? {
+        switch sender {
+        case strawberryStepper:
+            return .strawBerry
+        case bananaStepper:
+            return .banana
+        case pineappleStepper:
+            return .pineApple
+        case kiwiStepper:
+            return .kiwi
+        case mangoStepper:
+            return .mango
+        default:
+            return nil
+        }
+    }
+    
     func checkStepperValue() {
         guard let strawberryValue = Double(juiceMaker.checkStock(of: .strawBerry) ?? "0") else { return }
         guard let bananaValue = Double(juiceMaker.checkStock(of: .banana) ?? "0") else { return }
@@ -63,9 +80,9 @@ class ChangeInventoryViewController: UIViewController {
         pineappleStepper.value = pineAppleValue
         kiwiStepper.value = kiwiValue
         mangoStepper.value = mangoValue
-   
-//        guard let fruitValue = Double(takeFruitLabel(of: sender)?.text ?? "99" ) else { return }
-//        sender.value = fruitValue
+        
+        //        guard let fruitValue = Double(takeFruitLabel(of: sender)?.text ?? "99" ) else { return }
+        //        sender.value = fruitValue
     }
     
     func updateInventory() {

--- a/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
@@ -16,82 +16,71 @@ class HomeViewController: UIViewController {
     @IBOutlet weak private var kiwiStockLabel: UILabel!
     @IBOutlet weak private var mangoStockLabel: UILabel!
     
-    @IBAction private func orderStrawberryJuice(_ sender: UIButton) {
-        if juiceMaker.makeJuice(of: .strawBerry) {
-            showSuccessAlert(of: .strawBerry)
+    @IBOutlet weak private var strawberryBananaJuiceOrderButton: UIButton!
+    @IBOutlet weak private var mangoKiwiJuiceOrderButton: UIButton!
+    @IBOutlet weak private var strawberryJuiceOrderButton: UIButton!
+    @IBOutlet weak private var bananaJuiceOrderButton: UIButton!
+    @IBOutlet weak private var pineappleJuiceOrderButton: UIButton!
+    @IBOutlet weak private var kiwiJuiceJuiceOrderButton: UIButton!
+    @IBOutlet weak private var mangoJuiceOrderButton: UIButton!
+    
+    @IBAction private func orderFruitJuice(_ sender: UIButton) {
+        guard let juice = takeJuiceMenu(of: sender) else { return }
+        
+        if juiceMaker.makeJuice(of: juice) {
+            showSuccessAlert(of: juice)
             checkInventory()
         } else {
             showFailAlert()
         }
     }
     
-    @IBAction private func orderBananaJuice(_ sender: UIButton) {
-        if juiceMaker.makeJuice(of: .banana) {
-            showSuccessAlert(of: .banana)
-            checkInventory()
-        } else {
-            showFailAlert()
-        }
-    }
-    
-    @IBAction private func orderPineappleJuice(_ sender: UIButton) {
-        if juiceMaker.makeJuice(of: .pineApple) {
-            showSuccessAlert(of: .pineApple)
-            checkInventory()
-        } else {
-            showFailAlert()
-        }
-    }
-    
-    @IBAction private func orderKiwiJuice(_ sender: UIButton) {
-        if juiceMaker.makeJuice(of: .kiwi) {
-            showSuccessAlert(of: .kiwi)
-            checkInventory()
-        } else {
-            showFailAlert()
-        }
-    }
-    
-    @IBAction private func orderMangoJuice(_ sender: UIButton) {
-        if juiceMaker.makeJuice(of: .mango) {
-            showSuccessAlert(of: .mango)
-            checkInventory()
-        } else {
-            showFailAlert()
-        }
-    }
-    
-    @IBAction private func orderStrawberryBananaJuice(_ sender: UIButton) {
-        if juiceMaker.makeJuice(of: .strawBerryBanana) {
-            showSuccessAlert(of: .strawBerryBanana)
-            checkInventory()
-        } else {
-            showFailAlert()
-        }
-    }
-    
-    @IBAction private func orderMangoKiwi(_ sender: UIButton) {
-        if juiceMaker.makeJuice(of: .mangoKiwi) {
-            showSuccessAlert(of: .mangoKiwi)
-            checkInventory()
-        } else {
-            showFailAlert()
+    func takeJuiceMenu(of sender: UIButton) -> Juice? {
+        switch sender {
+        case strawberryBananaJuiceOrderButton:
+            return .strawBerryBanana
+        case mangoKiwiJuiceOrderButton:
+            return .mangoKiwi
+        case strawberryJuiceOrderButton:
+            return .strawBerry
+        case bananaJuiceOrderButton:
+            return .banana
+        case pineappleJuiceOrderButton:
+            return .pineApple
+        case kiwiJuiceJuiceOrderButton:
+            return .kiwi
+        case mangoJuiceOrderButton:
+            return .mango
+        default:
+            return nil
         }
     }
     
     private func showSuccessAlert(of juice: Juice) {
-        let alert = UIAlertController(title: "제조 완료", message: "\(juice.rawValue)쥬스 나왔습니다! 맛있게 드세요!", preferredStyle: .alert)
-        let ok = UIAlertAction(title: "확인", style: .default, handler: nil)
+        let alert = UIAlertController(title: "제조 완료",
+                                      message: "\(juice.rawValue)쥬스 나왔습니다! 맛있게 드세요!",
+                                      preferredStyle: .alert)
+        let ok = UIAlertAction(title: "확인",
+                               style: .default,
+                               handler: nil)
+        
         alert.addAction(ok)
         present(alert, animated: true, completion: nil)
     }
     
     private func showFailAlert() {
-        let alert = UIAlertController(title: "재고 부족", message: "재료가 모자라요. 재고를 수정할까요?", preferredStyle: .alert)
-        let ok = UIAlertAction(title: "재고수정", style: .default, handler: {_ in
+        let alert = UIAlertController(title: "재고 부족",
+                                      message: "재료가 모자라요. 재고를 수정할까요?",
+                                      preferredStyle: .alert)
+        let ok = UIAlertAction(title: "재고수정",
+                               style: .default,
+                               handler: {_ in
             self.presentChangeInventoryViewController()
         })
-        let cancel = UIAlertAction(title: "취소", style: .default, handler: nil)
+        let cancel = UIAlertAction(title: "취소",
+                                   style: .default,
+                                   handler: nil)
+        
         alert.addAction(cancel)
         alert.addAction(ok)
         present(alert, animated: true, completion: nil)

--- a/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
@@ -28,10 +28,10 @@ class HomeViewController: UIViewController {
         guard let juice = takeJuiceMenu(of: sender) else { return }
         
         if juiceMaker.makeJuice(of: juice) {
-            showSuccessAlert(of: juice)
+            makeAlert(title: "제조 완료", message: "\(juice.rawValue)쥬스 나왔습니다! 맛있게 드세요!", checkSuccess: true)
             checkInventory()
         } else {
-            showFailAlert()
+            makeAlert(title: "재고 부족", message: "재료가 모자라요. 재고를 수정할까요?", checkSuccess: false)
         }
     }
     
@@ -40,15 +40,15 @@ class HomeViewController: UIViewController {
 
         switch sender {
         case strawberryBananaJuiceOrderButton:
-            return .strawBerryBanana
+            return .strawberryBanana
         case mangoKiwiJuiceOrderButton:
             return .mangoKiwi
         case strawberryJuiceOrderButton:
-            return .strawBerry
+            return .strawberry
         case bananaJuiceOrderButton:
             return .banana
         case pineappleJuiceOrderButton:
-            return .pineApple
+            return .pineapple
         case kiwiJuiceJuiceOrderButton:
             return .kiwi
         case mangoJuiceOrderButton:
@@ -58,32 +58,23 @@ class HomeViewController: UIViewController {
         }
     }
     
-    private func showSuccessAlert(of juice: Juice) {
-        let alert = UIAlertController(title: "제조 완료",
-                                      message: "\(juice.rawValue)쥬스 나왔습니다! 맛있게 드세요!",
+    private func makeAlert(title: String, message: String, checkSuccess: Bool) {
+        let alert = UIAlertController(title: title,
+                                      message: message,
                                       preferredStyle: .alert)
         let ok = UIAlertAction(title: "확인",
                                style: .default,
-                               handler: nil)
-        
-        alert.addAction(ok)
-        present(alert, animated: true, completion: nil)
-    }
-    
-    private func showFailAlert() {
-        let alert = UIAlertController(title: "재고 부족",
-                                      message: "재료가 모자라요. 재고를 수정할까요?",
-                                      preferredStyle: .alert)
-        let ok = UIAlertAction(title: "재고수정",
-                               style: .default,
                                handler: {_ in
+            if !checkSuccess {
             self.presentChangeInventoryViewController()
+            }
         })
-        let cancel = UIAlertAction(title: "취소",
-                                   style: .default,
-                                   handler: nil)
-        
-        alert.addAction(cancel)
+        if !checkSuccess {
+            let cancel = UIAlertAction(title: "취소",
+                                       style: .cancel,
+                                       handler: nil)
+            alert.addAction(cancel)
+        }
         alert.addAction(ok)
         present(alert, animated: true, completion: nil)
     }
@@ -97,9 +88,9 @@ class HomeViewController: UIViewController {
     }
     
     private func checkInventory() {
-        strawberryStockLabel.text = juiceMaker.checkStock(of: .strawBerry)
+        strawberryStockLabel.text = juiceMaker.checkStock(of: .strawberry)
         bananaStockLabel.text = juiceMaker.checkStock(of: .banana)
-        pineappleStockLabel.text = juiceMaker.checkStock(of: .pineApple)
+        pineappleStockLabel.text = juiceMaker.checkStock(of: .pineapple)
         kiwiStockLabel.text = juiceMaker.checkStock(of: .kiwi)
         mangoStockLabel.text = juiceMaker.checkStock(of: .mango)
     }

--- a/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
@@ -17,58 +17,84 @@ class HomeViewController: UIViewController {
     @IBOutlet weak private var mangoStockLabel: UILabel!
     
     @IBAction private func orderStrawberryJuice(_ sender: UIButton) {
-        showAlert(of: .strawBerry)
-        checkInventory()
+        if juiceMaker.makeJuice(of: .strawBerry) {
+            showSuccessAlert(of: .strawBerry)
+            checkInventory()
+        } else {
+            showFailAlert()
+        }
     }
     
     @IBAction private func orderBananaJuice(_ sender: UIButton) {
-        showAlert(of: .banana)
-        checkInventory()
+        if juiceMaker.makeJuice(of: .banana) {
+            showSuccessAlert(of: .banana)
+            checkInventory()
+        } else {
+            showFailAlert()
+        }
     }
     
     @IBAction private func orderPineappleJuice(_ sender: UIButton) {
-        showAlert(of: .pineApple)
-        checkInventory()
+        if juiceMaker.makeJuice(of: .pineApple) {
+            showSuccessAlert(of: .pineApple)
+            checkInventory()
+        } else {
+            showFailAlert()
+        }
     }
     
     @IBAction private func orderKiwiJuice(_ sender: UIButton) {
-        showAlert(of: .kiwi)
-        checkInventory()
+        if juiceMaker.makeJuice(of: .kiwi) {
+            showSuccessAlert(of: .kiwi)
+            checkInventory()
+        } else {
+            showFailAlert()
+        }
     }
     
     @IBAction private func orderMangoJuice(_ sender: UIButton) {
-        showAlert(of: .mango)
-        checkInventory()
+        if juiceMaker.makeJuice(of: .mango) {
+            showSuccessAlert(of: .mango)
+            checkInventory()
+        } else {
+            showFailAlert()
+        }
     }
     
     @IBAction private func orderStrawberryBananaJuice(_ sender: UIButton) {
-        showAlert(of: .strawBerryBanana)
-        checkInventory()
+        if juiceMaker.makeJuice(of: .strawBerryBanana) {
+            showSuccessAlert(of: .strawBerryBanana)
+            checkInventory()
+        } else {
+            showFailAlert()
+        }
     }
     
     @IBAction private func orderMangoKiwi(_ sender: UIButton) {
-        showAlert(of: .mangoKiwi)
-        checkInventory()
+        if juiceMaker.makeJuice(of: .mangoKiwi) {
+            showSuccessAlert(of: .mangoKiwi)
+            checkInventory()
+        } else {
+            showFailAlert()
+        }
     }
     
-    private func showAlert(of juice: Juice) {
-        if juiceMaker.makeJuice(of: juice) {
-            let alert = UIAlertController(title: "제조 완료", message: "\(juice.rawValue)쥬스 나왔습니다! 맛있게 드세요!", preferredStyle: .alert)
-            let ok = UIAlertAction(title: "확인", style: .default, handler: nil)
-            
-            alert.addAction(ok)
-            present(alert, animated: true, completion: nil)
-        } else {
-            let alert = UIAlertController(title: "재고 부족", message: "재료가 모자라요. 재고를 수정할까요?", preferredStyle: .alert)
-            let ok = UIAlertAction(title: "재고수정", style: .default, handler: {_ in
-                self.presentChangeInventoryViewController()
-            })
-            let cancel = UIAlertAction(title: "취소", style: .destructive, handler: nil)
-            
-            alert.addAction(cancel)
-            alert.addAction(ok)
-            present(alert, animated: true, completion: nil)
-        }
+    private func showSuccessAlert(of juice: Juice) {
+        let alert = UIAlertController(title: "제조 완료", message: "\(juice.rawValue)쥬스 나왔습니다! 맛있게 드세요!", preferredStyle: .alert)
+        let ok = UIAlertAction(title: "확인", style: .default, handler: nil)
+        alert.addAction(ok)
+        present(alert, animated: true, completion: nil)
+    }
+    
+    private func showFailAlert() {
+        let alert = UIAlertController(title: "재고 부족", message: "재료가 모자라요. 재고를 수정할까요?", preferredStyle: .alert)
+        let ok = UIAlertAction(title: "재고수정", style: .default, handler: {_ in
+            self.presentChangeInventoryViewController()
+        })
+        let cancel = UIAlertAction(title: "취소", style: .default, handler: nil)
+        alert.addAction(cancel)
+        alert.addAction(ok)
+        present(alert, animated: true, completion: nil)
     }
     
     private func presentChangeInventoryViewController() {

--- a/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
@@ -87,7 +87,7 @@ class HomeViewController: UIViewController {
     }
     
     private func presentChangeInventoryViewController() {
-        guard let changeInventoryVC = self.storyboard?.instantiateViewController(withIdentifier: "ChangeInventoryViewController") as? ChangeInventoryViewController else { return }
+        guard let changeInventoryVC = self.storyboard?.instantiateViewController(withIdentifier: "ChangeInventoryNavigationController") as? UIViewController else { return }
         
         changeInventoryVC.modalPresentationStyle = .fullScreen
         changeInventoryVC.modalTransitionStyle = .coverVertical

--- a/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
@@ -89,6 +89,8 @@ class HomeViewController: UIViewController {
     private func presentChangeInventoryViewController() {
         guard let changeInventoryVC = self.storyboard?.instantiateViewController(withIdentifier: "ChangeInventoryViewController") as? ChangeInventoryViewController else { return }
         
+        changeInventoryVC.modalPresentationStyle = .fullScreen
+        changeInventoryVC.modalTransitionStyle = .coverVertical
         self.present(changeInventoryVC, animated: true)
     }
     
@@ -100,8 +102,7 @@ class HomeViewController: UIViewController {
         mangoStockLabel.text = juiceMaker.checkStock(of: .mango)
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func viewWillAppear(_ animated: Bool) {
         checkInventory()
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
@@ -7,7 +7,6 @@
 import UIKit
 
 class HomeViewController: UIViewController {
-    
     private let juiceMaker = JuiceMaker()
     
     @IBOutlet weak private var strawberryStockLabel: UILabel!
@@ -35,9 +34,7 @@ class HomeViewController: UIViewController {
         }
     }
     
-
     private func takeJuiceMenu(of sender: UIButton) -> Juice? {
-
         switch sender {
         case strawberryBananaJuiceOrderButton:
             return .strawberryBanana
@@ -66,15 +63,17 @@ class HomeViewController: UIViewController {
                                style: .default,
                                handler: {_ in
             if !checkSuccess {
-            self.presentChangeInventoryViewController()
+                self.presentChangeInventoryViewController()
             }
         })
         if !checkSuccess {
             let cancel = UIAlertAction(title: "취소",
                                        style: .cancel,
                                        handler: nil)
+            
             alert.addAction(cancel)
         }
+        
         alert.addAction(ok)
         present(alert, animated: true, completion: nil)
     }
@@ -98,5 +97,4 @@ class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         checkInventory()
     }
-    
 }

--- a/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/HomeViewController.swift
@@ -35,7 +35,7 @@ class HomeViewController: UIViewController {
         }
     }
     
-    func takeJuiceMenu(of sender: UIButton) -> Juice? {
+    private func takeJuiceMenu(of sender: UIButton) -> Juice? {
         switch sender {
         case strawberryBananaJuiceOrderButton:
             return .strawBerryBanana

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -5,10 +5,10 @@
 //  Created by Mene, Dragon on 2022/08/30.
 //
 
-enum Fruit: CaseIterable {
-    case strawberry
-    case banana
-    case pineapple
-    case kiwi
-    case mango
+enum Fruit: Int, CaseIterable {
+    case strawberry = 1
+    case banana = 2
+    case pineapple = 3
+    case kiwi = 4
+    case mango = 5
 }

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -6,9 +6,9 @@
 //
 
 enum Fruit: CaseIterable {
-    case strawBerry
+    case strawberry
     case banana
-    case pineApple
+    case pineapple
     case kiwi
     case mango
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -7,9 +7,10 @@
 import Foundation
 
 class FruitStore {
-    var inventory: [Fruit: Int] = [:]
+    static let shared = FruitStore.init(initialFruitAmount: 10)
     
-    init(initialFruitAmount: Int) {
+    var inventory: [Fruit: Int] = [:]
+    private init(initialFruitAmount: Int) {
         Fruit.allCases.forEach { inventory[$0] = initialFruitAmount }
     }
     

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -22,7 +22,6 @@ class FruitStore {
         guard let fruitStock = inventory[fruit] else { return }
         
         if fruitStock < amount {
-            print("수량이 작습니다!")
             return
         }
         

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -6,28 +6,28 @@
 //
 
 enum Juice: String {
-    case strawBerry = "딸기"
+    case strawberry = "딸기"
     case banana = "바나나"
-    case pineApple = "파인애플"
+    case pineapple = "파인애플"
     case kiwi = "키위"
     case mango = "망고"
-    case strawBerryBanana = "딸바"
+    case strawberryBanana = "딸바"
     case mangoKiwi = "망고키위"
     
     var recipe: [Fruit: Int] {
         switch self {
-        case .strawBerry:
-            return [.strawBerry: 16]
+        case .strawberry:
+            return [.strawberry: 16]
         case .banana:
             return [.banana: 2]
-        case .pineApple:
-            return [.pineApple: 2]
+        case .pineapple:
+            return [.pineapple: 2]
         case .kiwi:
             return [.kiwi: 3]
         case .mango:
             return [.mango: 3]
-        case .strawBerryBanana:
-            return [.strawBerry: 10, .banana: 1]
+        case .strawberryBanana:
+            return [.strawberry: 10, .banana: 1]
         case .mangoKiwi:
             return [.mango: 2, .kiwi: 1]
         }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -17,7 +17,6 @@ struct JuiceMaker {
             guard let fruitRequiredNumber = recipe[fruit] else { return false }
             
             if fruitStock < fruitRequiredNumber {
-                print("재고가 부족합니다.")
                 return false
             }
         }
@@ -29,13 +28,11 @@ struct JuiceMaker {
             JuiceMaker.store.inventory[fruit] = fruitStock - fruitRequiredNumber
         }
         
-        print("\(juice.rawValue) 쥬스를 만듭니다.")
         return true
     }
     
     func checkStock(of fruit: Fruit) -> String? {
         guard let fruitStock = JuiceMaker.store.inventory[fruit] else { return nil }
-        debugPrint("\(fruit)의 남은 개수는 \(fruitStock)")
         return String(fruitStock)
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -24,7 +24,7 @@ struct JuiceMaker {
         for (fruit, _) in recipe {
             guard let fruitStock = store.inventory[fruit] else { return false }
             guard let fruitRequiredNumber = recipe[fruit] else { return false }
-
+            
             store.inventory[fruit] = fruitStock - fruitRequiredNumber
         }
         

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,13 +7,13 @@
 import Foundation
 
 struct JuiceMaker {
-    private let store = FruitStore(initialFruitAmount: 10)
+    static let store = FruitStore(initialFruitAmount: 10)
     
     func makeJuice(of juice: Juice) -> Bool {
         let recipe = juice.recipe
         
         for (fruit, _) in recipe {
-            guard let fruitStock = store.inventory[fruit] else { return false }
+            guard let fruitStock = JuiceMaker.store.inventory[fruit] else { return false }
             guard let fruitRequiredNumber = recipe[fruit] else { return false }
             
             if fruitStock < fruitRequiredNumber {
@@ -23,10 +23,10 @@ struct JuiceMaker {
         }
         
         for (fruit, _) in recipe {
-            guard let fruitStock = store.inventory[fruit] else { return false }
+            guard let fruitStock = JuiceMaker.store.inventory[fruit] else { return false }
             guard let fruitRequiredNumber = recipe[fruit] else { return false }
 
-            store.inventory[fruit] = fruitStock - fruitRequiredNumber
+            JuiceMaker.store.inventory[fruit] = fruitStock - fruitRequiredNumber
         }
         
         print("\(juice.rawValue) 쥬스를 만듭니다.")
@@ -34,7 +34,7 @@ struct JuiceMaker {
     }
     
     func checkStock(of fruit: Fruit) -> String? {
-        guard let fruitStock = store.inventory[fruit] else { return nil }
+        guard let fruitStock = JuiceMaker.store.inventory[fruit] else { return nil }
         debugPrint("\(fruit)의 남은 개수는 \(fruitStock)")
         return String(fruitStock)
     }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,14 +7,13 @@
 import Foundation
 
 struct JuiceMaker {
-
-    static let store = FruitStore(initialFruitAmount: 10)
+    let store = FruitStore.shared
     
     func makeJuice(of juice: Juice) -> Bool {
         let recipe = juice.recipe
         
         for (fruit, _) in recipe {
-            guard let fruitStock = JuiceMaker.store.inventory[fruit] else { return false }
+            guard let fruitStock = store.inventory[fruit] else { return false }
             guard let fruitRequiredNumber = recipe[fruit] else { return false }
             
             if fruitStock < fruitRequiredNumber {
@@ -23,17 +22,17 @@ struct JuiceMaker {
         }
         
         for (fruit, _) in recipe {
-            guard let fruitStock = JuiceMaker.store.inventory[fruit] else { return false }
+            guard let fruitStock = store.inventory[fruit] else { return false }
             guard let fruitRequiredNumber = recipe[fruit] else { return false }
 
-            JuiceMaker.store.inventory[fruit] = fruitStock - fruitRequiredNumber
+            store.inventory[fruit] = fruitStock - fruitRequiredNumber
         }
         
         return true
     }
     
     func checkStock(of fruit: Fruit) -> String? {
-        guard let fruitStock = JuiceMaker.store.inventory[fruit] else { return nil }
+        guard let fruitStock = store.inventory[fruit] else { return nil }
         return String(fruitStock)
     }
 }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" id="SPY-pm-Yfa"/>
+                                <segue destination="Yu1-lM-nqp" kind="presentation" modalPresentationStyle="fullScreen" id="SPY-pm-Yfa"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -295,7 +295,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="622" y="156" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="622" y="156" width="25" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -314,7 +314,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="461" y="156" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="461" y="156" width="25" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -333,7 +333,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="303" y="155" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="303" y="155" width="25" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -356,7 +356,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="98" y="161" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="98" y="161" width="25" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -371,7 +371,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="196" y="158" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="196" y="158" width="25" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -399,10 +399,17 @@
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="S2u-nn-1kQ"/>
+                        <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="I0i-6c-4hD"/>
+                        <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="SFx-eZ-zl2"/>
+                        <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="CcW-rZ-3Mr"/>
+                        <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="gqV-cz-MZE"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1451" y="92"/>
+            <point key="canvasLocation" x="1450.9478672985781" y="90.769230769230759"/>
         </scene>
     </scenes>
     <resources>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
-    <device id="retina6_0" orientation="landscape" appearance="light"/>
+    <device id="retina4_7" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
@@ -15,7 +15,7 @@
             <objects>
                 <navigationController storyboardIdentifier="ChangeInventoryNavigationController" id="oed-94-V1F" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="msk-g6-khK">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="667" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -31,23 +31,23 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="HomeViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="60" y="52" width="724" height="136.66666666666666"/>
+                                <rect key="frame" x="16" y="52" width="635" height="131.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="114" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114" height="100.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="108.5" width="114" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -56,16 +56,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="148" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="130" y="0.0" width="114.5" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114.5" height="100.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="108.5" width="114.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -74,16 +74,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="296" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="260.5" y="0.0" width="114" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114" height="100.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="108.5" width="114" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -92,16 +92,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="444" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="390.5" y="0.0" width="114.5" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114.5" height="100.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="108.5" width="114.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -110,16 +110,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="592" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="521" y="0.0" width="114" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114" height="100.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="108.5" width="114" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -130,28 +130,49 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="60" y="208.66666666666663" width="724" height="140.33333333333337"/>
+                                <rect key="frame" x="16" y="203.5" width="635" height="151.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="724" height="66"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="635" height="71.5"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                                <rect key="frame" x="0.0" y="0.0" width="244.5" height="71.5"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <state key="normal" title="딸바쥬스 주문">
-                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <state key="normal">
+                                                    <attributedString key="attributedTitle">
+                                                        <fragment content="딸바쥬스">
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                        <fragment content=" ">
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" metaFont="system" size="15"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                        <fragment content="주문">
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                    </attributedString>
                                                 </state>
                                                 <connections>
                                                     <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fU7-t8-i9N"/>
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="296" y="0.0" width="132" height="66"/>
+                                                <rect key="frame" x="260.5" y="0.0" width="114" height="71.5"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="444" y="0.0" width="280" height="66"/>
+                                                <rect key="frame" x="390.5" y="0.0" width="244.5" height="71.5"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -164,13 +185,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="74.000000000000028" width="724" height="66.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="79.5" width="635" height="72"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="724" height="66.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="635" height="72"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="114" height="72"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -181,7 +202,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="130" y="0.0" width="114.5" height="72"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -192,7 +213,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="260.5" y="0.0" width="114" height="72"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -203,7 +224,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="390.5" y="0.0" width="114.5" height="72"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -214,7 +235,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="521" y="0.0" width="114" height="72"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -283,7 +304,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="667" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -293,129 +314,148 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="66L-FI-VI3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="762" y="-731"/>
+            <point key="canvasLocation" x="762" y="-732"/>
         </scene>
         <!--재고추가-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController storyboardIdentifier="ChangeInventoryViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Yu1-lM-nqp" customClass="ChangeInventoryViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                <rect key="frame" x="590" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="622" y="156" width="25" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="461" y="156" width="25" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                <rect key="frame" x="410" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="RVN-t5-RJN"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="303" y="155" width="25" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                <rect key="frame" x="261" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="kHQ-3i-Wuh"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                <rect key="frame" x="154" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="N3c-Pk-I1Y"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="98" y="161" width="25" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                <rect key="frame" x="60" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="196" y="158" width="25" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                <rect key="frame" x="50" y="192" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="ksx-nP-3Zh"/>
-                                </connections>
-                            </stepper>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="580" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="K2W-EJ-Jvt"/>
-                                </connections>
-                            </stepper>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="ld3-JW-fcj">
+                                <rect key="frame" x="18.5" y="93" width="630" height="189"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="qpG-eO-Ptd">
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="189"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                                <rect key="frame" x="0.0" y="109" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="0.0" y="157" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="ksx-nP-3Zh"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="Dqp-In-PRr">
+                                        <rect key="frame" x="134" y="0.0" width="94" height="189"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                                <rect key="frame" x="0.0" y="109" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="0.0" y="157" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="N3c-Pk-I1Y"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="hw5-t8-KZB">
+                                        <rect key="frame" x="268" y="0.0" width="94" height="189"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
+                                                <rect key="frame" x="0.0" y="109" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                                <rect key="frame" x="0.0" y="157" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="kHQ-3i-Wuh"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="cMV-qd-oE6">
+                                        <rect key="frame" x="402" y="0.0" width="94" height="189"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
+                                                <rect key="frame" x="0.0" y="109" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                                <rect key="frame" x="0.0" y="157" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="RVN-t5-RJN"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="AS5-ZW-bqV">
+                                        <rect key="frame" x="536" y="0.0" width="94" height="189"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                                <rect key="frame" x="0.0" y="109" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                                <rect key="frame" x="0.0" y="157" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="K2W-EJ-Jvt"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ld3-JW-fcj" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="Sle-X4-hoK"/>
+                            <constraint firstItem="ld3-JW-fcj" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="TmC-a9-Kat"/>
+                        </constraints>
                     </view>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" title="재고추가" id="g4W-fY-l7r">

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -302,10 +302,6 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="580" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
                                 <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -324,6 +320,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                 <rect key="frame" x="410" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="RVN-t5-RJN"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
                                 <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
@@ -343,6 +342,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                 <rect key="frame" x="261" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="kHQ-3i-Wuh"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
                                 <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
@@ -354,6 +356,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                 <rect key="frame" x="154" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="N3c-Pk-I1Y"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
                                 <rect key="frame" x="98" y="161" width="25" height="23"/>
@@ -381,6 +386,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="ksx-nP-3Zh"/>
+                                </connections>
                             </stepper>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aGV-Eb-Gzz">
                                 <rect key="frame" x="39" y="0.0" width="61" height="31"/>
@@ -389,9 +397,16 @@
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="Close"/>
                                 <connections>
-                                    <action selector="CloseButton:" destination="Yu1-lM-nqp" eventType="touchDown" id="tLn-JJ-HCn"/>
+                                    <action selector="closeButton:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="3Gs-6P-Bqh"/>
                                 </connections>
                             </button>
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                <rect key="frame" x="580" y="187" width="94" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="K2W-EJ-Jvt"/>
+                                </connections>
+                            </stepper>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -400,10 +415,15 @@
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="YT8-S8-v1C"/>
                         <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="S2u-nn-1kQ"/>
+                        <outlet property="kiwiStepper" destination="klA-59-Nu4" id="ly3-Cy-JHW"/>
                         <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="I0i-6c-4hD"/>
+                        <outlet property="mangoStepper" destination="xbn-6P-grO" id="Gjz-lN-b8w"/>
                         <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="SFx-eZ-zl2"/>
+                        <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="QCa-rC-8KI"/>
                         <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="CcW-rZ-3Mr"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="OEO-nF-2SO"/>
                         <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="gqV-cz-MZE"/>
                     </connections>
                 </viewController>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina4_7" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -41,13 +41,13 @@
                                         <rect key="frame" x="0.0" y="0.0" width="114" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="114" height="100.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114" height="97"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="108.5" width="114" height="23"/>
+                                                <rect key="frame" x="0.0" y="105" width="114" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -59,13 +59,13 @@
                                         <rect key="frame" x="130" y="0.0" width="114.5" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="114.5" height="100.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114.5" height="97"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="108.5" width="114.5" height="23"/>
+                                                <rect key="frame" x="0.0" y="105" width="114.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -77,13 +77,13 @@
                                         <rect key="frame" x="260.5" y="0.0" width="114" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="114" height="100.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114" height="97"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="108.5" width="114" height="23"/>
+                                                <rect key="frame" x="0.0" y="105" width="114" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -95,13 +95,13 @@
                                         <rect key="frame" x="390.5" y="0.0" width="114.5" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="114.5" height="100.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114.5" height="97"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="108.5" width="114.5" height="23"/>
+                                                <rect key="frame" x="0.0" y="105" width="114.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -113,13 +113,13 @@
                                         <rect key="frame" x="521" y="0.0" width="114" height="131.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="114" height="100.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="114" height="97"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="108.5" width="114" height="23"/>
+                                                <rect key="frame" x="0.0" y="105" width="114" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -346,10 +346,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ld3-JW-fcj">
-                                <rect key="frame" x="15" y="93" width="637" height="189"/>
+                                <rect key="frame" x="15" y="91.5" width="637" height="192.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="qpG-eO-Ptd">
-                                        <rect key="frame" x="0.0" y="0.0" width="111.5" height="189"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="111.5" height="192.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
                                                 <rect key="frame" x="18" y="0.0" width="75" height="84"/>
@@ -358,14 +358,14 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="50" y="109" width="11.5" height="23"/>
+                                                <rect key="frame" x="49" y="109" width="13.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="8.5" y="157" width="94" height="32"/>
+                                            <stepper opaque="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="8.5" y="160.5" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="idO-bO-YIO"/>
                                                 </connections>
@@ -373,7 +373,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="Dqp-In-PRr">
-                                        <rect key="frame" x="131.5" y="0.0" width="111.5" height="189"/>
+                                        <rect key="frame" x="131.5" y="0.0" width="111.5" height="192.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
                                                 <rect key="frame" x="18" y="0.0" width="75" height="84"/>
@@ -382,14 +382,14 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="50" y="109" width="11.5" height="23"/>
+                                                <rect key="frame" x="49" y="109" width="13.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="8.5" y="157" width="94" height="32"/>
+                                            <stepper opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="8.5" y="160.5" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="I35-KL-Stz"/>
                                                 </connections>
@@ -397,7 +397,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="hw5-t8-KZB">
-                                        <rect key="frame" x="263" y="0.0" width="111" height="189"/>
+                                        <rect key="frame" x="263" y="0.0" width="111" height="192.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
                                                 <rect key="frame" x="18" y="0.0" width="75" height="84"/>
@@ -406,14 +406,14 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="50" y="109" width="11.5" height="23"/>
+                                                <rect key="frame" x="49" y="109" width="13.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="8.5" y="157" width="94" height="32"/>
+                                            <stepper opaque="NO" tag="3" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                                <rect key="frame" x="8.5" y="160.5" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="BSG-9A-lj2"/>
                                                 </connections>
@@ -421,7 +421,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="cMV-qd-oE6">
-                                        <rect key="frame" x="394" y="0.0" width="111.5" height="189"/>
+                                        <rect key="frame" x="394" y="0.0" width="111.5" height="192.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
                                                 <rect key="frame" x="18.5" y="0.0" width="75" height="84"/>
@@ -430,14 +430,14 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="50" y="109" width="11.5" height="23"/>
+                                                <rect key="frame" x="49" y="109" width="13.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="9" y="157" width="94" height="32"/>
+                                            <stepper opaque="NO" tag="4" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                                <rect key="frame" x="9" y="160.5" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Xhh-EG-C3Q"/>
                                                 </connections>
@@ -445,7 +445,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="AS5-ZW-bqV">
-                                        <rect key="frame" x="525.5" y="0.0" width="111.5" height="189"/>
+                                        <rect key="frame" x="525.5" y="0.0" width="111.5" height="192.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
                                                 <rect key="frame" x="18.5" y="0.0" width="75" height="84"/>
@@ -454,14 +454,14 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="50" y="109" width="11.5" height="23"/>
+                                                <rect key="frame" x="49" y="109" width="13.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="9" y="157" width="94" height="32"/>
+                                            <stepper opaque="NO" tag="5" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                                <rect key="frame" x="9" y="160.5" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="CWo-Dc-gym"/>
                                                 </connections>
@@ -496,15 +496,10 @@
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="YT8-S8-v1C"/>
                         <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="S2u-nn-1kQ"/>
-                        <outlet property="kiwiStepper" destination="klA-59-Nu4" id="ly3-Cy-JHW"/>
                         <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="I0i-6c-4hD"/>
-                        <outlet property="mangoStepper" destination="xbn-6P-grO" id="Gjz-lN-b8w"/>
                         <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="SFx-eZ-zl2"/>
-                        <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="QCa-rC-8KI"/>
                         <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="CcW-rZ-3Mr"/>
-                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="OEO-nF-2SO"/>
                         <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="gqV-cz-MZE"/>
                     </connections>
                 </viewController>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -345,123 +345,123 @@
                         <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="ld3-JW-fcj">
-                                <rect key="frame" x="18.5" y="93" width="630" height="189"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ld3-JW-fcj">
+                                <rect key="frame" x="15" y="93" width="637" height="189"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="qpG-eO-Ptd">
-                                        <rect key="frame" x="0.0" y="0.0" width="94" height="189"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="qpG-eO-Ptd">
+                                        <rect key="frame" x="0.0" y="0.0" width="111.5" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <rect key="frame" x="18" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="0.0" y="109" width="94" height="23"/>
+                                                <rect key="frame" x="50" y="109" width="11.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="0.0" y="157" width="94" height="32"/>
+                                                <rect key="frame" x="8.5" y="157" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="idO-bO-YIO"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="Dqp-In-PRr">
-                                        <rect key="frame" x="134" y="0.0" width="94" height="189"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="Dqp-In-PRr">
+                                        <rect key="frame" x="131.5" y="0.0" width="111.5" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <rect key="frame" x="18" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="0.0" y="109" width="94" height="23"/>
+                                                <rect key="frame" x="50" y="109" width="11.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="0.0" y="157" width="94" height="32"/>
+                                                <rect key="frame" x="8.5" y="157" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="I35-KL-Stz"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="hw5-t8-KZB">
-                                        <rect key="frame" x="268" y="0.0" width="94" height="189"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="hw5-t8-KZB">
+                                        <rect key="frame" x="263" y="0.0" width="111" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <rect key="frame" x="18" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="0.0" y="109" width="94" height="23"/>
+                                                <rect key="frame" x="50" y="109" width="11.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="0.0" y="157" width="94" height="32"/>
+                                                <rect key="frame" x="8.5" y="157" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="BSG-9A-lj2"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="cMV-qd-oE6">
-                                        <rect key="frame" x="402" y="0.0" width="94" height="189"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="cMV-qd-oE6">
+                                        <rect key="frame" x="394" y="0.0" width="111.5" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <rect key="frame" x="18.5" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="0.0" y="109" width="94" height="23"/>
+                                                <rect key="frame" x="50" y="109" width="11.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="0.0" y="157" width="94" height="32"/>
+                                                <rect key="frame" x="9" y="157" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Xhh-EG-C3Q"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="AS5-ZW-bqV">
-                                        <rect key="frame" x="536" y="0.0" width="94" height="189"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="AS5-ZW-bqV">
+                                        <rect key="frame" x="525.5" y="0.0" width="111.5" height="189"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <rect key="frame" x="18.5" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="0.0" y="109" width="94" height="23"/>
+                                                <rect key="frame" x="50" y="109" width="11.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="0.0" y="157" width="94" height="32"/>
+                                                <rect key="frame" x="9" y="157" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="CWo-Dc-gym"/>
                                                 </connections>
@@ -469,13 +469,21 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="hw5-t8-KZB" firstAttribute="width" secondItem="qpG-eO-Ptd" secondAttribute="width" id="863-MH-BP8"/>
+                                    <constraint firstItem="Dqp-In-PRr" firstAttribute="width" secondItem="qpG-eO-Ptd" secondAttribute="width" id="akF-2J-UZa"/>
+                                    <constraint firstItem="cMV-qd-oE6" firstAttribute="width" secondItem="qpG-eO-Ptd" secondAttribute="width" id="awE-B8-ltp"/>
+                                    <constraint firstItem="AS5-ZW-bqV" firstAttribute="width" secondItem="qpG-eO-Ptd" secondAttribute="width" id="ggi-xf-vN0"/>
+                                </constraints>
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="ld3-JW-fcj" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="15" id="7bE-xw-nA6"/>
                             <constraint firstItem="ld3-JW-fcj" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="Sle-X4-hoK"/>
                             <constraint firstItem="ld3-JW-fcj" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="TmC-a9-Kat"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" secondItem="ld3-JW-fcj" secondAttribute="trailing" constant="15" id="XOd-jh-YKS"/>
                         </constraints>
                     </view>
                     <toolbarItems/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -332,7 +332,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="0.0" y="157" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="ksx-nP-3Zh"/>
+                                                    <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="idO-bO-YIO"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -356,7 +356,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="0.0" y="157" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="N3c-Pk-I1Y"/>
+                                                    <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="I35-KL-Stz"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -380,7 +380,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="0.0" y="157" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="kHQ-3i-Wuh"/>
+                                                    <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="BSG-9A-lj2"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -404,7 +404,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="0.0" y="157" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="RVN-t5-RJN"/>
+                                                    <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Xhh-EG-C3Q"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
@@ -428,7 +428,7 @@
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="0.0" y="157" width="94" height="32"/>
                                                 <connections>
-                                                    <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="K2W-EJ-Jvt"/>
+                                                    <action selector="setFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="CWo-Dc-gym"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -10,6 +10,22 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
+        <!--Navigation Controller-->
+        <scene sceneID="6o0-9y-mbe">
+            <objects>
+                <navigationController storyboardIdentifier="ChangeInventoryNavigationController" id="oed-94-V1F" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="msk-g6-khK">
+                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="Yu1-lM-nqp" kind="relationship" relationship="rootViewController" id="Pws-90-B4f"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="EyB-YM-1Wf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1451" y="-732"/>
+        </scene>
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
@@ -238,7 +254,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" modalPresentationStyle="fullScreen" id="SPY-pm-Yfa"/>
+                                <segue destination="oed-94-V1F" kind="presentation" modalPresentationStyle="fullScreen" id="XkL-OX-uNt"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -277,9 +293,9 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="66L-FI-VI3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
+            <point key="canvasLocation" x="762" y="-731"/>
         </scene>
-        <!--Change Inventory View Controller-->
+        <!--재고추가-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController storyboardIdentifier="ChangeInventoryViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Yu1-lM-nqp" customClass="ChangeInventoryViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
@@ -390,16 +406,6 @@
                                     <action selector="actionStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="ksx-nP-3Zh"/>
                                 </connections>
                             </stepper>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aGV-Eb-Gzz">
-                                <rect key="frame" x="39" y="0.0" width="61" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="19"/>
-                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal" title="Close"/>
-                                <connections>
-                                    <action selector="closeButton:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="3Gs-6P-Bqh"/>
-                                </connections>
-                            </button>
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                 <rect key="frame" x="580" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -412,7 +418,13 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <toolbarItems/>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <navigationItem key="navigationItem" title="재고추가" id="g4W-fY-l7r">
+                        <barButtonItem key="rightBarButtonItem" title="닫기" id="GG0-kz-Fhh">
+                            <connections>
+                                <action selector="closeButton:" destination="Yu1-lM-nqp" id="cPi-dn-Gly"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="bananaStepper" destination="O5s-2N-3iP" id="YT8-S8-v1C"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -140,24 +140,10 @@
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <state key="normal">
                                                     <attributedString key="attributedTitle">
-                                                        <fragment content="딸바쥬스">
-                                                            <attributes>
-                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
-                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                            </attributes>
-                                                        </fragment>
-                                                        <fragment content=" ">
+                                                        <fragment content="딸바쥬스 주문">
                                                             <attributes>
                                                                 <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <font key="NSFont" metaFont="system" size="15"/>
-                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                            </attributes>
-                                                        </fragment>
-                                                        <fragment content="주문">
-                                                            <attributes>
-                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
                                                                 <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                             </attributes>
                                                         </fragment>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -127,7 +127,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="orderStrawberryBananaJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RJn-3h-frK"/>
+                                                    <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fU7-t8-i9N"/>
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
@@ -142,7 +142,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="orderMangoKiwi:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fhF-cU-bQg"/>
+                                                    <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hT2-Kx-WT6"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -161,7 +161,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderStrawberryJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="eRe-wf-g1D"/>
+                                                            <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="paq-iK-Bcu"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
@@ -172,7 +172,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderBananaJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="m5X-gV-3QY"/>
+                                                            <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UND-wG-9Ta"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
@@ -183,7 +183,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderPineappleJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hfi-nN-RAG"/>
+                                                            <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xYP-Bu-XJF"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
@@ -194,7 +194,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderKiwiJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="FDP-Ai-uzH"/>
+                                                            <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xpP-wg-jX4"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
@@ -205,7 +205,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderMangoJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LZe-ju-EbA"/>
+                                                            <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Nv6-B2-XHe"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>
@@ -243,10 +243,17 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="bananaJuiceOrderButton" destination="y2A-PH-DJY" id="Iyf-lC-dvZ"/>
                         <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="UFB-ha-F3y"/>
+                        <outlet property="kiwiJuiceJuiceOrderButton" destination="wcW-7H-RXw" id="lCG-X1-7mA"/>
                         <outlet property="kiwiStockLabel" destination="FZq-de-TJG" id="tLt-RN-bxm"/>
+                        <outlet property="mangoJuiceOrderButton" destination="q6G-4X-bVm" id="IZ7-oW-mCW"/>
+                        <outlet property="mangoKiwiJuiceOrderButton" destination="ngP-kF-Yii" id="3hb-j3-rf7"/>
                         <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="Ac7-po-mYj"/>
+                        <outlet property="pineappleJuiceOrderButton" destination="BFb-ka-wGA" id="BhW-My-TUJ"/>
                         <outlet property="pineappleStockLabel" destination="ccQ-Dk-PuY" id="E1d-m5-veC"/>
+                        <outlet property="strawberryBananaJuiceOrderButton" destination="hrc-2F-fzl" id="yvn-iH-DTG"/>
+                        <outlet property="strawberryJuiceOrderButton" destination="avd-o5-3JM" id="TzO-op-mHu"/>
                         <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="iCb-LM-iq6"/>
                     </connections>
                 </viewController>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -135,20 +135,19 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
                                         <rect key="frame" x="0.0" y="0.0" width="635" height="71.5"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
                                                 <rect key="frame" x="0.0" y="0.0" width="244.5" height="71.5"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
-                                                <state key="normal">
-                                                    <attributedString key="attributedTitle">
-                                                        <fragment content="딸바쥬스 주문">
-                                                            <attributes>
-                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                <font key="NSFont" metaFont="system" size="15"/>
-                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                            </attributes>
-                                                        </fragment>
-                                                    </attributedString>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <state key="normal" title="딸바쥬스 주문">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <variation key="heightClass=compact-widthClass=compact">
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                </variation>
+                                                <variation key="heightClass=regular-widthClass=regular">
+                                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                </variation>
                                                 <connections>
                                                     <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fU7-t8-i9N"/>
                                                 </connections>
@@ -164,6 +163,12 @@
                                                 <state key="normal" title="망키쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <variation key="heightClass=compact-widthClass=compact">
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                </variation>
+                                                <variation key="heightClass=regular-widthClass=regular">
+                                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                </variation>
                                                 <connections>
                                                     <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hT2-Kx-WT6"/>
                                                 </connections>
@@ -183,6 +188,12 @@
                                                         <state key="normal" title="딸기쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <variation key="heightClass=compact-widthClass=compact">
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                        </variation>
+                                                        <variation key="heightClass=regular-widthClass=regular">
+                                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                        </variation>
                                                         <connections>
                                                             <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="paq-iK-Bcu"/>
                                                         </connections>
@@ -194,6 +205,12 @@
                                                         <state key="normal" title="바나나쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <variation key="heightClass=compact-widthClass=compact">
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                        </variation>
+                                                        <variation key="heightClass=regular-widthClass=regular">
+                                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                        </variation>
                                                         <connections>
                                                             <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UND-wG-9Ta"/>
                                                         </connections>
@@ -205,6 +222,12 @@
                                                         <state key="normal" title="파인애플쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <variation key="heightClass=compact-widthClass=compact">
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                        </variation>
+                                                        <variation key="heightClass=regular-widthClass=regular">
+                                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                        </variation>
                                                         <connections>
                                                             <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xYP-Bu-XJF"/>
                                                         </connections>
@@ -216,6 +239,12 @@
                                                         <state key="normal" title="키위쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <variation key="heightClass=compact-widthClass=compact">
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                        </variation>
+                                                        <variation key="heightClass=regular-widthClass=regular">
+                                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                        </variation>
                                                         <connections>
                                                             <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xpP-wg-jX4"/>
                                                         </connections>
@@ -227,6 +256,12 @@
                                                         <state key="normal" title="망고쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <variation key="heightClass=compact-widthClass=compact">
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                        </variation>
+                                                        <variation key="heightClass=regular-widthClass=regular">
+                                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                        </variation>
                                                         <connections>
                                                             <action selector="orderFruitJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Nv6-B2-XHe"/>
                                                         </connections>


### PR DESCRIPTION
@SungPyo
안녕하세요! `내일날씨맑음`

STEP 3 완료하고 PR 드립니다.

- 뷰 컨트롤러 사이에 과일 재고 데이터를 전달하는 방식에 대해 고민해 보았습니다.

- 스테퍼의 초기값 설정 방법에 대해 고민해 보았습니다.

- STEP 2에서 뷰컨트롤러 상에 구현해 놓았던 Close버튼을 요구사항에 따라 네비게이션 콘트롤러를 사용하여 `닫기` 버튼으로 변경하였습니다.

- 기기 크기에 따라 화면을 보여줄 수 있도록 Auto Layout 적용을 위해 고민하였습니다.


## 고민했던 점
- 뷰 컨트롤러 사이에서 과일 재고 데이터를 전달하는 방식에 대해 여러 방법을 생각해 보았지만, juiceMaker 파일의 store를 static으로 설정하여 사용하였습니다.

- `HomeViewController`에서 인벤토리에 있는 값을 매번 어떻게 가져올지 고민하다가, ViewWillAppear함수를 사용하여 매번 뷰가 올라올때마다 데이터를 가져오는 방식으로 구현하였습니다.
    - ViewWillAppear함수 활용을 위해 presentChangeInventoryViewController함수에서 changeInventoryVC.modalPresentationStyle = .fullScreen로 설정해주었습니다.

- `ChangeInventoryViewController`에서 Stepper의 Value값을 Stepper를 누를때마다 인벤토리에서 값을 읽어오도록 구현하고 싶었으나 누를때마다 값을 읽어오니 값이 고정되어 값이 변화하지 않아, ViewDidLoad함수에서 최초로딩할 때 전체 Stepper의 Value값을 가져오는 방식으로 구현하였습니다.

- `HomeViewController` 화면에서 기기 사이즈가 작은 경우 버튼의 텍스트가 `파인..주문`으로 노출되는 문제를 해결하기 위해 화면크기에 따라 폰트사이즈가 조절되도록 구현할 수 있도록 고민해 보았습니다.
    - 처음 생각한 방법: 버튼의 텍스트를 2줄로 줄바꿈하여 보여주면 ...으로 생략되지 않을 것 같아 버튼 title을 `Plain`에서 `Attributed`로 변경하고 줄바꿈해 보았지만 버튼 상에 첫번째 줄만 노출되는 문제가 있었습니다
    - 해결방안: 폰트에서 Body로 Compact & Regular 각각의 사이즈를 주어 작은 화면에서도 폰트가 ...으로 생략되지 않도록 구현하였습니다.
    
- `ChangeInventoryViewController` 화면에서 오토레이아웃을 적용하기 위해 고민해 보았습니다.
    - 각각의 요소에 뷰 컨트롤러를 적용하기는 어려울 것 같아서 `Vertical Stack View`를 사용하여 과일/갯수 레이블 / 스태퍼를 묶어주고, 5개의 과일 묶음을 `Horizontal Stack View`를 이용하여 다시 묶어주었습니다.
 
## 해결이 되지 않은 점
- STEP 3의 요구사항은 일단 만족은 시킨 것 같습니다.

## 조언을 얻고 싶은 부분
- checkInventory함수와 checkStepperValue함수를 현재 하나씩 초기값을 넣어주는 방식이 아닌 반복문을 돌려 많은 값을 넣어줘야하는 상황에서도 편리하게 초기값 셋팅을 하고자 하였으나, 개선하지 못하고 하나씩 초기값을 넣는 식으로 구현하였습니다...
    - 혹시, 위 2가지 함수를 어떻게 개선하면 좋을지 의견 주시면 감사하겠습니다!

- ChangeInventoryViewController에서 ViewDidLoad함수안에 checkInventory를 통해 Label의 초기값을 셋팅해주고, checkStepperValue를 통해 Stepper의 초기값을 셋팅해두었습니다.
    - 혹시, 각각의 초기값을 따로 설정해주는게 좋은 접근인지, 아니면 초기값은 하나의 함수에 묶어서 처리해주는게 좋은 접근인지 의견 주시면 감사하겠습니다!

- 현재 Stepper를 누를때마다 값을 +, -하고 Label에 값을 바꿔준 뒤 인벤토리에 값을 바로 업데이트 해주는 방식입니다.
    - 혹시, 업데이트를 자주하는 방식이 아닌 Label 값만을 바꿔주다가 Dismiss될 때 최종값을 인벤토리에 업데이트 해주는게 좋은 접근인지 의견 주시면 감사하겠습니다!

- STEP 3 요구사항에 `ChangeInventoryViewController`에 네비게이션 컨트롤러를 사용하여 타이틀을 추가하고 버튼을 적용하도록 되어 있어서 사용하긴 했는데, 직접 뷰 컨트롤러에 Label과 버튼을 사용하는 방식대비 어떤점이 좋은지 잘 모르겠습니다. 이전 STEP을 진행하면서 화면전환 방식에 대해 고민했을 때에도 `재고수정`이라는 새로운 context를 만드는 것이라 생각하고 모달로 구현을 했는데 네비게이션 바를 사용하는 것에 대한 이점이 있을까요?