### PR TITLE
쥬스메이커 [STEP 3] Gundy, 준호

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BFC4A0D328CEC17B008101DF /* FruitStoreDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC4A0D228CEC17B008101DF /* FruitStoreDelegate.swift */; };
 		BFC7C35B28BD9F5E00DF9406 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC7C35A28BD9F5E00DF9406 /* Fruit.swift */; };
 		BFC7C35D28BDCF4100DF9406 /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC7C35C28BDCF4100DF9406 /* Juice.swift */; };
 		BFE6A9AF28C83110008A0D84 /* AlertText.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE6A9AE28C83110008A0D84 /* AlertText.swift */; };
@@ -23,6 +24,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BFC4A0D228CEC17B008101DF /* FruitStoreDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStoreDelegate.swift; sourceTree = "<group>"; };
 		BFC7C35A28BD9F5E00DF9406 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		BFC7C35C28BDCF4100DF9406 /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
 		BFE6A9AE28C83110008A0D84 /* AlertText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertText.swift; sourceTree = "<group>"; };
@@ -65,12 +67,13 @@
 		C71CD66F266C7B500038B9CB /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
-				BFC7C35C28BDCF4100DF9406 /* Juice.swift */,
+				BFE6A9AE28C83110008A0D84 /* AlertText.swift */,
+				BFC7C35A28BD9F5E00DF9406 /* Fruit.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				EB98D8D728BDF11E00BB1553 /* FruitStoreError.swift */,
-				BFC7C35A28BD9F5E00DF9406 /* Fruit.swift */,
-				BFE6A9AE28C83110008A0D84 /* AlertText.swift */,
+				BFC4A0D228CEC17B008101DF /* FruitStoreDelegate.swift */,
+				BFC7C35C28BDCF4100DF9406 /* Juice.swift */,
+				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -189,6 +192,7 @@
 				BFC7C35D28BDCF4100DF9406 /* Juice.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
+				BFC4A0D328CEC17B008101DF /* FruitStoreDelegate.swift in Sources */,
 				EBFB25CB28C5E9920058D16C /* StockEditViewController.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -8,7 +8,49 @@
 import UIKit
 
 class StockEditViewController: UIViewController {
+    
+    weak var delegate: FruitStoreDelegate?
+    
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var mangoStockLabel: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        updateFruitStockLabel()
+    }
+    
     @IBAction func touchUpDismissButton(_ sender: UIButton) {
         dismiss(animated: true)
+    }
+    
+    func updateFruitStockLabel() {
+        if let strawberryStock = try? delegate?.fruitStore.currentStock(of: .strawberry) {
+            strawberryStockLabel.text = "\(strawberryStock)"
+        } else {
+            strawberryStockLabel.text = FruitStoreError.notExist
+        }
+        if let bananaStock = try? delegate?.fruitStore.currentStock(of: .banana) {
+            bananaStockLabel.text = "\(bananaStock)"
+        } else {
+            bananaStockLabel.text = FruitStoreError.notExist
+        }
+        if let kiwiStock = try? delegate?.fruitStore.currentStock(of: .kiwi) {
+            kiwiStockLabel.text = "\(kiwiStock)"
+        } else {
+            kiwiStockLabel.text = FruitStoreError.notExist
+        }
+        if let pineappleStock = try? delegate?.fruitStore.currentStock(of: .pineapple) {
+            pineappleStockLabel.text = "\(pineappleStock)"
+        } else {
+            pineappleStockLabel.text = FruitStoreError.notExist
+        }
+        if let mangoStock = try? delegate?.fruitStore.currentStock(of: .mango) {
+            mangoStockLabel.text = "\(mangoStock)"
+        } else {
+            mangoStockLabel.text = FruitStoreError.notExist
+        }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -10,11 +10,6 @@ import UIKit
 class StockEditViewController: UIViewController {
     
     weak var delegate: FruitStoreDelegate?
-    var amountOfStrawberryStockToChange: Int = 0
-    var amountOfBananaStockToChange: Int = 0
-    var amountOfKiwiStockToChange: Int = 0
-    var amountOfPineappleStockToChange: Int = 0
-    var amountOfMangoStockToChange: Int = 0
     
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
@@ -29,7 +24,7 @@ class StockEditViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        updateFruitStockLabel()
+        updateFruitStock()
     }
     
     @IBAction func touchUpDismissButton(_ sender: UIButton) {
@@ -39,83 +34,67 @@ class StockEditViewController: UIViewController {
     @IBAction func touchUpStepper(_ sender: UIStepper) {
         switch sender {
         case straberryStockStepper:
-            amountOfStrawberryStockToChange = Int(sender.value)
-            guard let currentStock = try? delegate?.fruitStore.currentStock(of: .strawberry) else {
-                return
+            if let changedStock = changeStock(of: .strawberry, by: sender) {
+                strawberryStockLabel.text = "\(changedStock)"
             }
-            guard currentStock + amountOfStrawberryStockToChange >= 0 else {
-                amountOfStrawberryStockToChange += 1
-                return
-            }
-            strawberryStockLabel.text = "\(currentStock + amountOfStrawberryStockToChange)"
         case bananaStockStepper:
-            amountOfBananaStockToChange = Int(sender.value)
-            guard let currentStock = try? delegate?.fruitStore.currentStock(of: .banana) else {
-                return
+            if let changedStock = changeStock(of: .banana, by: sender) {
+                bananaStockLabel.text = "\(changedStock)"
             }
-            guard currentStock + amountOfBananaStockToChange >= 0 else {
-                amountOfBananaStockToChange += 1
-                return
-            }
-            bananaStockLabel.text = "\(currentStock + amountOfBananaStockToChange)"
         case kiwiStockStepper:
-            amountOfKiwiStockToChange = Int(sender.value)
-            guard let currentStock = try? delegate?.fruitStore.currentStock(of: .kiwi) else {
-                return
+            if let changedStock = changeStock(of: .kiwi, by: sender) {
+                kiwiStockLabel.text = "\(changedStock)"
             }
-            guard currentStock + amountOfKiwiStockToChange >= 0 else {
-                amountOfKiwiStockToChange += 1
-                return
-            }
-            kiwiStockLabel.text = "\(currentStock + amountOfKiwiStockToChange)"
         case pineappleStockStepper:
-            amountOfPineappleStockToChange = Int(sender.value)
-            guard let currentStock = try? delegate?.fruitStore.currentStock(of: .pineapple) else {
-                return
+            if let changedStock = changeStock(of: .pineapple, by: sender) {
+                pineappleStockLabel.text = "\(changedStock)"
             }
-            guard currentStock + amountOfPineappleStockToChange >= 0 else {
-                amountOfPineappleStockToChange += 1
-                return
-            }
-            pineappleStockLabel.text = "\(currentStock + amountOfPineappleStockToChange)"
         case mangoStockStepper:
-            amountOfMangoStockToChange = Int(sender.value)
-            guard let currentStock = try? delegate?.fruitStore.currentStock(of: .mango) else {
-                return
+            if let changedStock = changeStock(of: .mango, by: sender) {
+                mangoStockLabel.text = "\(changedStock)"
             }
-            guard currentStock + amountOfMangoStockToChange >= 0 else {
-                amountOfMangoStockToChange += 1 
-                return
-            }
-            mangoStockLabel.text = "\(currentStock + amountOfMangoStockToChange)"
         default:
             return
         }
     }
     
-    func updateFruitStockLabel() {
+    func changeStock(of fruit: Fruit, by stockStepper: UIStepper) -> Int? {
+        guard let currentStock = try? delegate?.fruitStore.currentStock(of: fruit) else {
+            return nil
+        }
+        let stockAmountToChange: Int = Int(stockStepper.value) - currentStock
+        delegate?.fruitStore.changeStock(of: fruit, by: stockAmountToChange)
+        return currentStock + stockAmountToChange
+    }
+    
+    func updateFruitStock() {
         if let strawberryStock = try? delegate?.fruitStore.currentStock(of: .strawberry) {
             strawberryStockLabel.text = "\(strawberryStock)"
+            straberryStockStepper.value = Double(strawberryStock)
         } else {
             strawberryStockLabel.text = FruitStoreError.notExist
         }
         if let bananaStock = try? delegate?.fruitStore.currentStock(of: .banana) {
             bananaStockLabel.text = "\(bananaStock)"
+            bananaStockStepper.value = Double(bananaStock)
         } else {
             bananaStockLabel.text = FruitStoreError.notExist
         }
         if let kiwiStock = try? delegate?.fruitStore.currentStock(of: .kiwi) {
             kiwiStockLabel.text = "\(kiwiStock)"
+            kiwiStockStepper.value = Double(kiwiStock)
         } else {
             kiwiStockLabel.text = FruitStoreError.notExist
         }
         if let pineappleStock = try? delegate?.fruitStore.currentStock(of: .pineapple) {
             pineappleStockLabel.text = "\(pineappleStock)"
+            pineappleStockStepper.value = Double(pineappleStock)
         } else {
             pineappleStockLabel.text = FruitStoreError.notExist
         }
         if let mangoStock = try? delegate?.fruitStore.currentStock(of: .mango) {
             mangoStockLabel.text = "\(mangoStock)"
+            mangoStockStepper.value = Double(mangoStock)
         } else {
             mangoStockLabel.text = FruitStoreError.notExist
         }

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -10,12 +10,22 @@ import UIKit
 class StockEditViewController: UIViewController {
     
     weak var delegate: FruitStoreDelegate?
+    var amountOfStrawberryStockToChange: Int = 0
+    var amountOfBananaStockToChange: Int = 0
+    var amountOfKiwiStockToChange: Int = 0
+    var amountOfPineappleStockToChange: Int = 0
+    var amountOfMangoStockToChange: Int = 0
     
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var pineappleStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
+    @IBOutlet weak var straberryStockStepper: UIStepper!
+    @IBOutlet weak var bananaStockStepper: UIStepper!
+    @IBOutlet weak var kiwiStockStepper: UIStepper!
+    @IBOutlet weak var pineappleStockStepper: UIStepper!
+    @IBOutlet weak var mangoStockStepper: UIStepper!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,6 +34,63 @@ class StockEditViewController: UIViewController {
     
     @IBAction func touchUpDismissButton(_ sender: UIButton) {
         dismiss(animated: true)
+    }
+    
+    @IBAction func touchUpStepper(_ sender: UIStepper) {
+        switch sender {
+        case straberryStockStepper:
+            amountOfStrawberryStockToChange = Int(sender.value)
+            guard let currentStock = try? delegate?.fruitStore.currentStock(of: .strawberry) else {
+                return
+            }
+            guard currentStock + amountOfStrawberryStockToChange >= 0 else {
+                amountOfStrawberryStockToChange += 1
+                return
+            }
+            strawberryStockLabel.text = "\(currentStock + amountOfStrawberryStockToChange)"
+        case bananaStockStepper:
+            amountOfBananaStockToChange = Int(sender.value)
+            guard let currentStock = try? delegate?.fruitStore.currentStock(of: .banana) else {
+                return
+            }
+            guard currentStock + amountOfBananaStockToChange >= 0 else {
+                amountOfBananaStockToChange += 1
+                return
+            }
+            bananaStockLabel.text = "\(currentStock + amountOfBananaStockToChange)"
+        case kiwiStockStepper:
+            amountOfKiwiStockToChange = Int(sender.value)
+            guard let currentStock = try? delegate?.fruitStore.currentStock(of: .kiwi) else {
+                return
+            }
+            guard currentStock + amountOfKiwiStockToChange >= 0 else {
+                amountOfKiwiStockToChange += 1
+                return
+            }
+            kiwiStockLabel.text = "\(currentStock + amountOfKiwiStockToChange)"
+        case pineappleStockStepper:
+            amountOfPineappleStockToChange = Int(sender.value)
+            guard let currentStock = try? delegate?.fruitStore.currentStock(of: .pineapple) else {
+                return
+            }
+            guard currentStock + amountOfPineappleStockToChange >= 0 else {
+                amountOfPineappleStockToChange += 1
+                return
+            }
+            pineappleStockLabel.text = "\(currentStock + amountOfPineappleStockToChange)"
+        case mangoStockStepper:
+            amountOfMangoStockToChange = Int(sender.value)
+            guard let currentStock = try? delegate?.fruitStore.currentStock(of: .mango) else {
+                return
+            }
+            guard currentStock + amountOfMangoStockToChange >= 0 else {
+                amountOfMangoStockToChange += 1 
+                return
+            }
+            mangoStockLabel.text = "\(currentStock + amountOfMangoStockToChange)"
+        default:
+            return
+        }
     }
     
     func updateFruitStockLabel() {

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -11,29 +11,29 @@ class StockEditViewController: UIViewController {
     
     weak var delegate: FruitStoreDelegate?
     
-    @IBOutlet weak var strawberryStockLabel: UILabel!
-    @IBOutlet weak var bananaStockLabel: UILabel!
-    @IBOutlet weak var kiwiStockLabel: UILabel!
-    @IBOutlet weak var pineappleStockLabel: UILabel!
-    @IBOutlet weak var mangoStockLabel: UILabel!
-    @IBOutlet weak var straberryStockStepper: UIStepper!
-    @IBOutlet weak var bananaStockStepper: UIStepper!
-    @IBOutlet weak var kiwiStockStepper: UIStepper!
-    @IBOutlet weak var pineappleStockStepper: UIStepper!
-    @IBOutlet weak var mangoStockStepper: UIStepper!
+    @IBOutlet private weak var strawberryStockLabel: UILabel!
+    @IBOutlet private weak var bananaStockLabel: UILabel!
+    @IBOutlet private weak var kiwiStockLabel: UILabel!
+    @IBOutlet private weak var pineappleStockLabel: UILabel!
+    @IBOutlet private weak var mangoStockLabel: UILabel!
+    @IBOutlet private weak var strawberryStockStepper: UIStepper!
+    @IBOutlet private weak var bananaStockStepper: UIStepper!
+    @IBOutlet private weak var kiwiStockStepper: UIStepper!
+    @IBOutlet private weak var pineappleStockStepper: UIStepper!
+    @IBOutlet private weak var mangoStockStepper: UIStepper!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         updateFruitStock()
     }
     
-    @IBAction func touchUpDismissButton(_ sender: UIButton) {
+    @IBAction private func touchUpDismissButton(_ sender: UIButton) {
         dismiss(animated: true)
     }
     
-    @IBAction func touchUpStepper(_ sender: UIStepper) {
+    @IBAction private func touchUpStepper(_ sender: UIStepper) {
         switch sender {
-        case straberryStockStepper:
+        case strawberryStockStepper:
             if let changedStock = changeStock(of: .strawberry, by: sender) {
                 strawberryStockLabel.text = "\(changedStock)"
             }
@@ -58,7 +58,7 @@ class StockEditViewController: UIViewController {
         }
     }
     
-    func changeStock(of fruit: Fruit, by stockStepper: UIStepper) -> Int? {
+    private func changeStock(of fruit: Fruit, by stockStepper: UIStepper) -> Int? {
         guard let currentStock = try? delegate?.fruitStore.currentStock(of: fruit) else {
             return nil
         }
@@ -67,13 +67,13 @@ class StockEditViewController: UIViewController {
         return currentStock + stockAmountToChange
     }
     
-    func updateFruitStock() {
+    private func updateFruitStock() {
         if let strawberryStock = try? delegate?.fruitStore.currentStock(of: .strawberry) {
             strawberryStockLabel.text = "\(strawberryStock)"
-            straberryStockStepper.value = Double(strawberryStock)
+            strawberryStockStepper.value = Double(strawberryStock)
         } else {
             strawberryStockLabel.text = FruitStoreError.notExist
-            straberryStockStepper.isEnabled = false
+            strawberryStockStepper.isEnabled = false
         }
         if let bananaStock = try? delegate?.fruitStore.currentStock(of: .banana) {
             bananaStockLabel.text = "\(bananaStock)"

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -62,46 +62,39 @@ class StockEditViewController: UIViewController {
         guard let currentStock = try? delegate?.fruitStore.currentStock(of: fruit) else {
             return nil
         }
-        let stockAmountToChange: Int = Int(stockStepper.value) - currentStock
+        let stockStepperValue: Int = Int(stockStepper.value)
+        let stockAmountToChange: Int = stockStepperValue - currentStock
         delegate?.fruitStore.changeStock(of: fruit, by: stockAmountToChange)
         return currentStock + stockAmountToChange
     }
     
     private func updateFruitStock() {
-        if let strawberryStock = try? delegate?.fruitStore.currentStock(of: .strawberry) {
-            strawberryStockLabel.text = "\(strawberryStock)"
-            strawberryStockStepper.value = Double(strawberryStock)
-        } else {
-            strawberryStockLabel.text = FruitStoreError.notExist
-            strawberryStockStepper.isEnabled = false
+        for fruit in Fruit.allCases {
+            let fruitStock: Int? = try? delegate?.fruitStore.currentStock(of: fruit)
+            updateFruitStockLabel(of: fruit, to: fruitStock)
+            updateFruitStockStepper(of: fruit, to: fruitStock)
         }
-        if let bananaStock = try? delegate?.fruitStore.currentStock(of: .banana) {
-            bananaStockLabel.text = "\(bananaStock)"
-            bananaStockStepper.value = Double(bananaStock)
-        } else {
-            bananaStockLabel.text = FruitStoreError.notExist
-            bananaStockStepper.isEnabled = false
+    }
+    
+    private func updateFruitStockLabel(of fruit: Fruit, to fruitStock: Int?) {
+        guard let label = self.view.viewWithTag(fruit.rawValue) as? UILabel else {
+            return
         }
-        if let kiwiStock = try? delegate?.fruitStore.currentStock(of: .kiwi) {
-            kiwiStockLabel.text = "\(kiwiStock)"
-            kiwiStockStepper.value = Double(kiwiStock)
+        if let stock = fruitStock {
+            label.text = "\(stock)"
         } else {
-            kiwiStockLabel.text = FruitStoreError.notExist
-            kiwiStockStepper.isEnabled = false
+            label.text = FruitStoreError.notExist
         }
-        if let pineappleStock = try? delegate?.fruitStore.currentStock(of: .pineapple) {
-            pineappleStockLabel.text = "\(pineappleStock)"
-            pineappleStockStepper.value = Double(pineappleStock)
-        } else {
-            pineappleStockLabel.text = FruitStoreError.notExist
-            pineappleStockStepper.isEnabled = false
+    }
+    
+    private func updateFruitStockStepper(of fruit: Fruit, to fruitStock: Int?) {
+        guard let stepper = self.view.viewWithTag(-fruit.rawValue) as? UIStepper  else {
+            return
         }
-        if let mangoStock = try? delegate?.fruitStore.currentStock(of: .mango) {
-            mangoStockLabel.text = "\(mangoStock)"
-            mangoStockStepper.value = Double(mangoStock)
+        if let stock = fruitStock {
+            stepper.value = Double(stock)
         } else {
-            mangoStockLabel.text = FruitStoreError.notExist
-            mangoStockStepper.isEnabled = false
+            stepper.isEnabled = false
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -73,30 +73,35 @@ class StockEditViewController: UIViewController {
             straberryStockStepper.value = Double(strawberryStock)
         } else {
             strawberryStockLabel.text = FruitStoreError.notExist
+            straberryStockStepper.isEnabled = false
         }
         if let bananaStock = try? delegate?.fruitStore.currentStock(of: .banana) {
             bananaStockLabel.text = "\(bananaStock)"
             bananaStockStepper.value = Double(bananaStock)
         } else {
             bananaStockLabel.text = FruitStoreError.notExist
+            bananaStockStepper.isEnabled = false
         }
         if let kiwiStock = try? delegate?.fruitStore.currentStock(of: .kiwi) {
             kiwiStockLabel.text = "\(kiwiStock)"
             kiwiStockStepper.value = Double(kiwiStock)
         } else {
             kiwiStockLabel.text = FruitStoreError.notExist
+            kiwiStockStepper.isEnabled = false
         }
         if let pineappleStock = try? delegate?.fruitStore.currentStock(of: .pineapple) {
             pineappleStockLabel.text = "\(pineappleStock)"
             pineappleStockStepper.value = Double(pineappleStock)
         } else {
             pineappleStockLabel.text = FruitStoreError.notExist
+            pineappleStockStepper.isEnabled = false
         }
         if let mangoStock = try? delegate?.fruitStore.currentStock(of: .mango) {
             mangoStockLabel.text = "\(mangoStock)"
             mangoStockStepper.value = Double(mangoStock)
         } else {
             mangoStockLabel.text = FruitStoreError.notExist
+            mangoStockStepper.isEnabled = false
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class ViewController: UIViewController, FruitStoreDelegate {
     
     var fruitStore: FruitStore = .init(inventory: [.strawberry: 10, .banana:10, .kiwi: 10, .mango: 10])
     lazy var juiceMaker: JuiceMaker = .init(fruitStore: fruitStore)
@@ -26,6 +26,10 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         updateFruitStockLabel()
     }
     
@@ -106,6 +110,7 @@ class ViewController: UIViewController {
         guard let stockEditViewController = self.storyboard?.instantiateViewController(withIdentifier: "StockEditViewController") as? StockEditViewController else {
             return
         }
+        stockEditViewController.delegate = self
         let navigationController = UINavigationController(rootViewController: stockEditViewController)
         navigationController.modalTransitionStyle = .coverVertical
         navigationController.modalPresentationStyle = .fullScreen

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -9,20 +9,20 @@ import UIKit
 class ViewController: UIViewController, FruitStoreDelegate {
     
     var fruitStore: FruitStore = .init(inventory: [.strawberry: 10, .banana:10, .kiwi: 10, .mango: 10])
-    lazy var juiceMaker: JuiceMaker = .init(fruitStore: fruitStore)
+    private lazy var juiceMaker: JuiceMaker = .init(fruitStore: fruitStore)
     
-    @IBOutlet weak var strawberryJuiceOrderButton: UIButton!
-    @IBOutlet weak var bananaJuiceOrderButton: UIButton!
-    @IBOutlet weak var kiwiJuiceOrderButton: UIButton!
-    @IBOutlet weak var pineappleJuiceOrderButton: UIButton!
-    @IBOutlet weak var strawberryBananaMixJuiceOrderButton: UIButton!
-    @IBOutlet weak var mangoJuiceOrderButton: UIButton!
-    @IBOutlet weak var mangoKiwiMixJuiceOrderButton: UIButton!
-    @IBOutlet weak var strawberryStockLabel: UILabel!
-    @IBOutlet weak var bananaStockLabel: UILabel!
-    @IBOutlet weak var kiwiStockLabel: UILabel!
-    @IBOutlet weak var pineappleStockLabel: UILabel!
-    @IBOutlet weak var mangoStockLabel: UILabel!
+    @IBOutlet private weak var strawberryJuiceOrderButton: UIButton!
+    @IBOutlet private weak var bananaJuiceOrderButton: UIButton!
+    @IBOutlet private weak var kiwiJuiceOrderButton: UIButton!
+    @IBOutlet private weak var pineappleJuiceOrderButton: UIButton!
+    @IBOutlet private weak var strawberryBananaMixJuiceOrderButton: UIButton!
+    @IBOutlet private weak var mangoJuiceOrderButton: UIButton!
+    @IBOutlet private weak var mangoKiwiMixJuiceOrderButton: UIButton!
+    @IBOutlet private weak var strawberryStockLabel: UILabel!
+    @IBOutlet private weak var bananaStockLabel: UILabel!
+    @IBOutlet private weak var kiwiStockLabel: UILabel!
+    @IBOutlet private weak var pineappleStockLabel: UILabel!
+    @IBOutlet private weak var mangoStockLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,11 +34,11 @@ class ViewController: UIViewController, FruitStoreDelegate {
         fitText()
     }
     
-    @IBAction func touchUpEditStockButton(_ sender: UIBarButtonItem) {
+    @IBAction private func touchUpEditStockButton(_ sender: UIBarButtonItem) {
         presentStockEditView()
     }
     
-    @IBAction func touchUpJuiceOrderButton(_ sender: UIButton) {
+    @IBAction private func touchUpJuiceOrderButton(_ sender: UIButton) {
         guard let juice: Juice = juice(orderedBy: sender) else {
             return
         }
@@ -59,7 +59,7 @@ class ViewController: UIViewController, FruitStoreDelegate {
         }
     }
     
-    func juice(orderedBy button: UIButton) -> Juice? {
+    private func juice(orderedBy button: UIButton) -> Juice? {
         switch button {
         case strawberryJuiceOrderButton:
             return .strawberryJuice
@@ -80,14 +80,14 @@ class ViewController: UIViewController, FruitStoreDelegate {
         }
     }
     
-    func showOkayAlert(_ message: String) {
+    private func showOkayAlert(_ message: String) {
         let okAction = UIAlertAction(title: AlertText.okay,
                                      style: .default,
                                      handler: nil)
         showAlert(message, alertActions: okAction)
     }
     
-    func showStockEditAlert(_ message: String) {
+    private func showStockEditAlert(_ message: String) {
         let editAction = UIAlertAction(title: AlertText.yes,
                                        style: .default) { (action) in
             self.presentStockEditView()
@@ -97,7 +97,7 @@ class ViewController: UIViewController, FruitStoreDelegate {
         showAlert(message, alertActions: editAction, cancelAction)
     }
     
-    func showAddFruitsAlert(of juice: Juice, _ message: String) {
+    private func showAddFruitsAlert(of juice: Juice, _ message: String) {
         let addAction = UIAlertAction(title: AlertText.yes,
                                       style: .default) { (action) in
             self.fruitStore.addFruit(of: juice)
@@ -108,7 +108,7 @@ class ViewController: UIViewController, FruitStoreDelegate {
         showAlert(message, alertActions: addAction, cancelAction)
     }
     
-    func showAlert(_ message: String, alertActions: UIAlertAction...) {
+    private func showAlert(_ message: String, alertActions: UIAlertAction...) {
         let alert = UIAlertController(title: nil,
                                       message: message,
                                       preferredStyle: .alert)
@@ -120,7 +120,7 @@ class ViewController: UIViewController, FruitStoreDelegate {
                 completion: nil)
     }
     
-    func presentStockEditView() {
+    private func presentStockEditView() {
         guard let stockEditViewController = self.storyboard?.instantiateViewController(withIdentifier: "StockEditViewController") as? StockEditViewController else {
             return
         }
@@ -133,7 +133,7 @@ class ViewController: UIViewController, FruitStoreDelegate {
                      completion: nil)
     }
     
-    func updateFruitStockLabel() {
+    private func updateFruitStockLabel() {
         if let strawberryStock = try? fruitStore.currentStock(of: .strawberry) {
             strawberryStockLabel.text = "\(strawberryStock)"
         } else {
@@ -161,7 +161,7 @@ class ViewController: UIViewController, FruitStoreDelegate {
         }
     }
     
-    func fitText() {
+    private func fitText() {
         let buttons: [UIButton] = [strawberryJuiceOrderButton, bananaJuiceOrderButton, kiwiJuiceOrderButton, pineappleJuiceOrderButton, strawberryBananaMixJuiceOrderButton, mangoJuiceOrderButton, mangoKiwiMixJuiceOrderButton]
         for button in buttons {
             button.titleLabel?.adjustsFontSizeToFitWidth = true

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -31,6 +31,7 @@ class ViewController: UIViewController, FruitStoreDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateFruitStockLabel()
+        fitText()
     }
     
     @IBAction func touchUpEditStockButton(_ sender: UIBarButtonItem) {
@@ -157,6 +158,13 @@ class ViewController: UIViewController, FruitStoreDelegate {
             mangoStockLabel.text = "\(mangoStock)"
         } else {
             mangoStockLabel.text = FruitStoreError.notExist
+        }
+    }
+    
+    func fitText() {
+        let buttons: [UIButton] = [strawberryJuiceOrderButton, bananaJuiceOrderButton, kiwiJuiceOrderButton, pineappleJuiceOrderButton, strawberryBananaMixJuiceOrderButton, mangoJuiceOrderButton, mangoKiwiMixJuiceOrderButton]
+        for button in buttons {
+            button.titleLabel?.adjustsFontSizeToFitWidth = true
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -50,6 +50,8 @@ class ViewController: UIViewController, FruitStoreDelegate {
             switch fruitStoreError {
             case .outOfStock:
                 showStockEditAlert(fruitStoreError.localizedDescription)
+            case .notInInventoryFruitList:
+                showAddFruitsAlert(of: juice, fruitStoreError.localizedDescription)
             default:
                 showOkayAlert(fruitStoreError.localizedDescription)
             }
@@ -92,6 +94,17 @@ class ViewController: UIViewController, FruitStoreDelegate {
         let cancelAction = UIAlertAction(title: AlertText.no,
                                          style: .default)
         showAlert(message, alertActions: editAction, cancelAction)
+    }
+    
+    func showAddFruitsAlert(of juice: Juice, _ message: String) {
+        let addAction = UIAlertAction(title: AlertText.yes,
+                                      style: .default) { (action) in
+            self.fruitStore.addFruit(of: juice)
+            self.updateFruitStockLabel()
+        }
+        let cancelAction = UIAlertAction(title: AlertText.no,
+                                         style: .default)
+        showAlert(message, alertActions: addAction, cancelAction)
     }
     
     func showAlert(_ message: String, alertActions: UIAlertAction...) {

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -31,7 +31,7 @@ class ViewController: UIViewController, FruitStoreDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateFruitStockLabel()
-        fitText()
+        adjustsFontSizeOfButtonsToFitWidth()
     }
     
     @IBAction private func touchUpEditStockButton(_ sender: UIBarButtonItem) {
@@ -100,7 +100,7 @@ class ViewController: UIViewController, FruitStoreDelegate {
     private func showAddFruitsAlert(of juice: Juice, _ message: String) {
         let addAction = UIAlertAction(title: AlertText.yes,
                                       style: .default) { (action) in
-            self.fruitStore.addFruit(of: juice)
+            self.fruitStore.addNewFruitsOf(juice.fruitList)
             self.updateFruitStockLabel()
         }
         let cancelAction = UIAlertAction(title: AlertText.no,
@@ -161,10 +161,10 @@ class ViewController: UIViewController, FruitStoreDelegate {
         }
     }
     
-    private func fitText() {
+    private func adjustsFontSizeOfButtonsToFitWidth() {
         let buttons: [UIButton] = [strawberryJuiceOrderButton, bananaJuiceOrderButton, kiwiJuiceOrderButton, pineappleJuiceOrderButton, strawberryBananaMixJuiceOrderButton, mangoJuiceOrderButton, mangoKiwiMixJuiceOrderButton]
         for button in buttons {
-            button.titleLabel?.adjustsFontSizeToFitWidth = true
+            button.titleLabel?.textAlignment = .center
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -106,9 +106,10 @@ class ViewController: UIViewController {
         guard let stockEditViewController = self.storyboard?.instantiateViewController(withIdentifier: "StockEditViewController") as? StockEditViewController else {
             return
         }
-        stockEditViewController.modalTransitionStyle = .coverVertical
-        stockEditViewController.modalPresentationStyle = .fullScreen
-        self.present(stockEditViewController,
+        let navigationController = UINavigationController(rootViewController: stockEditViewController)
+        navigationController.modalTransitionStyle = .coverVertical
+        navigationController.modalPresentationStyle = .fullScreen
+        self.present(navigationController,
                      animated: true,
                      completion: nil)
     }

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -5,8 +5,8 @@
 //  Created by Gundy, 준호
 //
 
-enum Fruit: CaseIterable {
-    case strawberry
+enum Fruit: Int, CaseIterable {
+    case strawberry = 1
     case banana
     case pineapple
     case kiwi

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -69,10 +69,10 @@ class FruitStore {
         return currentStock
     }
     
-    func addFruit(of juice: Juice) {
-        for ingredient in juice.recipe {
-            if inventory[ingredient.fruit] == nil {
-                inventory[ingredient.fruit] = 0
+    func addNewFruitsOf(_ fruitList: [Fruit]) {
+        for fruit in fruitList {
+            if inventory[fruit] == nil {
+                inventory[fruit] = 0
             }
         }
     }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -68,4 +68,12 @@ class FruitStore {
         }
         return currentStock
     }
+    
+    func addFruit(of juice: Juice) {
+        for ingredient in juice.recipe {
+            if inventory[ingredient.fruit] == nil {
+                inventory[ingredient.fruit] = 0
+            }
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStoreDelegate.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStoreDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  FruitStoreDelegate.swift
+//  JuiceMaker
+//
+//  Created by Gundy, 준호
+//
+
+import Foundation
+
+protocol FruitStoreDelegate: AnyObject {
+    var fruitStore: FruitStore { get set }
+}

--- a/JuiceMaker/JuiceMaker/Model/FruitStoreDelegate.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStoreDelegate.swift
@@ -5,8 +5,6 @@
 //  Created by Gundy, 준호
 //
 
-import Foundation
-
 protocol FruitStoreDelegate: AnyObject {
     var fruitStore: FruitStore { get set }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
@@ -17,7 +17,7 @@ enum FruitStoreError: Error {
         case .invalidAmount:
             return "잘못된 수량입니다."
         case .notInInventoryFruitList:
-            return "창고 내부 목록에 없는 과일입니다."
+            return "창고 내부 목록에 없는 과일이에요. 과일을 목록에 추가할까요?"
         case .outOfStock:
             return "재료가 모자라요. 재고를 수정할까요?"
         case .unexpectedError:

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -56,4 +56,8 @@ enum Juice {
             return [Ingredient(fruit: .mango, amount: 2), Ingredient(fruit: .kiwi, amount: 1)]
         }
     }
+    
+    var fruitList: [Fruit] {
+        return recipe.map{ $0.fruit }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -4,8 +4,6 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-import Foundation
-
 struct JuiceMaker {
     private let fruitStore: FruitStore
     

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -287,119 +287,185 @@
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                <rect key="frame" x="590" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="580" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="5ij-Bs-yel"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="429" y="155" width="75" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                <rect key="frame" x="410" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="daC-vc-CV6"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="271" y="155" width="75" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                <rect key="frame" x="261" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="LQA-xN-OCw"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                <rect key="frame" x="154" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="sSP-n6-04l"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="60" y="161" width="75" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                <rect key="frame" x="60" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="165" y="158" width="75" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                <rect key="frame" x="50" y="192" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="chR-3u-G1f"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="590" y="156" width="75" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="93J-Rh-vOv">
+                                <rect key="frame" x="60" y="52" width="724" height="136.66666666666666"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="uqy-gv-9Vu">
+                                        <rect key="frame" x="0.0" y="0.0" width="132" height="136.66666666666666"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Mby-2O-Mgz">
+                                        <rect key="frame" x="148" y="0.0" width="132" height="136.66666666666666"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
+                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="n4T-Yd-84e">
+                                        <rect key="frame" x="296" y="0.0" width="132" height="136.66666666666666"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
+                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
+                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="sZs-yY-Hm9">
+                                        <rect key="frame" x="444" y="0.0" width="132" height="136.66666666666666"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
+                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
+                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="UlG-zD-apf">
+                                        <rect key="frame" x="592" y="0.0" width="132" height="136.66666666666666"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
+                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="Mby-2O-Mgz" firstAttribute="width" secondItem="uqy-gv-9Vu" secondAttribute="width" id="NWf-cz-Wud"/>
+                                    <constraint firstItem="n4T-Yd-84e" firstAttribute="width" secondItem="uqy-gv-9Vu" secondAttribute="width" id="YnK-ar-obo"/>
+                                    <constraint firstItem="UlG-zD-apf" firstAttribute="width" secondItem="uqy-gv-9Vu" secondAttribute="width" id="pNG-62-YrS"/>
+                                    <constraint firstItem="sZs-yY-Hm9" firstAttribute="width" secondItem="uqy-gv-9Vu" secondAttribute="width" id="xl1-oM-QfJ"/>
+                                </constraints>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Kg5-Na-laU">
+                                <rect key="frame" x="60" y="208.66666666666666" width="724" height="32"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ga9-81-Grr">
+                                        <rect key="frame" x="0.0" y="0.0" width="132" height="32"/>
+                                        <subviews>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="19" y="0.0" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="chR-3u-G1f"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3or-sm-EQa">
+                                        <rect key="frame" x="148" y="0.0" width="132" height="32"/>
+                                        <subviews>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="19" y="0.0" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="sSP-n6-04l"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="9uF-ys-ILb">
+                                        <rect key="frame" x="296" y="0.0" width="132" height="32"/>
+                                        <subviews>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                                <rect key="frame" x="19" y="0.0" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="LQA-xN-OCw"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Sgr-cc-faa">
+                                        <rect key="frame" x="444" y="0.0" width="132" height="32"/>
+                                        <subviews>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                                <rect key="frame" x="19" y="0.0" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="daC-vc-CV6"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Cgr-3l-MS2">
+                                        <rect key="frame" x="592" y="0.0" width="132" height="32"/>
+                                        <subviews>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                                <rect key="frame" x="19" y="0.0" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="5ij-Bs-yel"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="Sgr-cc-faa" firstAttribute="width" secondItem="ga9-81-Grr" secondAttribute="width" id="KwO-gS-W7s"/>
+                                    <constraint firstItem="3or-sm-EQa" firstAttribute="width" secondItem="ga9-81-Grr" secondAttribute="width" id="lZs-L7-cW0"/>
+                                    <constraint firstItem="9uF-ys-ILb" firstAttribute="width" secondItem="ga9-81-Grr" secondAttribute="width" id="rJZ-ZC-dWt"/>
+                                    <constraint firstItem="Cgr-3l-MS2" firstAttribute="width" secondItem="ga9-81-Grr" secondAttribute="width" id="zXm-Gz-lrN"/>
+                                </constraints>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="93J-Rh-vOv" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="16" id="Gtf-zz-apS"/>
+                            <constraint firstItem="Kg5-Na-laU" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="16" id="PAs-yH-92g"/>
+                            <constraint firstItem="93J-Rh-vOv" firstAttribute="height" secondItem="tKV-4l-Vtc" secondAttribute="height" multiplier="35%" id="ZW3-wO-X2K"/>
+                            <constraint firstItem="Kg5-Na-laU" firstAttribute="top" secondItem="93J-Rh-vOv" secondAttribute="bottom" constant="20" id="bLK-xj-nQ7"/>
+                            <constraint firstItem="93J-Rh-vOv" firstAttribute="top" secondItem="gcO-Xb-kNs" secondAttribute="top" constant="20" id="cDk-UN-IRy"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" secondItem="Kg5-Na-laU" secondAttribute="trailing" constant="16" id="eeI-2M-ApG"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" secondItem="93J-Rh-vOv" secondAttribute="trailing" constant="16" id="kqG-6f-fwU"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="재고 수정" id="feS-hM-Tb1">
                         <barButtonItem key="rightBarButtonItem" title="닫기" id="nxN-zf-ArU">

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -294,7 +294,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minimumValue="-100" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                 <rect key="frame" x="580" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <connections>
@@ -316,7 +316,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minimumValue="-100" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                 <rect key="frame" x="410" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <connections>
@@ -338,7 +338,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minimumValue="-100" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                 <rect key="frame" x="261" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <connections>
@@ -352,7 +352,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minimumValue="-100" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                 <rect key="frame" x="154" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <connections>
@@ -382,7 +382,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minimumValue="-100" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <connections>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -294,14 +294,6 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="622" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                 <rect key="frame" x="580" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -314,7 +306,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="461" y="156" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="429" y="155" width="75" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -333,7 +325,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="303" y="155" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="271" y="155" width="75" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -356,7 +348,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="98" y="161" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="60" y="161" width="75" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -371,7 +363,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="196" y="158" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="165" y="158" width="75" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -382,6 +374,14 @@
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                <rect key="frame" x="590" y="156" width="75" height="23"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -393,10 +393,17 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="xxf-iv-Wd3"/>
+                        <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="GQS-n0-n7B"/>
+                        <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="2nL-cI-5k5"/>
+                        <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="ENB-hq-GEX"/>
+                        <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="G6P-Vk-Y3s"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="901"/>
+            <point key="canvasLocation" x="1636.4928909952605" y="900"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="cAf-jL-tPK">

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <action selector="touchUpEditStockButton:" destination="BYZ-38-t0r" id="XVO-mb-Un3"/>
+                                <action selector="touchUpEditStockButton:" destination="BYZ-38-t0r" id="RzZ-AK-mZs"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -279,7 +279,7 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--Stock Edit View Controller-->
+        <!--재고 수정-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController storyboardIdentifier="StockEditViewController" id="Yu1-lM-nqp" customClass="StockEditViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
@@ -382,20 +382,17 @@
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cpR-nc-oU7">
-                                <rect key="frame" x="728" y="34" width="49" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="닫기"/>
-                                <connections>
-                                    <action selector="touchUpDismissButton:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="G9z-vc-rYR"/>
-                                </connections>
-                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <navigationItem key="navigationItem" title="재고 수정" id="feS-hM-Tb1">
+                        <barButtonItem key="rightBarButtonItem" title="닫기" id="nxN-zf-ArU">
+                            <connections>
+                                <action selector="touchUpDismissButton:" destination="Yu1-lM-nqp" id="pmX-VE-OUL"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -299,7 +299,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -317,7 +317,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -335,7 +335,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -353,7 +353,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -371,7 +371,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
                                                 <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -394,7 +394,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ga9-81-Grr">
                                         <rect key="frame" x="0.0" y="0.0" width="132" height="32"/>
                                         <subviews>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                            <stepper opaque="NO" tag="-1" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                                 <rect key="frame" x="19" y="0.0" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="chR-3u-G1f"/>
@@ -405,7 +405,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3or-sm-EQa">
                                         <rect key="frame" x="148" y="0.0" width="132" height="32"/>
                                         <subviews>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                            <stepper opaque="NO" tag="-2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                                 <rect key="frame" x="19" y="0.0" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="sSP-n6-04l"/>
@@ -416,7 +416,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="9uF-ys-ILb">
                                         <rect key="frame" x="296" y="0.0" width="132" height="32"/>
                                         <subviews>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                            <stepper opaque="NO" tag="-3" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                 <rect key="frame" x="19" y="0.0" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="LQA-xN-OCw"/>
@@ -427,7 +427,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Sgr-cc-faa">
                                         <rect key="frame" x="444" y="0.0" width="132" height="32"/>
                                         <subviews>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                            <stepper opaque="NO" tag="-4" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                                 <rect key="frame" x="19" y="0.0" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="daC-vc-CV6"/>
@@ -438,7 +438,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Cgr-3l-MS2">
                                         <rect key="frame" x="592" y="0.0" width="132" height="32"/>
                                         <subviews>
-                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                            <stepper opaque="NO" tag="-4" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                                 <rect key="frame" x="19" y="0.0" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="5ij-Bs-yel"/>
@@ -483,8 +483,8 @@
                         <outlet property="mangoStockStepper" destination="xbn-6P-grO" id="2jd-Av-rvj"/>
                         <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="ENB-hq-GEX"/>
                         <outlet property="pineappleStockStepper" destination="Rcr-xr-eqz" id="4nH-rh-drO"/>
-                        <outlet property="straberryStockStepper" destination="ZQk-f4-zrz" id="TcR-C2-Ny4"/>
                         <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="G6P-Vk-Y3s"/>
+                        <outlet property="strawberryStockStepper" destination="ZQk-f4-zrz" id="IaX-Ky-GAW"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -294,9 +294,12 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minimumValue="-100" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                 <rect key="frame" x="580" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="5ij-Bs-yel"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
                                 <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
@@ -313,9 +316,12 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minimumValue="-100" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                 <rect key="frame" x="410" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="daC-vc-CV6"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
                                 <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
@@ -332,9 +338,12 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minimumValue="-100" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                 <rect key="frame" x="261" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="LQA-xN-OCw"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
                                 <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
@@ -343,9 +352,12 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minimumValue="-100" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                 <rect key="frame" x="154" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="sSP-n6-04l"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
                                 <rect key="frame" x="60" y="161" width="75" height="23"/>
@@ -370,9 +382,12 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minimumValue="-100" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="chR-3u-G1f"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
                                 <rect key="frame" x="590" y="156" width="75" height="23"/>
@@ -395,9 +410,14 @@
                     </navigationItem>
                     <connections>
                         <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="xxf-iv-Wd3"/>
+                        <outlet property="bananaStockStepper" destination="O5s-2N-3iP" id="Fcb-F2-Tc6"/>
                         <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="GQS-n0-n7B"/>
+                        <outlet property="kiwiStockStepper" destination="klA-59-Nu4" id="zh0-sO-om9"/>
                         <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="2nL-cI-5k5"/>
+                        <outlet property="mangoStockStepper" destination="xbn-6P-grO" id="2jd-Av-rvj"/>
                         <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="ENB-hq-GEX"/>
+                        <outlet property="pineappleStockStepper" destination="Rcr-xr-eqz" id="4nH-rh-drO"/>
+                        <outlet property="straberryStockStepper" destination="ZQk-f4-zrz" id="TcR-C2-Ny4"/>
                         <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="G6P-Vk-Y3s"/>
                     </connections>
                 </viewController>


### PR DESCRIPTION
@junbangg
안녕하세요 알라딘! 🏜
추석은 잘 마무리하고 계신가요? 🌕
즐거운 한가위였기를 바랍니다. 😄
세 번째 PR도 잘 부탁드립니다. 🙌
이번 피드백도 감사합니다! 

#### 함수별 기능
- `updateFruitStock`: 각 과일의 레이블을 수량에 맞게 바꾸고 Stepper와 동기화 시키는 메서드, 과일이 목록에 없다면 레이블의 문구를 `FruitStoreError.notExist`로 바꾸고 Stepper를 비활성화 시킨다.
- `touchUpStepper`: 각 스텝퍼별로 `changeStock` 메서드를 호출해 재고의 변화를 과일 레이블에 적용시키는 메서드.
- `changeStock`: 스텝퍼의 값과 재고의 차를 변화량으로 반환하는 메서드.
- `showAddFruitsAlert`: 재고 목록에 없는 과일을 목록에 추가할 것인지 얼럿을 띄우는 메서드.
- `addFruit`: Juice의 recipe의 과일 중 재고목록에 없는 과일을 추가하는 메서드.
-  `fitText`: 화면이 작아서 쥬스 주문 버튼의 레이블 글자가 생략될 시 딱 맞춰주는 메서드.

### 코드를 작성할 때 고민되었던 점
- 화면 사이의 데이터 공유를 위해 Delegate 패턴을 활용했습니다. 
- FruitStore 타입의 fruitStore 프로퍼티를 요구하는 FruitStoreDelegate 프로토콜을 추가한 뒤, ViewController에서 채택했습니다.
- StockEditViewController에 FruitStoreDelegate 타입의 옵셔널 변수 delegate를 약한참조로 추가했습니다.
- StockEditViewController를 present 하기 전에 delegate를 self(ViewController)로 초기화했습니다.
- delegate를 사용해서 ViewController 프로퍼티 fruitStore의 currentStock, changeStock 메서드를 호출했습니다.
~~~swift
// FruitStoreDelegate 프로토콜 추가
protocol FruitStoreDelegate: AnyObject {
    var fruitStore: FruitStore { get set }
}


// ViewController에서 FruitStoreDelegate 프로토콜 채택
class ViewController: UIViewController, FruitStoreDelegate {

    // StockEditViewController의 delegate를 ViewController로 초기화
    func presentStockEditView() {
        guard let stockEditViewController = self.storyboard?.instantiateViewController(withIdentifier: "StockEditViewController") as? StockEditViewController else {
            return
        }
        stockEditViewController.delegate = 

// FruitStoreDelegate 프로토콜 타입의 delegate 추가 
class StockEditViewController: UIViewController {
    
    weak var delegate: FruitStoreDelegate?
    
    // delegate를 사용해서 currentStock, changeStock 메서드 호출
    func changeStock(of fruit: Fruit, by stockStepper: UIStepper) -> Int? {
        guard let currentStock = try? delegate?.fruitStore.currentStock(of: fruit) else {
            return nil
        }
        let stockAmountToChange: Int = Int(stockStepper.value) - currentStock
        delegate?.fruitStore.changeStock(of: fruit, by: stockAmountToChange)
        return currentStock + stockAmountToChange
    }
~~~
- 싱글턴을 사용하지 않은 이유는 싱글턴은 결국 `share`에 그 목적이 있다고 생각하기 때문입니다. "JuiceMaker라는 클래스는 FruitStore를 소유하고 있다"는 STEP 1의 요구조건과는 거리가 있다고 느껴져 싱글턴을 사용하지 않았습니다. FruitStore를 직접 소유한다는 점에서 델리게이트 패턴을 적용하는 것이 더욱 적절하다고 생각했습니다.
- 첫 화면과 겹치는 과일 이미지 및 재고 레이블은 첫 화면의 오토레이아웃 제약사항을 따랐습니다. 그 편이 사용자 입장에서 볼 때 더 자연스럽게 느껴질 것이라고 생각했습니다. Stepper의 경우는 기존 오토레이아웃 조건에서의 규칙을 그대로 적용하되, 사이즈 조절이 되지 않는 특성상 가운데 정렬을 우선적으로 따르게 설정하였습니다.
- 기존에는 재고수정 페이지로 화면전환을 할 때, 재고 수정 뷰 컨트롤러를 프레젠트 하였습니다. 하지만 네비게이션 바를 구현해야했기 때문에 `let navigationController = UINavigationController(rootViewController: stockEditViewController)` 선언부를 추가하고 네비게이션 컨트롤러를 프레젠트 하는 것으로 변경하였습니다.
- 재고를 수정하는 것이 어느 순간에 이루어지는 것이 적절한지에 대한 고민을 했습니다. 스텝퍼를 누를때마다 재고가 실시간으로 변경되어야 하는 것인지, 장바구니에 물건을 담기전 수량만 변경하는 것처럼 생각해 최종적으로 무언가 액션이 추가됐을 때 재고가 변경되어야 하는 것인지 고민을 했습니다. 결국 상의한 결과 레이아웃에 컴포넌트를 추가하지 않고 기능을 만족시키기 위해 즉각적으로 재고 수량이 변경되는 것으로 선택하였습니다.
- 버튼 타이틀 레이블의 글자가 길어지더라도 무관하게 자동으로 간격에 맞춰주기 위해 `fitText` 메서드를 만들었습니다. 

### 조언을 얻고 싶은 부분
- 현재 저희는 스토리보드의 인스펙터 탭을 통한 기능과 코드를 통한 기능을 함께 사용하고 있습니다. 때문에 해당 사항은 코드만 봐서는 구현되지않았는지 생각이 들 수도 있을 것 같습니다. 가령 저희는 스텝퍼의 미니멈밸류를 0으로 하고, 스텝퍼와 재고를 동기화시켰기때문에 스텝퍼를 통한 조작에서 재고는 0보다 작아질 수 없습니다. 하지만 이는 코드에서는 알 수 없는 부분이고, 혹시 누군가가 스토리보드를 통해 미니멈밸류를 수정한다면 발견하지 못하고 사용될 가능성도 있다고 생각합니다. 이같은 경우 코드상에서 더욱 분명히 하기 위해 `viewDidLoad` 메서드 등에서 `stepper.minimumValue = 0` 등의 코드를 작성하는 것이 좋을까요? 스토리보드를 건들지않는한 `stepper.minimumValue = 0`는 쓰이지 않는 코드가 됩니다. 이럴 때 어떤 선택이 더 좋을지 조언을 구하고 싶습니다.
- 오류처리를 위해 try를 사용하는 구간이 생기면 적절한 처리를 위해 고민을 했습니다. 하지만 `StockEditViewController`의 `changeStock` 메서드 같은 경우는 그저 nil을 반환할 뿐입니다. 이는 저희가 `updateFruitStock` 메서드를 통해 해당 오류가 발생할 원천인 스텝퍼를 비활성화했기 때문에 nil을 받는 경우가 절대 없으리라는 생각이 듭니다. 이런 경우 '아마도 절대 사용되지 않을 오류처리 코드'가 될지라도 '만에하나 나의 의도대로 스텝퍼가 비활성화되지않을 수 있으니까' nil을 반환하는 것보다도 더 적극적인 오류처리를 하는 것이 좋을지 궁금합니다.
- updateFruitStock 메서드는 Label의 text를 수정하고 Stepper의 value와 isEnabled를 수정하는 역할을 합니다. 한 메서드에서 한번에 많은 기능을 처리하는 데 어떤 방향으로 기능 분리를 하면 좋을까요? Label과 Stepper를 기준으로 분리를 해야할 지, if 블록 단위로 분리를 해야할 지... 조언을 얻고 싶습니다.
~~~swift
func updateFruitStock() {
    if let strawberryStock = try? delegate?.fruitStore.currentStock(of: .strawberry) {
        strawberryStockLabel.text = "\(strawberryStock)"
        straberryStockStepper.value = Double(strawberryStock)
    } else {
        strawberryStockLabel.text = FruitStoreError.notExist
        straberryStockStepper.isEnabled = false
    }
    ...
}
~~~
- `import Foundation`의 삭제와 같은 작업만으로 커밋을 진행할 때 메시지 서브젝트를 무엇으로 해야할 지 고민입니다. 우선 chore가 가장 적합한 것 같아서 그렇게 적용했는데, 어떤 카르마 스타일을 따라야 할까요?