### PR TITLE
쥬스 메이커 [STEP 3] inho, 토털이

### DIFF
--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -96,6 +96,7 @@ class JuiceMakerViewController: UIViewController {
               let stockEditVC = stockEditNavigationController.topViewController as? StockEditViewController else {
                   return
               }
+        
         stockEditVC.delegate = self
         Fruit.allCases.forEach({ fruit in
             guard let fruitStock = try? juiceMaker.fetchStock(of: fruit) else { return }
@@ -112,5 +113,7 @@ class JuiceMakerViewController: UIViewController {
 
 extension JuiceMakerViewController: StockEditDelegate {
     func didEndStockEditing(fruitStock: [Fruit : Int]) {
+        juiceMaker.updateAllStock(using: fruitStock)
+        updateAllStockLabels()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -19,12 +19,9 @@ class JuiceMakerViewController: UIViewController {
         super.viewDidLoad()
         
         navigationController?.navigationBar.backgroundColor = .systemGray5
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
         updateAllStockLabels()
     }
-    
+
     private func updateAllStockLabels() {
         Fruit.allCases.forEach({ fruit in
             updateStockLabel(of: fruit)
@@ -99,10 +96,17 @@ class JuiceMakerViewController: UIViewController {
             StockEditViewController.init(fruitStore: self.juiceMaker.fetchFruitStore(), coder: coder) })
         let stockEditNavigationController = UINavigationController(rootViewController: stockEditViewController)
         
+        stockEditViewController.delegate = self
         present(stockEditNavigationController, animated: true, completion: nil)
     }
     
     @IBAction func stockEditButtonPressed() {
         presentStockEditViewController()
+    }
+}
+
+extension JuiceMakerViewController: StockEditDelegate {
+    func didEndStockEditing() {
+        updateAllStockLabels()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -96,7 +96,7 @@ class JuiceMakerViewController: UIViewController {
               let stockEditVC = stockEditNavigationController.topViewController as? StockEditViewController else {
                   return
               }
-        
+        stockEditVC.delegate = self
         Fruit.allCases.forEach({ fruit in
             guard let fruitStock = try? juiceMaker.fetchStock(of: fruit) else { return }
             
@@ -110,3 +110,7 @@ class JuiceMakerViewController: UIViewController {
     }
 }
 
+extension JuiceMakerViewController: StockEditDelegate {
+    func didEndStockEditing(fruitStock: [Fruit : Int]) {
+    }
+}

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -92,9 +92,17 @@ class JuiceMakerViewController: UIViewController {
     
     private func presentStockEditViewController() {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
-        let stockEditVC = storyboard.instantiateViewController(identifier: "stockEditNavigation")
+        guard let stockEditNavigationController = storyboard.instantiateViewController(identifier: "stockEditNavigation") as? UINavigationController,
+              let stockEditVC = stockEditNavigationController.topViewController as? StockEditViewController else {
+                  return
+              }
         
-        present(stockEditVC, animated: true, completion: nil)
+        Fruit.allCases.forEach({ fruit in
+            guard let fruitStock = try? juiceMaker.fetchStock(of: fruit) else { return }
+            
+            stockEditVC.fruitStock[fruit] = fruitStock
+        })
+        present(stockEditNavigationController, animated: true, completion: nil)
     }
     
     @IBAction func stockEditButtonPressed() {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -96,11 +96,12 @@ class JuiceMakerViewController: UIViewController {
     private func presentStockEditViewController() {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         guard let stockEditNavigationController = storyboard.instantiateViewController(identifier: "stockEditNavigation") as? UINavigationController,
-              let stockEditVC = stockEditNavigationController.topViewController as? StockEditViewController else {
+              let stockEditViewController = stockEditNavigationController.topViewController as? StockEditViewController else {
                   return
               }
+        
         stockEditNavigationController.modalPresentationStyle = .fullScreen
-        stockEditVC.setFruitStore(fruitStore: juiceMaker.fetchFruitStore())
+        stockEditViewController.setFruitStore(fruitStore: juiceMaker.fetchFruitStore())
         present(stockEditNavigationController, animated: true, completion: nil)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -19,6 +19,9 @@ class JuiceMakerViewController: UIViewController {
         super.viewDidLoad()
         
         navigationController?.navigationBar.backgroundColor = .systemGray5
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
         updateAllStockLabels()
     }
     
@@ -96,24 +99,12 @@ class JuiceMakerViewController: UIViewController {
               let stockEditVC = stockEditNavigationController.topViewController as? StockEditViewController else {
                   return
               }
-        
-        stockEditVC.delegate = self
-        Fruit.allCases.forEach({ fruit in
-            guard let fruitStock = try? juiceMaker.fetchStock(of: fruit) else { return }
-            
-            stockEditVC.fruitStock[fruit] = fruitStock
-        })
+        stockEditNavigationController.modalPresentationStyle = .fullScreen
+        stockEditVC.setFruitStore(fruitStore: juiceMaker.fetchFruitStore())
         present(stockEditNavigationController, animated: true, completion: nil)
     }
     
     @IBAction func stockEditButtonPressed() {
         presentStockEditViewController()
-    }
-}
-
-extension JuiceMakerViewController: StockEditDelegate {
-    func didEndStockEditing(fruitStock: [Fruit : Int]) {
-        juiceMaker.updateAllStock(using: fruitStock)
-        updateAllStockLabels()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -95,13 +95,10 @@ class JuiceMakerViewController: UIViewController {
     
     private func presentStockEditViewController() {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
-        guard let stockEditNavigationController = storyboard.instantiateViewController(identifier: "stockEditNavigation") as? UINavigationController,
-              let stockEditViewController = stockEditNavigationController.topViewController as? StockEditViewController else {
-                  return
-              }
+        let stockEditViewController = storyboard.instantiateViewController(identifier: "stockEditViewController", creator: { coder in
+            StockEditViewController.init(fruitStore: self.juiceMaker.fetchFruitStore(), coder: coder) })
+        let stockEditNavigationController = UINavigationController(rootViewController: stockEditViewController)
         
-        stockEditNavigationController.modalPresentationStyle = .fullScreen
-        stockEditViewController.setFruitStore(fruitStore: juiceMaker.fetchFruitStore())
         present(stockEditNavigationController, animated: true, completion: nil)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class StockEditViewController: UIViewController {
     
-    private var fruitStore: FruitStore?
+    private var fruitStore: FruitStore
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
     @IBOutlet weak var pineappleStockLabel: UILabel!
@@ -21,6 +21,16 @@ class StockEditViewController: UIViewController {
     @IBOutlet weak var pineappleStepper: UIStepper!
     @IBOutlet weak var kiwiStepper: UIStepper!
     @IBOutlet weak var mangoStepper: UIStepper!
+    
+    init?(fruitStore: FruitStore, coder: NSCoder) {
+        self.fruitStore = fruitStore
+        super.init(coder: coder)
+    }
+
+    @available(*, unavailable, renamed: "init(fruitStore:coder:)")
+    required init?(coder: NSCoder) {
+        fatalError("Invalid way of decoding this class")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,33 +44,33 @@ class StockEditViewController: UIViewController {
     }
     
     @IBAction func strawberryStepperPressed(_ sender: UIStepper) {
-        fruitStore?.updateFruitStock(fruit: .strawberry, amountOf: Int(sender.value))
+        fruitStore.updateFruitStock(fruit: .strawberry, amountOf: Int(sender.value))
         strawberryStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func bananaStepperPressed(_ sender: UIStepper) {
-        fruitStore?.updateFruitStock(fruit: .banana, amountOf: Int(sender.value))
+        fruitStore.updateFruitStock(fruit: .banana, amountOf: Int(sender.value))
         bananaStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func pineappleStepperPressed(_ sender: UIStepper) {
-        fruitStore?.updateFruitStock(fruit: .pineapple, amountOf: Int(sender.value))
+        fruitStore.updateFruitStock(fruit: .pineapple, amountOf: Int(sender.value))
         pineappleStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func kiwiStepperPressed(_ sender: UIStepper) {
-        fruitStore?.updateFruitStock(fruit: .kiwi, amountOf: Int(sender.value))
+        fruitStore.updateFruitStock(fruit: .kiwi, amountOf: Int(sender.value))
         kiwiStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func mangoStepperPressed(_ sender: UIStepper) {
-        fruitStore?.updateFruitStock(fruit: .mango, amountOf: Int(sender.value))
+        fruitStore.updateFruitStock(fruit: .mango, amountOf: Int(sender.value))
         mangoStockLabel.text = Int(sender.value).description
     }
     
     private func setStockLabelAndStepperValue() {
         Fruit.allCases.forEach({ fruit in
-            guard let fruitStock = try? fruitStore?.fetchStock(of: fruit) else { return }
+            guard let fruitStock = try? fruitStore.fetchStock(of: fruit) else { return }
             switch fruit {
             case .strawberry:
                 strawberryStepper.value = Double(fruitStock)

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -7,8 +7,13 @@
 
 import UIKit
 
+protocol StockEditDelegate {
+    func didEndStockEditing()
+}
+
 class StockEditViewController: UIViewController {
     
+    var delegate: StockEditDelegate?
     private var fruitStore: FruitStore
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
@@ -40,6 +45,7 @@ class StockEditViewController: UIViewController {
     }
 
     @IBAction func dismissButtonPressed(_ sender: UIBarButtonItem) {
+        delegate?.didEndStockEditing()
         dismiss(animated: true)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -24,4 +24,25 @@ class StockEditViewController: UIViewController {
     @IBAction func dismissButtonPressed(_ sender: UIBarButtonItem) {
         dismiss(animated: true)
     }
+    
+    @IBAction func strawberryStepperPressed(_ sender: UIStepper) {
+        strawberryStockLabel.text = Int(sender.value).description
+    }
+    
+    @IBAction func bananaStepperPressed(_ sender: UIStepper) {
+        bananaStockLabel.text = Int(sender.value).description
+    }
+    
+    @IBAction func pineappleStepperPressed(_ sender: UIStepper) {
+        pineappleStockLabel.text = Int(sender.value).description
+    }
+    
+    @IBAction func kiwiStepperPressed(_ sender: UIStepper) {
+        kiwiStockLabel.text = Int(sender.value).description
+    }
+    
+    @IBAction func mangoStepperPressed(_ sender: UIStepper) {
+        mangoStockLabel.text = Int(sender.value).description
+    }
+    
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -7,15 +7,9 @@
 
 import UIKit
 
-protocol StockEditDelegate {
-    func didEndStockEditing(fruitStock: [Fruit: Int])
-}
-
 class StockEditViewController: UIViewController {
     
-    var delegate: StockEditDelegate?
-    internal var fruitStock = [Fruit: Int]()
-    
+    private var fruitStore: FruitStore?
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
     @IBOutlet weak var pineappleStockLabel: UILabel!
@@ -36,54 +30,58 @@ class StockEditViewController: UIViewController {
     }
 
     @IBAction func dismissButtonPressed(_ sender: UIBarButtonItem) {
-        delegate?.didEndStockEditing(fruitStock: fruitStock)
         dismiss(animated: true)
     }
     
     @IBAction func strawberryStepperPressed(_ sender: UIStepper) {
-        fruitStock[.strawberry] = Int(sender.value)
+        fruitStore?.updateFruitStock(fruit: .strawberry, amountOf: Int(sender.value))
         strawberryStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func bananaStepperPressed(_ sender: UIStepper) {
-        fruitStock[.banana] = Int(sender.value)
+        fruitStore?.updateFruitStock(fruit: .banana, amountOf: Int(sender.value))
         bananaStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func pineappleStepperPressed(_ sender: UIStepper) {
-        fruitStock[.pineapple] = Int(sender.value)
+        fruitStore?.updateFruitStock(fruit: .pineapple, amountOf: Int(sender.value))
         pineappleStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func kiwiStepperPressed(_ sender: UIStepper) {
-        fruitStock[.kiwi] = Int(sender.value)
+        fruitStore?.updateFruitStock(fruit: .kiwi, amountOf: Int(sender.value))
         kiwiStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func mangoStepperPressed(_ sender: UIStepper) {
-        fruitStock[.mango] = Int(sender.value)
+        fruitStore?.updateFruitStock(fruit: .mango, amountOf: Int(sender.value))
         mangoStockLabel.text = Int(sender.value).description
     }
     
     private func setStockLabelAndStepperValue() {
-        fruitStock.forEach({ fruit in
-            switch fruit.key {
+        Fruit.allCases.forEach({ fruit in
+            guard let fruitStock = try? fruitStore?.fetchStock(of: fruit) else { return }
+            switch fruit {
             case .strawberry:
-                strawberryStepper.value = Double(fruit.value)
-                strawberryStockLabel.text = String(fruit.value)
+                strawberryStepper.value = Double(fruitStock)
+                strawberryStockLabel.text = String(fruitStock)
             case .banana:
-                bananaStepper.value = Double(fruit.value)
-                bananaStockLabel.text = String(fruit.value)
+                bananaStepper.value = Double(fruitStock)
+                bananaStockLabel.text = String(fruitStock)
             case .pineapple:
-                pineappleStepper.value = Double(fruit.value)
-                pineappleStockLabel.text = String(fruit.value)
+                pineappleStepper.value = Double(fruitStock)
+                pineappleStockLabel.text = String(fruitStock)
             case .kiwi:
-                kiwiStepper.value = Double(fruit.value)
-                kiwiStockLabel.text = String(fruit.value)
+                kiwiStepper.value = Double(fruitStock)
+                kiwiStockLabel.text = String(fruitStock)
             case .mango:
-                mangoStepper.value = Double(fruit.value)
-                mangoStockLabel.text = String(fruit.value)
+                mangoStepper.value = Double(fruitStock)
+                mangoStockLabel.text = String(fruitStock)
             }
         })
+    }
+    
+    func setFruitStore(fruitStore: FruitStore) {
+        self.fruitStore = fruitStore
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -34,22 +34,27 @@ class StockEditViewController: UIViewController {
     }
     
     @IBAction func strawberryStepperPressed(_ sender: UIStepper) {
+        fruitStock[.strawberry] = Int(sender.value)
         strawberryStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func bananaStepperPressed(_ sender: UIStepper) {
+        fruitStock[.banana] = Int(sender.value)
         bananaStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func pineappleStepperPressed(_ sender: UIStepper) {
+        fruitStock[.pineapple] = Int(sender.value)
         pineappleStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func kiwiStepperPressed(_ sender: UIStepper) {
+        fruitStock[.kiwi] = Int(sender.value)
         kiwiStockLabel.text = Int(sender.value).description
     }
     
     @IBAction func mangoStepperPressed(_ sender: UIStepper) {
+        fruitStock[.mango] = Int(sender.value)
         mangoStockLabel.text = Int(sender.value).description
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class StockEditViewController: UIViewController {
     
+    var fruitStock = [Fruit: Int]()
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
     @IBOutlet weak var pineappleStockLabel: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -14,7 +14,7 @@ protocol StockEditDelegate {
 class StockEditViewController: UIViewController {
     
     var delegate: StockEditDelegate?
-    private var fruitStock = [Fruit: Int]()
+    internal var fruitStock = [Fruit: Int]()
     
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -15,4 +15,7 @@ class StockEditViewController: UIViewController {
         navigationController?.navigationBar.backgroundColor = .systemGray5
     }
 
+    @IBAction func dismissButtonPressed(_ sender: UIBarButtonItem) {
+        dismiss(animated: true)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -16,9 +16,16 @@ class StockEditViewController: UIViewController {
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
 
+    @IBOutlet weak var strawberryStepper: UIStepper!
+    @IBOutlet weak var bananaStepper: UIStepper!
+    @IBOutlet weak var pineappleStepper: UIStepper!
+    @IBOutlet weak var kiwiStepper: UIStepper!
+    @IBOutlet weak var mangoStepper: UIStepper!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setStockLabelAndStepperValue()
         navigationController?.navigationBar.backgroundColor = .systemGray5
     }
 
@@ -46,4 +53,25 @@ class StockEditViewController: UIViewController {
         mangoStockLabel.text = Int(sender.value).description
     }
     
+    private func setStockLabelAndStepperValue() {
+        fruitStock.forEach({ fruit in
+            switch fruit.key {
+            case .strawberry:
+                strawberryStepper.value = Double(fruit.value)
+                strawberryStockLabel.text = String(fruit.value)
+            case .banana:
+                bananaStepper.value = Double(fruit.value)
+                bananaStockLabel.text = String(fruit.value)
+            case .pineapple:
+                pineappleStepper.value = Double(fruit.value)
+                pineappleStockLabel.text = String(fruit.value)
+            case .kiwi:
+                kiwiStepper.value = Double(fruit.value)
+                kiwiStockLabel.text = String(fruit.value)
+            case .mango:
+                mangoStepper.value = Double(fruit.value)
+                mangoStockLabel.text = String(fruit.value)
+            }
+        })
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -7,7 +7,13 @@
 
 import UIKit
 
+protocol StockEditDelegate {
+    func didEndStockEditing(fruitStock: [Fruit: Int])
+}
+
 class StockEditViewController: UIViewController {
+    
+    var delegate: StockEditDelegate?
     
     var fruitStock = [Fruit: Int]()
     @IBOutlet weak var strawberryStockLabel: UILabel!
@@ -30,6 +36,7 @@ class StockEditViewController: UIViewController {
     }
 
     @IBAction func dismissButtonPressed(_ sender: UIBarButtonItem) {
+        delegate?.didEndStockEditing(fruitStock: fruitStock)
         dismiss(animated: true)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -8,6 +8,12 @@
 import UIKit
 
 class StockEditViewController: UIViewController {
+    
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var mangoStockLabel: UILabel!
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockEditViewController.swift
@@ -14,8 +14,8 @@ protocol StockEditDelegate {
 class StockEditViewController: UIViewController {
     
     var delegate: StockEditDelegate?
+    private var fruitStock = [Fruit: Int]()
     
-    var fruitStock = [Fruit: Int]()
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
     @IBOutlet weak var pineappleStockLabel: UILabel!

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -16,11 +16,8 @@ class FruitStore {
         }
     }
     
-    func add(_ fruit: Fruit, amountOf amount: Int) {
-        if let currentStock = fruitStock[fruit] {
-            let totalStock = currentStock + amount
-            fruitStock.updateValue(totalStock, forKey: fruit)
-        }
+    func updateFruitStock(fruit: Fruit, amountOf amount: Int) {
+        fruitStock.updateValue(amount, forKey: fruit)
     }
     
     func use(_ fruit: Fruit, amountOf amount: Int) {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -98,4 +98,8 @@ struct JuiceMaker {
             fruitStore.updateFruitStock(fruit: fruit, amountOf: stock)
         })
     }
+    
+    func fetchFruitStore() -> FruitStore {
+        return self.fruitStore
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -92,4 +92,10 @@ struct JuiceMaker {
     func fetchStock(of fruit: Fruit) throws -> Int {
         return try fruitStore.fetchStock(of: fruit)
     }
+    
+    func updateAllStock(using fruitStock: [Fruit: Int]) {
+        fruitStock.forEach({ (fruit, stock) in
+            fruitStore.updateFruitStock(fruit: fruit, amountOf: stock)
+        })
+    }
 }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -275,7 +275,7 @@
         <!--재고 수정-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" customClass="StockEditViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="stockEditViewController" id="Yu1-lM-nqp" customClass="StockEditViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -438,25 +438,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="901"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="cAf-jL-tPK">
-            <objects>
-                <navigationController storyboardIdentifier="stockEditNavigation" automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
-                        <rect key="frame" x="0.0" y="0.0" width="896" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="Yu1-lM-nqp" kind="relationship" relationship="rootViewController" id="wH1-3A-cBm"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="2s5-lS-967" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1637" y="21"/>
+            <point key="canvasLocation" x="1556" y="93"/>
         </scene>
     </scenes>
     <resources>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -388,6 +388,13 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="OWv-rT-Yt6"/>
+                        <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="Vnc-U6-Pbd"/>
+                        <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="B1v-Rf-Qzt"/>
+                        <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="Bda-Eb-uMb"/>
+                        <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="XxE-Da-Z56"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -298,6 +298,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                 <rect key="frame" x="580" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="mangoStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="sUH-yH-iiZ"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
                                 <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
@@ -317,6 +320,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                 <rect key="frame" x="410" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="kiwiStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="szL-b3-qe2"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
                                 <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
@@ -336,6 +342,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                 <rect key="frame" x="261" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="pineappleStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="3rj-Lz-D6a"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
                                 <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
@@ -347,6 +356,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                 <rect key="frame" x="154" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="bananaStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="MIj-ew-P1b"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
                                 <rect key="frame" x="98" y="161" width="11.666666666666664" height="23"/>
@@ -374,6 +386,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="strawberryStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="RYE-hN-KFD"/>
+                                </connections>
                             </stepper>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -406,11 +406,15 @@
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="flB-hM-Yc2"/>
                         <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="OWv-rT-Yt6"/>
+                        <outlet property="kiwiStepper" destination="klA-59-Nu4" id="vlO-2J-quV"/>
                         <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="Vnc-U6-Pbd"/>
+                        <outlet property="mangoStepper" destination="xbn-6P-grO" id="D2f-PX-Yx4"/>
                         <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="B1v-Rf-Qzt"/>
+                        <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="ZyT-Ca-m8f"/>
                         <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="Bda-Eb-uMb"/>
-                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="aNw-yU-dVz"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="zOs-G3-ZcN"/>
                         <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="XxE-Da-Z56"/>
                     </connections>
                 </viewController>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -379,7 +379,15 @@
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <navigationItem key="navigationItem" title="재고 수정" id="g4W-fY-l7r"/>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" title="재고 수정" id="g4W-fY-l7r">
+                        <barButtonItem key="rightBarButtonItem" title="닫기" id="w1A-ph-AQt">
+                            <connections>
+                                <action selector="dismissButtonPressed:" destination="Yu1-lM-nqp" id="QzG-mj-kQE"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -360,21 +360,30 @@
                                     <action selector="bananaStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="MIj-ew-P1b"/>
                                 </connections>
                             </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="98" y="161" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                <rect key="frame" x="60" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="Pq7-UK-OUJ">
+                                <rect key="frame" x="30.5" y="72.999999999999986" width="94" height="150.66666666666666"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                        <rect key="frame" x="0.0" y="89.666666666666671" width="94" height="23"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                        <rect key="frame" x="0.0" y="118.66666666666669" width="94" height="32"/>
+                                        <connections>
+                                            <action selector="strawberryStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="RYE-hN-KFD"/>
+                                        </connections>
+                                    </stepper>
+                                </subviews>
+                            </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
                                 <rect key="frame" x="196" y="158" width="11.666666666666664" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -383,13 +392,6 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                <rect key="frame" x="50" y="192" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="strawberryStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="RYE-hN-KFD"/>
-                                </connections>
-                            </stepper>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -408,6 +410,7 @@
                         <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="Vnc-U6-Pbd"/>
                         <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="B1v-Rf-Qzt"/>
                         <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="Bda-Eb-uMb"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="aNw-yU-dVz"/>
                         <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="XxE-Da-Z56"/>
                     </connections>
                 </viewController>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
-    <device id="retina6_0" orientation="landscape" appearance="light"/>
+    <device id="retina6_1" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
@@ -15,23 +15,23 @@
             <objects>
                 <viewController storyboardIdentifier="Main" id="BYZ-38-t0r" customClass="JuiceMakerViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="60" y="52" width="724" height="136.66666666666666"/>
+                                <rect key="frame" x="60" y="64" width="776" height="145"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="142.5" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="148" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="158.5" y="0.0" width="142.5" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="296" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="317" y="0.0" width="142" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="142" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="122" width="142" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="444" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="475" y="0.0" width="142.5" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="592" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="633.5" y="0.0" width="142.5" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="142.5" height="114"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="122" width="142.5" height="23"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="60" y="208.66666666666663" width="724" height="140.33333333333337"/>
+                                <rect key="frame" x="60" y="229" width="776" height="144"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="724" height="66"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="776" height="68"/>
                                         <subviews>
                                             <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="301" height="68"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="296" y="0.0" width="132" height="66"/>
+                                                <rect key="frame" x="317" y="0.0" width="142" height="68"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="444" y="0.0" width="280" height="66"/>
+                                                <rect key="frame" x="475" y="0.0" width="301" height="68"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -148,13 +148,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="74.000000000000028" width="724" height="66.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="76" width="776" height="68"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="724" height="66.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="776" height="68"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
+                                                        <rect key="frame" x="0.0" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -164,8 +164,8 @@
                                                             <action selector="juiceOrderButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RT4-v2-evO"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                        <rect key="frame" x="158.5" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -175,8 +175,8 @@
                                                             <action selector="juiceOrderButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uuX-Yd-5Rm"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                        <rect key="frame" x="317" y="0.0" width="142" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -187,7 +187,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="475" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -198,7 +198,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="633.5" y="0.0" width="142.5" height="68"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -260,7 +260,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -277,124 +277,142 @@
             <objects>
                 <viewController id="Yu1-lM-nqp" customClass="StockEditViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                <rect key="frame" x="590" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="622" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="580" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="mangoStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="sUH-yH-iiZ"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="461" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                <rect key="frame" x="410" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="kiwiStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="szL-b3-qe2"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="303" y="155" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                <rect key="frame" x="261" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="pineappleStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="3rj-Lz-D6a"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                <rect key="frame" x="154" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="bananaStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="MIj-ew-P1b"/>
-                                </connections>
-                            </stepper>
-                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="Pq7-UK-OUJ">
-                                <rect key="frame" x="30.5" y="72.999999999999986" width="94" height="150.66666666666666"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="xke-Qi-KuC">
+                                <rect key="frame" x="125" y="130.5" width="646" height="153"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                        <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                        <rect key="frame" x="0.0" y="89.666666666666671" width="94" height="23"/>
-                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                        <rect key="frame" x="0.0" y="118.66666666666669" width="94" height="32"/>
-                                        <connections>
-                                            <action selector="strawberryStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="RYE-hN-KFD"/>
-                                        </connections>
-                                    </stepper>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="Pq7-UK-OUJ">
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="153"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="86"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                                <rect key="frame" x="0.0" y="92" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="0.0" y="121" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="strawberryStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="RYE-hN-KFD"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="Fvj-H9-Rbm">
+                                        <rect key="frame" x="138" y="0.0" width="94" height="153"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="86"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                                <rect key="frame" x="0.0" y="92" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="0.0" y="121" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="bananaStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="MIj-ew-P1b"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="gys-dQ-jC0">
+                                        <rect key="frame" x="276" y="0.0" width="94" height="153"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
+                                                <rect key="frame" x="0.0" y="91" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                                <rect key="frame" x="0.0" y="121" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="pineappleStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="3rj-Lz-D6a"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="kHJ-a2-fX8">
+                                        <rect key="frame" x="414" y="0.0" width="94" height="153"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
+                                                <rect key="frame" x="0.0" y="91" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                                <rect key="frame" x="0.0" y="121" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="kiwiStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="szL-b3-qe2"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="yEy-z4-e4P">
+                                        <rect key="frame" x="552" y="0.0" width="94" height="153"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="84"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                                <rect key="frame" x="0.0" y="91" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                                <rect key="frame" x="0.0" y="121" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="mangoStepperPressed:" destination="Yu1-lM-nqp" eventType="valueChanged" id="sUH-yH-iiZ"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
                             </stackView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="196" y="158" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="xke-Qi-KuC" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="HkV-hs-ncw"/>
+                            <constraint firstItem="xke-Qi-KuC" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="QeS-b4-7TY"/>
+                            <constraint firstItem="xke-Qi-KuC" firstAttribute="width" relation="greaterThanOrEqual" secondItem="gcO-Xb-kNs" secondAttribute="width" multiplier="80%" id="VRO-KC-EhQ"/>
+                        </constraints>
                     </view>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" title="재고 수정" id="g4W-fY-l7r">
@@ -428,7 +446,7 @@
                 <navigationController storyboardIdentifier="stockEditNavigation" automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,259 @@
+# ios-juice-maker
+iOS 쥬스 메이커 재고관리 시작 저장소
+
+목차
+1. [제목](#제목)
+2. [소개](#소개)
+3. [앱실행화면](#앱-실행-화면)
+4. [타임라인](#타임라인)
+5. [프로젝트 구조](#프로젝트-구조)
+6. [트러블 슈팅](#트러블-슈팅)
+    <ul>
+    <li><a href="#Step1">Step1</a></li>
+    <li><a href="#Step2">Step2</a></li>
+    <li><a href="#Step3">Step3</a></li>
+    </ul>
+7. [참고 링크](#참고-링크)
+ 
+# 제목: 쥬스 메이커
+## 소개
+주스재고에서 과일을 꺼내어 주스를 만들어주는 프로그램입니다.
+|![캡처](https://avatars.githubusercontent.com/u/66786418?v=4)|![CCF2339F-606F-4EE9-97EC-88620DE7174A (1) (1)](https://user-images.githubusercontent.com/71054048/188081997-a9ac5789-ddd6-4682-abb1-90d2722cf998.jpg)|
+|:---:|:---:|
+|토털이|인호|
+
+## 타임라인: 시간 순으로 프로젝트의 주요 진행 척도를 표시
+| 날짜 | 중요 진행 상황 | 코드 관련 사항
+|---|---|---|
+|8/30| `STEP1` 시작, 과일 쥬스 제조 및 수량 변경 기능 구현 | `FruitStore`에 `addStock`, `useStock`등등 메서드 구현, `JuiceMaker`속 `Recipe`를 `enum`으로 만들어 레시피에 맞는 쥬스 제조 기능 구현, `JuiceMakerError`로 에러 처리 구현
+|9/1| 코드 리뷰 후 리팩토링| `useStock`, `addStock`을 `use`로 변경, `Recipe` 타입 내 프로퍼티를 딕셔너리 타입으로 수정하여 가독성을 높임
+|9/2| `FruitStock` 재고 초기화 자동화 | `CaseIterable` 프로토콜을 사용하여 `allCase`로 `forEach`문을 사용해 초기화를 자동화 시킴
+|9/5| `STEP 2` 시작, 첫 화면 구현 및 제조 알람 구현 | 과일 별 IBOutlet 레이블 설정후 `juiceMaker`를 통해 데이터를 받아와 화면에 구현, `juiceMaker`를 활용해 주문 기능 구현. 주문실패 및 주문 성공시 `Alert` 인스턴스에 확인을 누르면 `alert`이 사라지도록 구현
+|9/6| 주문시 과일 레이블 업데이트 구현 | `stockEditButtonPressed`로 메서드 이름 변경, 모든 과일을 업데이트 해주는 `updateAllStockLabels()` 메서드로 과일을 업데이트, 
+|9/8| 코드 리뷰 후 리팩토링| 함수 네이밍 수정 및 접근 제어자 수정, modal 방식 변경, 모든 과일을 업데이트 해주는 방법에서 부분적으로 업데이트 해주도록 `updateStockLable(of fruit)` 메서드 추가, `Juice` 타입에 해당하는 알람의 메세지를 옮겨줌
+|9/9| 코드 리뷰 후 리팩토링 | 뷰컨트롤러 이름 `JuiceMakerViewController`로 수정, `Juice`타입에 `orderFailedMessage` 프로퍼티로 추가
+|9/12|`STEP3` 시작, 닫기 버튼 및 Stepper 기능 및 데이터 전달방법 구현 | `Stepper` `IBOutlet`선언 및 값 변경에 따라 `JuiceMaker` 속 데이터를 변경하고 이전 화면에 전달하는 기능을 프로퍼티, Delegate 순으로 구현, 오토레이아웃 설정 |
+|9/16|코드 리뷰 후 리펙토링|`FruitStore`참조값을 이용한 데이터 전달 방법 적용, 뷰컨트롤러 네이밍 `VC`에서 `ViewController`로 수정|
+
+## 앱 실행 화면
+
+### 1. 주문 화면 및 알람
+![](https://i.imgur.com/kkN5ROz.gif)
+### 2. 재고 수정 화면
+![](https://i.imgur.com/hxP5eDk.gif)
+### 3. 재고 부족시 재고 수정 화면으로 전환
+![](https://i.imgur.com/VAFYgUo.gif)
+### 4. AutoLayout 적용으로 여러 기기에서 실행 가능
+![](https://i.imgur.com/ghNSrqO.gif)
+
+
+## 트러블 슈팅
+<details>
+<summary id="Step1"><h4>Step1</h4></summary>
+<div markdown="1">
+    
+#### 1. `fruitStock`프로퍼티 초기화 방법
+과일마다 재고를 초기화 해주기 위해 몇가지 방법을 고민했다.
+1. 프로퍼티에 직접 과일별로 갯수를 입력하는 방법
+```swift
+var fruitStock: [Fruit: Int] = [.strawberry: 10, .banana: 10, .pineapple: 10, .kiwi: 10, .mango: 10]
+```
+- 위 방법은 가독성이 좋고 각 과일의 초기값이 다를때에 활용할 수 있지만 일일이 적어준다는 단점이 있다.
+
+2. `Fruit`타입의 `allCases`,`forEach`를 이용하여 초기화하는 방법
+```swift
+let initialStock = 10
+var fruitStock = [Fruit: Int]()
+
+init() {
+    Fruit.allCases.forEach { fruit in
+        fruitStock[fruit] = initialStock
+    }
+}
+```
+- 위 방법은 한번에 같은 값을 초기화 해주기에 좋지만 직관성이 떨어진다.
+3. `Fruit`타입에 연산프로퍼티와 초기화 함수 모두 사용하는 방법
+```swift
+enum Fruit: CaseIterable {
+    case strawberry, banana, pineapple, kiwi, mango
+    var initialStock: Int {
+        switch self {
+        default:
+            return 10
+        }
+    }
+}
+
+init() {
+    Fruit.allCases.forEach { fruit in
+        fruitStock.updateValue(fruit.initialStock, forKey: fruit)
+    }
+}
+```
+- 1, 2번의 단점을 보완하기 위해 최종적으로 사용한 코드이다.
+- `Fruit`타입 내에 `initialStock`프로퍼티의 `switch`문을 이용하여 각 케이스 별로 초기값이 다른 상황을 처리할 수 있고 `fruitStock`프로퍼티에 값을 일일이 넣어주지 않도록 작성되었다.
+
+#### 2. `Juice`타입에 중첩된 `Recipe`구조체
+- 처음 레시피 구조체는 아래와 같은 형태로 여러개의 과일과 수량을 담을 수 없는 레시피의 형태였다. 그래서 하나의 주스에 대해 여러개의 레시피가 있는 것 같은 코드가 작성되었다.
+```swift
+struct Recipe {
+    let fruit: Fruit, amount: Int
+}
+
+case .strawberryBananaJuice:
+    return Recipe[(fruit: .strawberry, amount: 10), Recipe(fruit: .banana, amount: 1)]
+```
+- 이를 아래와 같이 한개의 레시피에 여러개의 재료가 있는 코드로 수정되었다.
+```swift
+struct Recipe {
+    let ingredient: [Fruit: Int]
+}
+
+case .strawberryBananaJuice:
+    return Recipe(ingredient: [.strawberry: 10, .banana: 1])
+```
+
+</div>
+</details>
+
+<details>
+<summary id="Step2"><h4>Step2</h4></summary>
+<div markdown="1">
+
+#### `JuiceMakerViewController`에서 과일 재고량 레이블 업데이트 방법
+앱을 실행하거나 과일 주문 버튼이 눌려 과일 수량이 변경되었을 때, 각 수량이 레이블에 반영되어야 한다.
+이를 구현할때, 각 과일별 레이블을 관리하는 메서드를 만드는 대신
+`updateStockLabel(of fruit: Fruit)`인 하나의 메서드에서 `switch`문을 이용하여 원하는 레이블을 업데이트 한다.
+```swift
+func updateStockLabel(of fruit: Fruit) {
+    guard let fruitStock = try? juiceMaker.fetchStock(of: fruit) else { return }
+        
+    switch fruit {
+    case .strawberry:
+        strawberryStockLabel.text = String(fruitStock)
+    case .banana:
+        bananaStockLabel.text = String(fruitStock)
+    ...
+    }
+}
+```
+
+#### 과일 주문 버튼 처리방법
+앱 내에 음료 주문 버튼이 총 7개가 있다. 이때 각 버튼에 대한 액션을 일일이 만들어야 하나 고민하다가, 버튼의 `tag`값을 이용하여 하나의 메서드로 관리하도록 구현했다. 
+```swift
+@IBAction func touchUpOrderButton(_ sender: UIButton) {
+    if let orderedJuice = JuiceMaker.Juice(rawValue: sender.tag) {
+        do {
+            try juiceMaker.produce(juice: orderedJuice)
+            showOrderedAlert(juice: orderedJuice)
+        } catch JuiceMakerError.outOfStock {
+            showOrderFailedAlert()
+        }
+        ...
+    }
+}
+```
+- 위 방법은 비효율을 줄이는 장점이 있지만, 음료나 버튼의 갯수가 많아지면 tag 값을 관리하기 어렵거나 tag 값과 음료가 매치되지 않아서 유지보수에 단점이 있다.
+- 그래서 두번째 뷰 컨트롤러의 `stepper`을 다루는 부분에서는 하나하나 관리하도록 구현했다.
+
+#### 화면 전환 방법
+앱 내에는 `JuiceMakerViewController`, `StockEditViewController` 두가지가 있고, 각 뷰컨트롤러에는 네비게이션 컨트롤러가 연결되어 있다. 
+
+</div>
+</details>
+
+<details>
+<summary id="Step3"><h4>Step3</h4></summary>
+<div markdown="1">
+
+#### 뷰 컨트롤러 간에 데이터 전달 방법
+총 3가지의 방법을 이용해봤다.
+1. `JuiceMakerViewController`에서 `StockEditViewController`로 넘어갈때는 fruitStock프로퍼티에 접근하여 값을 전달하는 방법
+```swift
+class StockEditViewController: UIViewController {
+    var fruitStock = [Fruit: Int]()
+    ...
+}
+    
+class JuiceMakerViewController: UIViewController {
+    ...
+    Fruit.allCases.forEach({ fruit in
+        guard let fruitStock = try? juiceMaker.fetchStock(of: fruit) else { return }
+            
+        stockEditVC.fruitStock[fruit] = fruitStock
+    })
+}
+```
+2. `StockEditViewController`에서 재고 수정을 마친 데이터를 `JuiceMakerViewController`로 보낼때 delegate를 이용하는 방법.
+```swift
+protocol StockEditDelegate {
+    func didEndStockEditing(fruitStock: [Fruit: Int])
+}
+
+class StockEditViewController: UIViewController {   
+    var delegate: StockEditDelegate?
+    ...
+    @IBAction func dismissButtonPressed(_ sender: UIBarButtonItem) {
+        delegate?.didEndStockEditing(fruitStock: fruitStock)
+        dismiss(animated: true)
+    }
+    ...
+}
+
+extension JuiceMakerViewController: StockEditDelegate {
+    func didEndStockEditing(fruitStock: [Fruit: Int]) {
+        juiceMaker.updateAllStock(using: fruitStock)
+        updateAllStockLabels()
+    }
+}
+```
+
+3. 하나의 `FruitStock`인스턴스를 모듈 내에서 활용하는 방법
+```swift
+class FruitStore {
+    private var fruitStock: [Fruit: Int] = [:]
+    ...
+}
+
+class StockEditViewController: UIViewController {
+    private var fruitStore: FruitStore?
+    ...
+    func setFruitStore(fruitStore: FruitStore) {
+        self.fruitStore = fruitStore
+    }
+    ...
+}
+
+class JuiceMakerViewController: UIViewController {
+    ...
+    stockEditViewController.setFruitStore(fruitStore: juiceMaker.fetchFruitStore())
+}
+```
+#### `StockEditViewController`내 요소 업데이트 방법(label, stepper)
+
+`JuiceMakerViewController`에서 여러 버튼을 관리할때 하나의 메서드에서 tag를 이용한 것과 달리
+여러 stepper에 대한 `outlet`과 `action`을 연결하여 독립적으로 관리하도록 구현했다. 
+```swift
+@IBOutlet weak var strawberryStepper: UIStepper!
+
+@IBAction func strawberryStepperPressed(_ sender: UIStepper) {
+    fruitStore?.updateFruitStock(fruit: .strawberry, amountOf: Int(sender.value))
+    strawberryStockLabel.text = Int(sender.value).description
+}
+```
+
+#### 오토 레이아웃 적용
+- `StockEditViewController`에서 오토레이아웃을 정할때, 각 과일의 이미지, 레이블, 스테퍼를 하나의 수직stackView로 만들고, 그렇게 만들어진 5개의 stackView를 하나의 수평stackView에 담았다.
+- `Ipod touch`기기에서 stepper의 요소가 잘리는 문제가 있었는데, 이를 해결하기 위해서
+가장 포괄적인 수평stackView의 width를 safe Area 너비의 80% 이상으로 지정해서
+작은 화면에서도 요소가 잘리지 않도록 했다.(오토레이아웃 화면 참고)
+
+</div>
+</details>
+
+## 참고 링크
+- [Swift Language Guide - Initialization](https://docs.swift.org/swift-book/LanguageGuide/Initialization.html)
+- [Swift Language Guide - Access Control](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html)
+- [Swift Language Guide - Nested Types](https://docs.swift.org/swift-book/LanguageGuide/NestedTypes.html)
+- [Swift Language Guide - Type Casting](https://docs.swift.org/swift-book/LanguageGuide/TypeCasting.html)
+- [Swift Language Guide - Error Handling](https://docs.swift.org/swift-book/LanguageGuide/ErrorHandling.html)


### PR DESCRIPTION
안녕하세요, @havilog 
토털이, 인호 입니다.

쥬스 메이커 프로그램 step 3 PR입니다!

## 고민했던 부분
#### 뷰컨트롤러 간에 데이터를 전달하는 방법
- `JuiceMakerVC`에서 `StockEditVC`로 넘어갈때는 두번째 뷰컨의 `fruitStock`프로퍼티에 접근하여 값을 전달합니다.
```swift
class StockEditViewController: UIViewController {
    var fruitStock = [Fruit: Int]()
    ...
}
    
class JuiceMakerViewController: UIViewController {
    ...
    Fruit.allCases.forEach({ fruit in
        guard let fruitStock = try? juiceMaker.fetchStock(of: fruit) else { return }
            
        stockEditVC.fruitStock[fruit] = fruitStock
    })
}
```
- `StockEditVC`에서 재고 수정을 마친 데이터를 `JuiceMakerVC`로 보낼때는 `delegate`을 이용합니다. 
```swift
protocol StockEditDelegate {
    func didEndStockEditing(fruitStock: [Fruit: Int])
}

class StockEditViewController: UIViewController {   
    var delegate: StockEditDelegate?
    ...
    @IBAction func dismissButtonPressed(_ sender: UIBarButtonItem) {
        delegate?.didEndStockEditing(fruitStock: fruitStock)
        dismiss(animated: true)
    }
    ...
}

extension JuiceMakerViewController: StockEditDelegate {
    func didEndStockEditing(fruitStock: [Fruit: Int]) {
        juiceMaker.updateAllStock(using: fruitStock)
        updateAllStockLabels()
    }
}
```
- `StockEditVC`에서 닫기 버튼이 눌렸을때 `delegate`의 메서드를 호출합니다. 
- `didEndStockEditing`의 메서드 내에서는 전달받은 데이터를 가지고 `fruitStock`과 과일 재고에 맞게 레이블을 업데이트 하는 메서드를 호출합니다.
- 위 두가지 방식을 이용한 이유는 아래 조언을 얻고싶은 부분에 같이 남겨두었습니다!
#### `StockEditVC` 내에서 정보 업데이트 방법(label, stepper)
- `JuiceMakerVC`에서 여러 버튼을 하나의 메서드에서 `tag`를 이용했던 방법과 달리 각 스테퍼에 메서드를 연결했습니다. 메서드 내에서는 스테퍼의 바뀌는 `value` 값을 `fruitStock`프로퍼티와 `fruitStockLable`에 바로 전달해줍니다.
```swift
@IBAction func strawberryStepperPressed(_ sender: UIStepper) {
    fruitStock[.strawberry] = Int(sender.value)
    strawberryStockLabel.text = Int(sender.value).description
}
```
#### 오토레이아웃 적용
- `StockEditVC`에서 오토레이아웃을 정할때, 각 과일의 이미지, 레이블, 스테퍼를 하나의 수직`stackView`로 만들고, 그렇게 만들어진 5개의 `stackView`를 하나의 수평`stackView`에 담습니다.
- `Ipod touch`기기에서 `stepper`의 요소가 잘리는 문제가 있었는데, 이를 해결하기 위해서
가장 포괄적인 수평`stackView`의 `width`를 safe Area 너비의 80% 이상으로 지정해서 
작은 화면에서도 요소가 잘리지 않도록 했습니다.

## 조언을 얻고싶은 부분
- Delgate를 공부하고 사용하다가 순환 참조 문제가 발생할 수 있다는걸 알게됐습니다. 어떤 상황에 순환참조가 일어나는지 알아보고 저희 코드와 비교해 보니, 저희 코드에서는 순환 참조가 일어나지 않는것 같습니다. 
Delegate을 사용했을때 순환 참조가 일어나는 경우는 두 뷰컨트롤러 내에서 서로를 프로퍼티로 참조하고 있을때 발생한다고 이해했는데, 저희 코드처럼 스토리 보드 ID로 접근하는게 아닌 직접 다음 뷰컨트롤러의 인스턴스를 프로퍼티로 받아오는 경우가 많은지 궁금합니다..!

- 위에서 고민한 내용대로, `JuiceMakerVC`에서 `StockEditVC`로 넘어갈때는 두번째 뷰컨의 `fruitStock`프로퍼티에 접근하고 `StockEditVC`에서 `JuiceMakerVC`로 데이터를 전달할 때는 `delegate`을 이용합니다.
처음에는 첫번째뷰에서 두번째로 넘어갈때에 `delegate`을 이용하려 했는데 실패한 이유가
두번째 뷰컨에서 첫번째 뷰의 `delegate`프로퍼티를 self로 받아야 하는 과정이 있는데, 두번째 뷰컨은 첫번째 뷰컨에서 `present`할때 메모리에 올라가서 `delegate`지정이 안되어 데이터를 전달할 수 없다고 이해했고, 현재 코드대로 프로퍼티를 이용했습니다.
그리고 검색했을때, 주로 두번째 뷰컨에서 첫번째 뷰컨으로 넘어올때 `delegate`을 이용한다는 내용도 있었는데 아마 위의 이유 때문이지 않을까 싶었습니다.
`delegate`를 이용한 해결 방법이 있는지, 아니면 지금 이해한 내용이 맞는지 궁금합니다..!!🤔