### PR TITLE
쥬스 메이커 [STEP 3] 써니쿠키, 써머캣

### DIFF
--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -19,7 +19,7 @@ class FruitStockViewController: UIViewController {
         .banana: bananaStockLabel,
         .pineapple: pineappleStockLabel,
         .kiwi: kiwiStockLabel,
-        .mango: mangoStockLabel
+        .mango: mangoStockLabel,
     ]
     
     lazy var fruitStepper: [UIStepper: Fruit] = [
@@ -27,7 +27,7 @@ class FruitStockViewController: UIViewController {
         bananaStepper: .banana,
         pineappleStepper: .pineapple,
         kiwiStepper: .kiwi,
-        mangoStepper: .mango
+        mangoStepper: .mango,
     ]
     
     func updateFruitStockLabel() {
@@ -62,8 +62,5 @@ class FruitStockViewController: UIViewController {
         
         fruitLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
     }
-    
-    
-    
-    
+
 }

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -22,9 +22,23 @@ class FruitStockViewController: UIViewController {
         .mango: mangoStockLabel
     ]
     
+    lazy var fruitStepper: [UIStepper: Fruit] = [
+        strawberryStepper: .strawberry,
+        bananaStepper: .banana,
+        pineappleStepper: .pineapple,
+        kiwiStepper: .kiwi,
+        mangoStepper: .mango
+    ]
+    
     func updateFruitStockLabel() {
         for (fruit, label) in fruitLabel {
             label.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
+        }
+    }
+    
+    func assignStepperValue() {
+        for (stepper, fruit) in fruitStepper {
+            stepper.value = Double(FruitStore.sharedFruitStore.fetchStockOf(fruit))
         }
     }
 
@@ -32,6 +46,7 @@ class FruitStockViewController: UIViewController {
         super.viewDidLoad()
         
         updateFruitStockLabel()
+        assignStepperValue()
     }
     
     @IBAction func touchUpDismissButton(_ sender: UIBarButtonItem) {
@@ -39,24 +54,13 @@ class FruitStockViewController: UIViewController {
     }
     
     @IBAction func changeFruitStock(_ sender: UIStepper) {
-        let fruitStepper: [UIStepper: Fruit] = [
-            strawberryStepper: .strawberry,
-            bananaStepper: .banana,
-            pineappleStepper: .pineapple,
-            kiwiStepper: .kiwi,
-            mangoStepper: .mango
-        ]
-
-        sender.minimumValue = -1
-        
         guard let fruit = fruitStepper[sender],
               let fruitLabel = fruitLabel[fruit] else { return }
         
-        FruitStore.sharedFruitStore.changeStockOf(fruit: fruit, by: Int(sender.value))
+        let changedValue = Int(sender.value) - FruitStore.sharedFruitStore.fetchStockOf(fruit)
+        FruitStore.sharedFruitStore.changeStockOf(fruit: fruit, by: changedValue)
         
         fruitLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
-        
-        sender.value = 0
     }
     
     

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -8,6 +8,12 @@ class FruitStockViewController: UIViewController {
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
     
+    @IBOutlet weak var strawberryStepper: UIStepper!
+    @IBOutlet weak var bananaStepper: UIStepper!
+    @IBOutlet weak var pineappleStepper: UIStepper!
+    @IBOutlet weak var kiwiStepper: UIStepper!
+    @IBOutlet weak var mangoStepper: UIStepper!
+    
     lazy var fruitLabel: [Fruit: UILabel] = [
         .strawberry: strawberryStockLabel,
         .banana: bananaStockLabel,
@@ -31,5 +37,29 @@ class FruitStockViewController: UIViewController {
     @IBAction func touchUpDismissButton(_ sender: Any) {
         self.dismiss(animated: true)
     }
+    
+    @IBAction func changeFruitStock(_ sender: UIStepper) {
+        let fruitStepper: [UIStepper: Fruit] = [
+            strawberryStepper: .strawberry,
+            bananaStepper: .banana,
+            pineappleStepper: .pineapple,
+            kiwiStepper: .kiwi,
+            mangoStepper: .mango
+        ]
+
+        sender.minimumValue = -1
+        
+        guard let fruit = fruitStepper[sender],
+              let fruitLabel = fruitLabel[fruit] else { return }
+        
+        FruitStore.sharedFruitStore.changeStockOf(fruit: fruit, by: Int(sender.value))
+        
+        fruitLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
+        
+        sender.value = 0
+    }
+    
+    
+    
     
 }

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -30,6 +30,13 @@ class FruitStockViewController: UIViewController {
         mangoStepper: .mango,
     ]
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        updateFruitStockLabel()
+        assignStepperValue()
+    }
+    
     func updateFruitStockLabel() {
         for (fruit, label) in fruitLabel {
             label.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
@@ -42,13 +49,6 @@ class FruitStockViewController: UIViewController {
         }
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        updateFruitStockLabel()
-        assignStepperValue()
-    }
-    
     @IBAction func touchUpDismissButton(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true)
     }
@@ -58,9 +58,9 @@ class FruitStockViewController: UIViewController {
               let fruitLabel = fruitLabel[fruit] else { return }
         
         let changedValue = Int(sender.value) - FruitStore.sharedFruitStore.fetchStockOf(fruit)
+        
         FruitStore.sharedFruitStore.changeStockOf(fruit: fruit, by: changedValue)
         
         fruitLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
     }
-
 }

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -7,9 +7,25 @@ class FruitStockViewController: UIViewController {
     @IBOutlet weak var pineappleStockLabel: UILabel!
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
+    
+    lazy var fruitLabel: [Fruit: UILabel] = [
+        .strawberry: strawberryStockLabel,
+        .banana: bananaStockLabel,
+        .pineapple: pineappleStockLabel,
+        .kiwi: kiwiStockLabel,
+        .mango: mangoStockLabel
+    ]
+    
+    func updateFruitStockLabel() {
+        for (fruit, label) in fruitLabel {
+            label.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
+        }
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        updateFruitStockLabel()
     }
     
     @IBAction func touchUpDismissButton(_ sender: Any) {

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -11,4 +11,9 @@ class FruitStockViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
+    
+    @IBAction func touchUpDismissButton(_ sender: Any) {
+        self.dismiss(animated: true)
+    }
+    
 }

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -34,7 +34,7 @@ class FruitStockViewController: UIViewController {
         updateFruitStockLabel()
     }
     
-    @IBAction func touchUpDismissButton(_ sender: Any) {
+    @IBAction func touchUpDismissButton(_ sender: UIBarButtonItem) {
         self.dismiss(animated: true)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -35,25 +35,17 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         
+        updateFruitStockLabel()
     }
     
     func updateFruitStockLabel() {
         for (fruit, label) in fruitLabel {
             label.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
-        }
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        updateFruitStockLabel()
-    }
-    
-    
-    func updateFruitStockLabelUsedFor(_ juice: Juice) {
-        for fruit in juice.recipe.keys {
-            guard let validLabel = fruitLabel[fruit] else { return }
-            validLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
         }
     }
     
@@ -69,15 +61,31 @@ class ViewController: UIViewController {
         ]
         
         guard let juice = juiceButton[sender] else { return }
-        
         let result = juiceMaker.makeJuice(juice, total: 1)
+        
         showAlert(result: result, juice: juice)
+    }
+    
+    func showAlert(result: Result<String, Error>, juice: Juice) {
+        let message = createAlertFor(result: result, juice: juice).message
+        let okAction = createAlertFor(result: result, juice: juice).okAction
+        let noAction = createAlertFor(result: result, juice: juice).noAction
+        
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        
+        alert.addAction(okAction)
+
+        if let validNoAction = noAction {
+            alert.addAction(validNoAction)
+        }
+        
+        present(alert, animated: true, completion: nil)
     }
     
     func createAlertFor(
         result: Result<String, Error>,
         juice: Juice
-    ) -> (message: String, okAction: UIAlertAction, noAction: UIAlertAction?){
+    ) -> (message: String, okAction: UIAlertAction, noAction: UIAlertAction?) {
         var okAction: UIAlertAction
         var noAction: UIAlertAction?
         var message: String
@@ -103,20 +111,16 @@ class ViewController: UIViewController {
         return (message: message, okAction: okAction, noAction: noAction)
     }
     
-    func showAlert(result: Result<String, Error>, juice: Juice) {
-        let message = createAlertFor(result: result, juice: juice).message
-        let okAction = createAlertFor(result: result, juice: juice).okAction
-        let noAction = createAlertFor(result: result, juice: juice).noAction
-        
-        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        
-        alert.addAction(okAction)
-
-        if let validNoAction = noAction {
-            alert.addAction(validNoAction)
+    func updateFruitStockLabelUsedFor(_ juice: Juice) {
+        for fruit in juice.recipe.keys {
+            guard let validLabel = fruitLabel[fruit] else { return }
+            
+            validLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
         }
-        
-        present(alert, animated: true, completion: nil)
+    }
+    
+    @IBAction func touchUpChangeFruitStockButton(_ sender: UIBarButtonItem) {
+        moveToFruitStockVC()
     }
     
     func moveToFruitStockVC() {
@@ -124,11 +128,8 @@ class ViewController: UIViewController {
                 self.storyboard?.instantiateViewController(withIdentifier: "fruitStoreStockNC") else { return }
         
         fruitStoreStockViewController.modalPresentationStyle = UIModalPresentationStyle.fullScreen
+        
         self.present(fruitStoreStockViewController, animated: true, completion: nil)
-    }
-    
-    @IBAction func touchUpChangeFruitStockButton(_ sender: UIBarButtonItem) {
-        moveToFruitStockVC()
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -124,12 +124,13 @@ class ViewController: UIViewController {
     }
     
     func moveToFruitStockVC() {
-        guard let fruitStoreStockViewController =
-                self.storyboard?.instantiateViewController(withIdentifier: "fruitStoreStockNC") else { return }
+        guard let fruitStoreStockVC = self.storyboard?.instantiateViewController(withIdentifier: "fruitStoreStock") as? FruitStockViewController else {return}
         
-        fruitStoreStockViewController.modalPresentationStyle = UIModalPresentationStyle.fullScreen
+        let fruitStockNC = UINavigationController.init(rootViewController: fruitStoreStockVC)
         
-        self.present(fruitStoreStockViewController, animated: true, completion: nil)
+        fruitStockNC.modalPresentationStyle = UIModalPresentationStyle.fullScreen
+        
+        self.present(fruitStockNC, animated: true, completion: nil)
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -36,10 +36,19 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+    }
+    
+    func updateFruitStockLabel() {
         for (fruit, label) in fruitLabel {
             label.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
         }
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateFruitStockLabel()
+    }
+    
     
     func updateFruitStockLabelUsedFor(_ juice: Juice) {
         for fruit in juice.recipe.keys {
@@ -113,6 +122,8 @@ class ViewController: UIViewController {
     func moveToFruitStockVC() {
         guard let fruitStoreStockViewController =
                 self.storyboard?.instantiateViewController(withIdentifier: "fruitStoreStockNC") else { return }
+        
+        fruitStoreStockViewController.modalPresentationStyle = UIModalPresentationStyle.fullScreen
         self.present(fruitStoreStockViewController, animated: true, completion: nil)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -30,7 +30,7 @@ class ViewController: UIViewController {
         .banana: bananaStockLabel,
         .pineapple: pineappleStockLabel,
         .kiwi: kiwiStockLabel,
-        .mango: mangoStockLabel
+        .mango: mangoStockLabel,
     ]
     
     override func viewDidLoad() {

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -112,7 +112,7 @@ class ViewController: UIViewController {
     
     func moveToFruitStockVC() {
         guard let fruitStoreStockViewController =
-                self.storyboard?.instantiateViewController(withIdentifier: "fruitStoreStock") else { return }
+                self.storyboard?.instantiateViewController(withIdentifier: "fruitStoreStockNC") else { return }
         self.present(fruitStoreStockViewController, animated: true, completion: nil)
     }
     

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -280,7 +280,7 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--재고 수정 화면-->
+        <!--재고 수정-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
                 <viewController storyboardIdentifier="fruitStoreStock" id="Yu1-lM-nqp" customClass="FruitStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
@@ -387,8 +387,13 @@
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <navigationItem key="navigationItem" title="재고 수정 화면" leftItemsSupplementBackButton="YES" id="g4W-fY-l7r">
+                    <navigationItem key="navigationItem" title="재고 수정" leftItemsSupplementBackButton="YES" id="g4W-fY-l7r">
                         <barButtonItem key="backBarButtonItem" title="뒤로가기" id="usK-5H-c0b"/>
+                        <barButtonItem key="rightBarButtonItem" title="닫기" id="pd4-4m-cSl">
+                            <connections>
+                                <action selector="touchUpDismissButton:" destination="Yu1-lM-nqp" id="Taw-ro-yg0"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="5bv-5c-P8w"/>
@@ -400,12 +405,12 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="901"/>
+            <point key="canvasLocation" x="1636" y="1129"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="cAf-jL-tPK">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="fruitStoreStockNC" automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
@@ -417,6 +422,7 @@
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2s5-lS-967" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <barButtonItem title="닫기" id="SLr-E3-9Ir"/>
             </objects>
             <point key="canvasLocation" x="1637" y="21"/>
         </scene>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -6,6 +6,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -288,119 +289,163 @@
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                <rect key="frame" x="590" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="622" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="580" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="U0Z-Jj-kVm"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="461" y="156" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                <rect key="frame" x="410" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="d09-L1-aPx"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="303" y="155" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                <rect key="frame" x="261" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="J0f-BQ-Sfe"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                <rect key="frame" x="154" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="DTM-QO-kqf"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="98" y="161" width="57" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                <rect key="frame" x="60" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="196" y="158" width="44" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                <rect key="frame" x="50" y="192" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="NPm-Ih-04F"/>
-                                </connections>
-                            </stepper>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="mzs-75-aCr">
+                                <rect key="frame" x="60" y="97.666666666666686" width="724" height="195"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="26M-HK-Ec8">
+                                        <rect key="frame" x="0.0" y="0.0" width="138.33333333333334" height="195"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                                <rect key="frame" x="31.666666666666671" y="0.0" width="75" height="110"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                                <rect key="frame" x="22.333333333333329" y="125" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="22.333333333333329" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="NPm-Ih-04F"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="width" secondItem="ZQk-f4-zrz" secondAttribute="width" id="n6O-oa-gtT"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="xhG-jK-LSY">
+                                        <rect key="frame" x="146.33333333333331" y="0.0" width="138.33333333333331" height="195"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
+                                                <rect key="frame" x="31.666666666666657" y="0.0" width="75" height="110"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                                <rect key="frame" x="22.333333333333314" y="125" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="22.333333333333314" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="DTM-QO-kqf"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="width" secondItem="O5s-2N-3iP" secondAttribute="width" id="FVH-Bo-Fmq"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="aPg-s2-HG1">
+                                        <rect key="frame" x="292.66666666666669" y="0.0" width="138.66666666666669" height="195"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
+                                                <rect key="frame" x="32" y="0.0" width="75" height="110"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
+                                                <rect key="frame" x="22.333333333333314" y="125" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Kro-LY-K9I">
+                                                <rect key="frame" x="22.333333333333314" y="163" width="94" height="32"/>
+                                                <subviews>
+                                                    <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                                        <rect key="frame" x="0.0" y="0.0" width="94" height="32"/>
+                                                        <connections>
+                                                            <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="J0f-BQ-Sfe"/>
+                                                        </connections>
+                                                    </stepper>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="width" secondItem="Rcr-xr-eqz" secondAttribute="width" id="4FC-r7-q3Z"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="h6H-H6-on0">
+                                        <rect key="frame" x="439.33333333333331" y="0.0" width="138.33333333333331" height="195"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
+                                                <rect key="frame" x="31.666666666666686" y="0.0" width="75" height="110"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
+                                                <rect key="frame" x="22.000000000000057" y="125" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                                <rect key="frame" x="22.000000000000057" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="d09-L1-aPx"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="width" secondItem="klA-59-Nu4" secondAttribute="width" id="XmZ-0K-80r"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="pPI-gt-AKh">
+                                        <rect key="frame" x="585.66666666666663" y="0.0" width="138.33333333333337" height="195"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
+                                                <rect key="frame" x="31.666666666666742" y="0.0" width="75" height="110"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                                <rect key="frame" x="22" y="125" width="94" height="23"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                                <rect key="frame" x="22" y="163" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="U0Z-Jj-kVm"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="width" secondItem="xbn-6P-grO" secondAttribute="width" id="6jd-7d-4mN"/>
+                                        </constraints>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="mzs-75-aCr" firstAttribute="height" secondItem="tKV-4l-Vtc" secondAttribute="height" multiplier="0.5" id="Eey-wj-TLy"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" secondItem="mzs-75-aCr" secondAttribute="trailing" constant="16" id="FSd-KW-zHp"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mzs-75-aCr" secondAttribute="trailing" id="cKj-kW-cMq"/>
+                            <constraint firstItem="mzs-75-aCr" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="eqd-1k-zYM"/>
+                            <constraint firstItem="mzs-75-aCr" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gcO-Xb-kNs" secondAttribute="leading" id="hNj-je-2oH"/>
+                            <constraint firstItem="mzs-75-aCr" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="16" id="jP5-Fl-5Ib"/>
+                            <constraint firstItem="mzs-75-aCr" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="xUm-jV-T0r"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="재고 수정" leftItemsSupplementBackButton="YES" id="g4W-fY-l7r">
                         <barButtonItem key="backBarButtonItem" title="뒤로가기" id="usK-5H-c0b"/>
@@ -425,7 +470,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1635.7819905213269" y="1127.6923076923076"/>
+            <point key="canvasLocation" x="1833" y="975"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="cAf-jL-tPK">

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -470,26 +470,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1833" y="975"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="cAf-jL-tPK">
-            <objects>
-                <navigationController storyboardIdentifier="fruitStoreStockNC" automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="Yu1-lM-nqp" kind="relationship" relationship="rootViewController" id="wH1-3A-cBm"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="2s5-lS-967" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <barButtonItem title="닫기" id="SLr-E3-9Ir"/>
-            </objects>
-            <point key="canvasLocation" x="1637" y="21"/>
+            <point key="canvasLocation" x="1477" y="92"/>
         </scene>
     </scenes>
     <resources>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
@@ -20,19 +20,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="60" y="52" width="724" height="136.66666666666666"/>
+                                <rect key="frame" x="16" y="98.999999999999986" width="812" height="136.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -41,16 +41,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="148" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -59,16 +59,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="296" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.33333333333334" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.33333333333334" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -77,16 +77,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="444" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -95,16 +95,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="592" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -115,32 +115,74 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="60" y="208.66666666666663" width="724" height="140.33333333333337"/>
+                                <rect key="frame" x="16" y="255.66666666666666" width="812" height="80.333333333333343"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="724" height="66"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="812" height="36"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                                <rect key="frame" x="0.0" y="0.0" width="315.33333333333331" height="36"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <state key="normal" title="딸바쥬스 주문">
-                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <state key="normal">
+                                                    <attributedString key="attributedTitle">
+                                                        <fragment content="딸바쥬스">
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                        <fragment content=" ">
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" metaFont="system" size="15"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                        <fragment content="주문">
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                    </attributedString>
                                                 </state>
                                                 <connections>
                                                     <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fdf-f4-kl9"/>
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="296" y="0.0" width="132" height="66"/>
+                                                <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="444" y="0.0" width="280" height="66"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                                <rect key="frame" x="496.66666666666663" y="0.0" width="315.33333333333337" height="36"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <state key="normal" title="망키쥬스 주문">
-                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <state key="normal">
+                                                    <attributedString key="attributedTitle">
+                                                        <fragment content="망키쥬스">
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                        <fragment content=" ">
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" metaFont="system" size="15"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                        <fragment content="주문">
+                                                            <attributes>
+                                                                <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                    </attributedString>
                                                 </state>
                                                 <connections>
                                                     <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MCM-9G-HkD"/>
@@ -149,61 +191,151 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="74.000000000000028" width="724" height="66.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="44.000000000000028" width="812" height="36.333333333333343"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="724" height="66.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="812" height="36.333333333333336"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
+                                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="딸기쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="딸기쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content=" ">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Xqv-2V-Gjy"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="바나나쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="바나나쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content=" ">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5DB-Qh-3jr"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="파인애플쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="파인애플쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content=" ">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mbj-Qy-off"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="키위쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="키위쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content=" ">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="K3a-wl-4mD"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="36.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="망고쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="망고쥬스 주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="orderJuiceWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pZs-Cq-9oP"/>
@@ -269,7 +401,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="47" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -290,26 +422,26 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="mzs-75-aCr">
-                                <rect key="frame" x="60" y="97.666666666666686" width="724" height="195"/>
+                                <rect key="frame" x="16" y="97.666666666666686" width="812" height="195"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="26M-HK-Ec8">
-                                        <rect key="frame" x="0.0" y="0.0" width="138.33333333333334" height="195"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="156" height="195"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="31.666666666666671" y="0.0" width="75" height="110"/>
+                                                <rect key="frame" x="40.666666666666657" y="0.0" width="75" height="106.66666666666667"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="22.333333333333329" y="125" width="94" height="23"/>
+                                                <rect key="frame" x="31" y="121.66666666666667" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="22.333333333333329" y="163" width="94" height="32"/>
+                                                <rect key="frame" x="31" y="163" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="NPm-Ih-04F"/>
                                                 </connections>
@@ -320,23 +452,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="xhG-jK-LSY">
-                                        <rect key="frame" x="146.33333333333331" y="0.0" width="138.33333333333331" height="195"/>
+                                        <rect key="frame" x="164" y="0.0" width="156" height="195"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="31.666666666666657" y="0.0" width="75" height="110"/>
+                                                <rect key="frame" x="40.666666666666657" y="0.0" width="75" height="106.66666666666667"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="22.333333333333314" y="125" width="94" height="23"/>
+                                                <rect key="frame" x="31" y="121.66666666666667" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="22.333333333333314" y="163" width="94" height="32"/>
+                                                <rect key="frame" x="31" y="163" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="DTM-QO-kqf"/>
                                                 </connections>
@@ -347,23 +479,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="aPg-s2-HG1">
-                                        <rect key="frame" x="292.66666666666669" y="0.0" width="138.66666666666669" height="195"/>
+                                        <rect key="frame" x="328" y="0.0" width="156" height="195"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="32" y="0.0" width="75" height="110"/>
+                                                <rect key="frame" x="40.666666666666686" y="0.0" width="75" height="106.66666666666667"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="22.333333333333314" y="125" width="94" height="23"/>
+                                                <rect key="frame" x="31" y="121.66666666666667" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Kro-LY-K9I">
-                                                <rect key="frame" x="22.333333333333314" y="163" width="94" height="32"/>
+                                                <rect key="frame" x="31" y="163" width="94" height="32"/>
                                                 <subviews>
                                                     <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                                         <rect key="frame" x="0.0" y="0.0" width="94" height="32"/>
@@ -379,23 +511,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="h6H-H6-on0">
-                                        <rect key="frame" x="439.33333333333331" y="0.0" width="138.33333333333331" height="195"/>
+                                        <rect key="frame" x="492" y="0.0" width="156" height="195"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="31.666666666666686" y="0.0" width="75" height="110"/>
+                                                <rect key="frame" x="40.666666666666629" y="0.0" width="75" height="106.66666666666667"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="22.000000000000057" y="125" width="94" height="23"/>
+                                                <rect key="frame" x="31" y="121.66666666666667" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="22.000000000000057" y="163" width="94" height="32"/>
+                                                <rect key="frame" x="31" y="163" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="d09-L1-aPx"/>
                                                 </connections>
@@ -406,23 +538,23 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="pPI-gt-AKh">
-                                        <rect key="frame" x="585.66666666666663" y="0.0" width="138.33333333333337" height="195"/>
+                                        <rect key="frame" x="656" y="0.0" width="156" height="195"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="31.666666666666742" y="0.0" width="75" height="110"/>
+                                                <rect key="frame" x="40.666666666666629" y="0.0" width="75" height="106.66666666666667"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="22" y="125" width="94" height="23"/>
+                                                <rect key="frame" x="31" y="121.66666666666667" width="94" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="22" y="163" width="94" height="32"/>
+                                                <rect key="frame" x="31" y="163" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="U0Z-Jj-kVm"/>
                                                 </connections>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -306,6 +306,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                 <rect key="frame" x="580" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="U0Z-Jj-kVm"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
                                 <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
@@ -325,6 +328,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                 <rect key="frame" x="410" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="d09-L1-aPx"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
                                 <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
@@ -344,6 +350,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                 <rect key="frame" x="261" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="J0f-BQ-Sfe"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
                                 <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
@@ -355,9 +364,12 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                 <rect key="frame" x="154" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="DTM-QO-kqf"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="98" y="161" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="98" y="161" width="57" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -372,7 +384,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="196" y="158" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="196" y="158" width="44" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -382,6 +394,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="changeFruitStock:" destination="Yu1-lM-nqp" eventType="valueChanged" id="NPm-Ih-04F"/>
+                                </connections>
                             </stepper>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
@@ -396,16 +411,21 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="jA9-qV-gyo"/>
                         <outlet property="bananaStockLabel" destination="gKu-86-RhI" id="5bv-5c-P8w"/>
+                        <outlet property="kiwiStepper" destination="klA-59-Nu4" id="2ak-oy-ktV"/>
                         <outlet property="kiwiStockLabel" destination="ZDv-1m-HBY" id="3Ep-dK-tg2"/>
+                        <outlet property="mangoStepper" destination="xbn-6P-grO" id="c79-ra-gcZ"/>
                         <outlet property="mangoStockLabel" destination="YJI-ER-LJR" id="JUT-pg-5Eq"/>
+                        <outlet property="pineappleStepper" destination="Rcr-xr-eqz" id="FBg-eJ-ebb"/>
                         <outlet property="pineappleStockLabel" destination="MpT-VW-hCb" id="A7V-wg-z4g"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="iuI-o8-xJV"/>
                         <outlet property="strawberryStockLabel" destination="0yV-kn-zaT" id="nV2-YG-qLB"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1636" y="1129"/>
+            <point key="canvasLocation" x="1635.7819905213269" y="1127.6923076923076"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="cAf-jL-tPK">

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# 쥬스 메이커 
+# 쥬스 메이커
 
 ## 목차
 [1. ✏️ 프로젝트 소개](1.✏️-프로젝트-소개) </br>
 [2. 🧑‍🤝‍🧑 팀원](2.-🧑‍🤝‍🧑-팀원) </br>
-[3. 👩🏻‍💻 실행 예시](3.-👩🏻‍💻-실행-예시) </br>
-[4. 🔥 트러블 슈팅](4.-🔥-트러블-슈팅) </br>
-[5.  🔗 참고 링크](5.-🔗-참고-링크) </br>
+[3. 🔍 프로젝트 구성 - ClassDiagram](3.-🔍-프로젝트-구성(ClassDiagram)) </br>
+[4. 👩🏻‍💻 실행 예시](4.-👩🏻‍💻-실행-예시) </br>
+[5. 🔥 트러블 슈팅](5.-🔥-트러블-슈팅) </br>
+[6.  🔗 참고 링크](6.-🔗-참고-링크) </br>
 
 ---
 
@@ -26,12 +27,22 @@
 
 | SummerCat                                                 | SunnyCookie                                             |
 | --------------------------------------------------------- | ------------------------------------------------------- |
-| <img width="180px" src="https://i.imgur.com/TVKv7PD.png"> | <img width="180" src="https://i.imgur.com/z4FjnKX.png"> |
+| <img width="180px" src="https://i.imgur.com/TVKv7PD.png"> | <img width="180" src="https://i.imgur.com/z4FjnKX.png"> 
+
+---
+
+## 3. 🔍 프로젝트 구성(ClassDiagram)
+
+### 1️⃣ Model
+<img width = 900, src = "https://i.imgur.com/drYww31.png">
+
+### 2️⃣ ViewController + Model
+<img width = 900, src = "https://i.imgur.com/dgYUo8O.png">
 
 ---
 
 
-## 3. 👩🏻‍💻 실행 예시
+## 4. 👩🏻‍💻 실행 예시
 
 ### **1️⃣ [맛있는 쥬스를 만들어드립니다]** View에서 쥬스를 주문
     
@@ -62,9 +73,13 @@
     | |
     |<img width = 400, src = "https://i.imgur.com/1qlXlIb.gif"> |
 
+
+
+
+
 ---
 
-## 4. 🔥 트러블 슈팅
+## 5. 🔥 트러블 슈팅
 
 ### 1️⃣ `enum Juice` 타입에서 사용하는 과일의 종류, 갯수 연결하기
 열거형으로 정리한 쥬스타입의 case마다 레시피로 사용되는 각 과일의 갯수를 연관지어 지정해놓고 싶었습니다. 예를 들어, 딸기바나나쥬스는 딸기 10개 바나나 1개를 사용하기 때문에 `case 딸기바나나쥬스` 에는 딸기 10개, 바나나 1개를 연결하고 싶었습니다.
@@ -308,7 +323,7 @@ Stepper는 크기를 변경할 수 없기 때문에, 세 요소의 너비를 일
 
 ---
 
-## 5.  🔗 참고 링크
+## 6.  🔗 참고 링크
 ### Apple 공식문서
 - [Enumerations](https://docs.swift.org/swift-book/LanguageGuide/Enumerations.html)
 - [Choosing Between Structures and Classes](https://developer.apple.com/documentation/swift/choosing-between-structures-and-classes)

--- a/README.md
+++ b/README.md
@@ -1,106 +1,78 @@
-# README(1) **쥬스 메이커**
+# 쥬스 메이커 
+
+## 목차
+[1. ✏️ 프로젝트 소개](1.✏️-프로젝트-소개) </br>
+[2. 🧑‍🤝‍🧑 팀원](2.-🧑‍🤝‍🧑-팀원) </br>
+[3. 👩🏻‍💻 실행 예시](3.-👩🏻‍💻-실행-예시) </br>
+[4. 🔥 트러블 슈팅](4.-🔥-트러블-슈팅) </br>
+[5.  🔗 참고 링크](5.-🔗-참고-링크) </br>
 
 ---
 
-### 1. 🍹 프로젝트 소개 (STEP 1)
+## 1. ✏️ 프로젝트 소개
 
-- JuiceMaker는 FruitStore의 과일을 이용해 juice를 제작합니다.
-- Juice별 Recipe에 따라 FruitStore의 과일 재고를 파악하고 재고가 충분할 때만 Juice를 제작할 수 있습니다.
-
-
----
-
-### 2. 🧑‍🤝‍🧑 팀원
-
-
-|SummerCat|SunnyCookie|
-|------|---|
-|<img width="180px" src="https://i.imgur.com/TVKv7PD.png">|  <img width="180" src="https://i.imgur.com/z4FjnKX.png">
-
----
-
-### 3. ✏️ 프로젝트 구조
-
-#### `FruitStore`
-- `FruitStore`는 `enum` 타입의 `Fruit`를 통해 취급하는 과일을 명시합니다.
-- 각 과일의 재고는 `[Fruit: Int]` 형태의 딕셔너리 `fruitStock` 프로퍼티에서 관리합니다.
-    ```swift=
-    private var fruitStock: Dictionary<Fruit, Int> = [
-            .strawberry : 10,
-            .banana : 10,
-            .pineapple : 10,
-            .kiwi : 10,
-            .mango : 10,
-        ]
-    ```
-    - `fruitStock` 딕셔너리 작성 시 마지막 Element 뒤에 `,`를 붙인 이유
-        - [구글의 Swift 컨벤션](https://google.github.io/swift/#braces)
-        - array와 dictionary의 각 element가 한 줄에 하나씩 작성되었을 경우, 뒤에 꼭 `,`를 붙여야 한다. 이렇게 해야 나중에 항목이 추가되었을 때 더 명확하게 차이를 알 수 있다.
-     ![](https://i.imgur.com/LXCgkly.png)
-      - 접근제어자를 `private`으로 설정한 이유: 과일가게의 과일의 재고 값을 외부에서 마음대로 바꾸지 못하도록 해야 한다고 생각해서 `private`을 사용해 `FruitStore` 내에서만 접근이 가능하도록 설정했습니다. 
-
-- `changeStockOf` 함수
-    - `FruitStore`가 가지고 있는 과일의 재고의 수량을 변경하는 함수입니다.
-    ```swift
-    func changeStockOf(fruit: Fruit, by quantity: Int) {
-            guard let currentStock = fruitStock[fruit] else {
-                return
-            }
-
-            fruitStock[fruit] = currentStock + quantity
-        }
-    ```
-    - `guard`문을 사용해 현재의 재고 수량을 옵셔널 바인딩 해서 `currentStock`에 넣은 후, 조정한 수량만큼 `fruitStock[fruit]`에 넣어줍니다.
-    - `fruitStock[fruit] = currentStock = quantity`에서 옵셔널 바인딩이 필요하지 않은 이유는, `fuitStock[fruit]`의 값이 존재하지 않더라도, `currentStock + quantity`의 값을 새로 할당해주기 때문입니다.
-
--  `checkStockOf` 함수
-    - `JuiceMaker`가 요청한 과일의 수량을 확인하는 함수입니다.
-    - 요청이 들어온 과일이 존재하지 않을 경우, `noSuchFruit` 에러를 반환합니다.
-    - 요청이 들어온 과일의 수량이 부족할 경우, `stockShortage` 에러를 반환합니다.
-
-#### `JuiceMaker`
-- `JuiceMaker`는 `FruitStore`를 소유하기 위해 `fruitStore`라는 `FruitStore`의 인스턴스를 갖습니다.
-- `JuiceMaker`는 `enum` 타입의 `Juice`를 통해 취급하는 쥬스를 명시합니다. `enum` 타입 안에 `juiceName` 프로퍼티를 만들어 각 쥬스의 한글이름을 반환할 수 있도록 하고,  `recipe` 프로퍼티에 사용하는 과일과 갯수를 딕셔너리로 정리해 주었습니다.
-    - 딕셔너리를 사용해서 `recipe`를 작성한 이유: **고민한 부분**에 작성
-- `makeJuice` 메서드는 쥬스 제작이 가능한지 확인하기 위해 `checkFruitStore` 메서드를 통해 레시피에 맞는 과일갯수를 체크하고, 사용한 과일만큼 `useFruitStore` 메서드를 통해 `fruitStore`의 과일 재고를 조정합니다. 
-    - 이 과정중 do - try - catch 구문을 사용하여 error를 처리합니다.
-    - `JuiceMakerError`로 다운캐스팅 된 `error` 상수를 catch에서 정의해, `errorDescription`으로 에러 메시지를 불러옵니다.
-    - error가 catch 될 시에 음료제작을 중단하기 위해 return처리 됩니다. 
-- `checkFruitStore` 메서드는 `recipe`에서 필요한 과일의 개수와 `fruitStore`의 재고를 비교하기 위해 `FruitStore`의 `checkStockOf` 메서드를 이용합니다. `checkStockOf`에 과일의 종류와, 해당 과일의 필요한 총량을 전달합니다. 딕셔너리의 key값을 이용하기 위해 for - in 구문을 이용했습니다.
-    - `JuiceMaker`의 `changeStockOf`에서 던진 오류를 `checkFruitStore`에서 처리할 수도 있지만, 그렇게 작성할 경우 함수의 depth가 깊어져 가독성이 떨어진다고 판단해 오류를 한번 더 던져서 `makeJuice`에서 오류를 처리하도록 했습니다.
-
-- `useFruit` 메서드는 `fruitStore`의 과일의 재고를 조정합니다.
-
-
-#### `JuiceMakerError`
-- `JuiceMakerError`에서는 `Error` 프로토콜을 채택한 `enum`타입을 이용해 에러를 case별로 정리했습니다.
-- `extension`을 이용해 do-catch구문에서 에러메세지로 이용할 구문을 `errorDescription` 프로퍼티에 정리했습니다. 사용시에는 as로 다운캐스팅하여 `errorDescription`을 이용해 에러메세지를 출력할 수 있도록 하였습니다.
-    - `LocalizedError` 프로토콜에 이미 `errorDescription`이 구현되어 있지만 `LocalizedError`를 채택하지 않은 이유는, `LocalizedError`에 구현되어 있는 `errorDescription`의 반환값이 `String?`이기 때문입니다.
-    - 정의된 유형의 에러가 발생했을 때에만 `errorDescription`을 내보내는 방향으로 설계했기 때문에 옵셔널 타입으로 반환할 필요가 없다고 생각해, `String`을 반환하는 `errorDescription`을 `extension`에 새로 정의해서 사용했습니다.
+`맛있는 쥬스를 만들어 드려요!` 화면에서 사용자가 원하는 쥬스의 주문 버튼을 누르면, JuiceMaker는 FruitStore의 과일을 이용해 juice를 제작합니다.
+  - 쥬스 주문 결과(성공/실패)를 alert창을 통해 사용자에게 결과를 알려줍니다.
+  - 과일의 재고가 부족할 경우, 쥬스 주문에 실패합니다.
+  - 쥬스 주문 실패 시 뜨는 alert창에서, `재고 수정` 화면으로 이동할 수 있습니다.
+ 
+`재고수정` 버튼을 누르면 `재고 수정` 화면으로 이동해 과일의 재고를 조정할 수 있습니다.
 
 
 ---
 
-### 4. 👩🏻‍💻 실행 화면(기능 설명)
+## 2. 🧑‍🤝‍🧑 팀원
+
+
+| SummerCat                                                 | SunnyCookie                                             |
+| --------------------------------------------------------- | ------------------------------------------------------- |
+| <img width="180px" src="https://i.imgur.com/TVKv7PD.png"> | <img width="180" src="https://i.imgur.com/z4FjnKX.png"> |
+
+---
+
+
+## 3. 👩🏻‍💻 실행 예시
+
+### **1️⃣ [맛있는 쥬스를 만들어드립니다]** View에서 쥬스를 주문
     
-| 코드 | 출력 |
-|------|---|
-|<img width="350" src="https://i.imgur.com/DuDhrbk.png"> |<img width="350" src="https://i.imgur.com/82VzY4r.png">|
+- 쥬스 제작에 필요한 과일의 재고가 충분할 시 성공 Alert을 띄웁니다.   
+- 과일 재고가 부족하면 실패 Alert을 띄웁니다.
+    | **주문 성공 시 성공 Alert 예시**                            |
+    | ---------------------------------------------------------- |
+    |<img width = 400, src = "https://i.imgur.com/4SDmkYJ.gif">|
+    | **주문 실패 시 실패 Alert 예시**                            |
+    | |
+    |<img width = 400, src = "https://i.imgur.com/zRWTBGt.gif"> |
+    
+</br>   
 
-- `딸바쥬스`를 만들고 난 후`딸기`의 재고가 0이기 때문에, 이후에 `딸바쥬스`를 만들어달라고 요청한 경우 쥬스를 만들지 않고 `재고 부족` 메시지를 출력합니다.
-    - 이 때, 두 과일(`딸기`, `바나나`) 중 하나라도 재고가 부족한 경우 쥬스를 만들지 않고 두 과일의 재고 모두 조정되지 않습니다.
+### **2️⃣ [재고수정]** View에서 재고를 수정
+- Stepper로 재고를 수정 하면 [맛있는 쥬스를 만들어드립니다] View의 재고에 적용됩니다.
+    | **재고 수정 예시**                            |
+    | ---------------------------------------------------------- |
+    |<img width = 400, src = "https://i.imgur.com/mkfb4rT.gif">|
+
+
+### **3️⃣ AutoLayout** 적용
+- AutoLayout을 적용해 디스플레이 사이즈가 변경되어도 각 view가 변경된 화면의 크기에 맞추어 리사이징됩니다.
+    | **iPhone SE 시뮬레이터 예시**                            |
+    | ---------------------------------------------------------- |
+    |<img width = 400, src = "https://i.imgur.com/ImLktxf.gif">|
+    | **iPhone 13 Pro 시뮬레이터 예시**                            |
+    | |
+    |<img width = 400, src = "https://i.imgur.com/1qlXlIb.gif"> |
 
 ---
 
-### 5. 🔥 트러블 슈팅
+## 4. 🔥 트러블 슈팅
 
-#### `enum Juice` 타입에서 사용하는 과일의 종류, 갯수 연결하기
+### 1️⃣ `enum Juice` 타입에서 사용하는 과일의 종류, 갯수 연결하기
 열거형으로 정리한 쥬스타입의 case마다 레시피로 사용되는 각 과일의 갯수를 연관지어 지정해놓고 싶었습니다. 예를 들어, 딸기바나나쥬스는 딸기 10개 바나나 1개를 사용하기 때문에 `case 딸기바나나쥬스` 에는 딸기 10개, 바나나 1개를 연결하고 싶었습니다.
 - **시도1 : 연관값(Associated Values) 사용**
     ```swift
     case strawberryBananaJuice(strawberry: 10, banana: 1)
     ```
-    - 연관값을 사용할 경우, 만들 쥬스를 고르기 위해 case를 불러올 때 연관값을 반드시 초기화(할당)해야 해서 최초에 할당한 연관값이 사용되지 않는 문제가 있었습니다.
+    - 연관값을 사용할 경우, 만들 쥬스를 고르기 위해 case를 불러올 때 연관값을 반드시 초기화(할당)해야 해서 최초에 할당한 연관값을 재사용할 수 없는 문제가 있었습니다.
 
  - **시도2 : 튜플을 리턴해주는 메서드, 프로퍼티 사용**
      ```swift
@@ -151,24 +123,199 @@
 
 ---
 
-### 6. 👆🏻 추가로 수정해보고 싶은 내용
-#### `Recipe` 구현 방식 수정
-- [다른 조의 리뷰 내용](https://github.com/yagom-academy/ios-juice-maker/pull/248#discussion_r959716917)을 보니, `Recipe`를 dictionary가 아닌 tuple, struct, class 등 다른 타입으로 구현했을 때 어떤 장단점이 있을 지 생각해 보면 좋을 것 같다는 내용이 있었다. 
-- class나 struct로 구현해보면 좋을 것 같다는 생각이 들어서 STEP 2를 진행하면서 한번 도전해 보려고 한다!
-#### `makeJuice` 메서드의 반환값 설정
-- 현재는 반환값이 없는 함수인데, STEP 2의 내용을 확인해보니 쥬스 만들기 성공/실패에 따른 반환값이 필요해 보인다. 크게 `Result` 타입을 반환하는 방법, `Bool` 타입을 반환하는 방법 두 가지가 있을 것 같다.
-#### 아직 해결되지 않은 고민
-- `enum Juice`와 `enum Fruit`를 각각 `JuiceMaker`와 `FruitStore`안에 정의했는데, 처음에는 각 쥬스 메이커와 과일 가게가 그 타입을 소유한다고 생각해서 그렇게 작성했었다(공부해야 할 내용에 `Nested Type`이 있기도 했고).
-- `enum Juice`와 `enum Fruit`을 분리해서 별도의 파일에 정의하는 것이 좋을까??? 리뷰어님한테 질문해보자..!
+### 2️⃣ `재고수정` 화면으로 이동할 때, 내비게이션 방식과 모달 방식 중 어느 것을 쓸 것인가?
+
+`내비게이션 방식`은 현재 화면의 연장선상으로 세부사항을 열어보거나 다음 step으로 넘어갈 때 사용합니다.
+`모달 방식`은 지금 화면에서 조금 벗어나 잠시 다른 일을 처리하거나, 연장선을 벗어나 새로운 갈래로 나갈 때 사용합니다.
+
+쥬스를 주문하는 현재 화면에서 재고를 변경해주는 화면으로 이동할 때는 쥬스 주문과는 별개로 잠시 연장선상을 벗어나 다른 일을 처리한 후 돌아온다고 생각하여 화면 전환 방식으로 모달 방식을 채택했습니다. 
 
 ---
 
-### 7. 🔗 참고 링크
+### 3️⃣ 과일 재고의 개수를 `ViewController`와 `FruitStockViewController`간에 공유하게 하는 방법
 
-- [Swift Language Guide - Access Control
-](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html)
-- [Swift Language Guide - Nested Types
-](https://docs.swift.org/swift-book/LanguageGuide/NestedTypes.html)
-- [Swift Language Guide - Enumerations](https://docs.swift.org/swift-book/LanguageGuide/Enumerations.html)
-- [Swift Language Guide - Error Handling](https://docs.swift.org/swift-book/LanguageGuide/ErrorHandling.html)
+검색을 통해 프로퍼티로 직접 전달하는 방법, delegation을 이용하는 방법 등 다양한 방법이 있다는 것을 알게 되었지만, 활동학습 시간에 배운 Singleton Pattern을 이용하기로 했습니다.
 
+그 이유는 이 프로젝트가 매우 단순한 구조의 프로젝트이기 때문이기도 하고, 현재 구조체로 정의되어 있는 `JuiceMaker`가 프로퍼티로 클래스 `FruitStore`의 인스턴스를 `private`으로 가지고 있었기 때문에, 클래스로 되어있는 `FruitStore`에 싱글톤 패턴을 적용하는 편이 낫다고 생각했습니다.
+`FruitStore`에 싱글톤 패턴을 적용할 경우, `JuiceMaker`, `ViewController`, `FruitStockViewController`에서 모두 하나의 인스턴스에 접근이 가능하기 때문입니다.
+
+---
+
+### 4️⃣ `UILabel`과 `UIButton`을 다룰 때, 코드에서 중복되는 부분을 줄일 방법
+
+처음에는 각 `label`과 `button`을 일일이 직접 매핑하거나 `switch case`로 구분하도록 작성했었습니다. 하지만 두 가지 경우 모두 각 케이스마다 중복되는 코드가 많아 중복되는 코드를 줄일 방법을 고민(구글링)해 보았고, 아래의 글을 참고해 개선해 보았습니다.
+(참고: https://stackoverflow.com/questions/52548196/shorten-long-switch-case)
+
+`label`의 경우, `.text = String(FruitStore.sharedFruitStore.fetchStockOf(.strawberry))`부분이 `.strawberry`라는 과일 값만 빼고는 모두 똑같이 중복되고 있습니다.
+
+```swift
+// 최초에 작성한 코드 - label을 일일이 매핑
+strawberryStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.strawberry))
+        bananaStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.banana))
+        pineappleStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.pineapple))
+        kiwiStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.kiwi))
+        mangoStockLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(.mango))
+```
+
+
+아래와 같이 `[UILabel: Fruit]` 딕셔너리를 생성하고, `for-in`을 사용해 딕셔너리를 순회하면서 값을 `label`에 넣어주도록 수정해 보았습니다.
+
+
+```swift
+// 최종 수정한 코드
+let fruitLabel: [UILabel: Fruit] = [
+    strawberryStockLabel: .strawberry,
+    bananaStockLabel: .banana,
+    pineappleStockLabel: .pineapple,
+    kiwiStockLabel: .kiwi,
+    mangoStockLabel: .mango,
+    ]
+        
+    for (label, fruit) in fruitLabel {
+    label.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
+    }
+```
+
+`button`을 식별해서 `switch case`를 이용해 `juiceMaker.makeJuice(Juice, total: Int)`에 넣어주는 부분 역시 `makeJuice` 메서드를 호출해서 `result`에 넣어주는 부분이 반복되고 있었습니다.
+
+```swift
+// 최초에 작성한 코드 - button을 switch case로 구분
+ @IBAction func orderJuice(sender: UIButton) {
+    switch sender {
+        case strawberryBananaJuiceButton:
+            result = juiceMaker.makeJuice(.strawberryBananaJuice, total: 1)
+        case mangoKiwiJuiceButton:
+            result = juiceMaker.makeJuice(.mangoKiwiJuice, total: 1)
+        case strawberryJuiceButton:
+            result = juiceMaker.makeJuice(.strawberryJuice, total: 1)
+        case bananaJuiceButton:
+            result = juiceMaker.makeJuice(.bananaJuice, total: 1)
+        case pineappleJuiceButton:
+            result = juiceMaker.makeJuice(.pineappleJuice, total: 1)
+        case kiwiJuiceButton:
+            result = juiceMaker.makeJuice(.kiwiJuice, total: 1)
+        case mangoJuiceButton:
+            result = juiceMaker.makeJuice(.mangoJuice, total: 1)
+        default:
+            return
+        }
+     ...
+ }
+```
+
+이 부분도 아래와 같이 `[UIButton: Juice]` 딕셔너리를 생성하고, `juiceButton[sender]`의 값을 `juice`에 할당해 옵셔널 바인딩 해주니 `result`를 생성하는 `makeJuice()` 메서드를 한 번만 호출하도록 개선했습니다.
+
+```swift
+ @IBAction func orderJuice(sender: UIButton) {
+    let juiceButton: [UIButton: Juice] = [
+        strawberryBananaJuiceButton: .strawberryBananaJuice,
+        mangoKiwiJuiceButton: .mangoKiwiJuice,
+        strawberryJuiceButton: .strawberryJuice,
+        bananaJuiceButton: .bananaJuice,
+        pineappleJuiceButton: .pineappleJuice,
+        kiwiJuiceButton: .kiwiJuice,
+        mangoJuiceButton: .mangoJuice,
+        ]
+
+    guard let juice = juiceButton[sender] else { return }
+
+    let result = juiceMaker.makeJuice(juice, total: 1)
+    ...
+ }
+```
+
+---
+
+### 5️⃣ [재고수정] View의 Navigation bar가 보이지 않는 문제
+
+#### **[방법1]** `VC -> FruitStockVC`로 직접 화면 전환
+`FruitStockVC` 내비게이션 바가 보이지 않아 새로운 내비게이션 바를 화면에 추가해 보았습니다.
+  - 이럴 경우, 한 VC에 2개의 내비게이션 바가 존재하는 다소 이상한 상황이라고 생각해 다른 방법을 찾아보기로 했습니다.
+  - 스토리보드상에는 보였던 `FruitStockVC`의 내비게이션 바가 실행 화면에서 보이지 않았던 이유가, `FruitStockVC`가 어떤 내비게이션 스택 안에도 담기지 않았기 때문이라고 생각했습니다.
+ 
+#### **[방법2]** `VC -> NavigationController -> FruitStockVC`로 이동
+`VC`에서 `FruitStockVC`로 직접 이동하지 않고, `FruitStockVC`를 담고 있는 내비게이션 컨트롤러로 이동해 그 내비게이션 컨트롤러의 루트 뷰 컨트롤러인 `FruitStockVC`를 띄우도록 하면 `FruitStockVC`는 내비게이션 스택 안에 존재하게 되므로 내비게이션 바가 화면에 보일 것이라고 생각했습니다.
+
+내비게이션 바를 새로 추가하지 않고도 스토리보드 상에 보이는 내비게이션 바가 실행 화면에서도 정상적으로 출력되어 title을 작성할 수 있었고 navigationBarButton을 이용해 '닫기'버튼을 구현할 수 있었습니다.
+
+---
+
+### 6️⃣ stepper의 `-` 버튼이 작동하지 않는 문제
+
+Stepper를 이용해서 재고를 수정하기 위해 처음에 작성했던 코드는 아래와 같습니다.
+
+```swift
+@IBAction func changeFruitStock(_ sender: UIStepper) {
+    let fruitStepper: [UIStepper: Fruit] = [
+        strawberryStepper: .strawberry,
+        bananaStepper: .banana,
+        pineappleStepper: .pineapple,
+        kiwiStepper: .kiwi,
+        mangoStepper: .mango
+    ]
+
+    sender.minimumValue = -1
+
+    guard let fruit = fruitStepper[sender],
+        let fruitLabel = fruitLabel[fruit] else { return }
+
+    FruitStore.sharedFruitStore.changeStockOf(fruit: fruit, by: Int(sender.value))
+
+    fruitLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
+
+    sender.value = 0
+}
+```
+
+  - `-` 값을 전달할 수 있도록 stepper가 전달하는 값의 최소값을 `-1`로 설정
+ 
+  -  stepper를 누를 시, stepper는 값을 기억하고 있으므로 stepper를 누를 때마다 stepper의 value가 1 > 2 > 3 > 4 > ... 로 증가하게 되어 `changeStockOf`에 전달되는 값은 +1 > +3 > +6 > ... 로 변하게 됩니다.
+        - 한 번 누를 때마다 `sender.value`를 통해 전달되는 값이 1 또는 -1이 되기를 원해서, 마지막에 `sender.value = 0`으로 stepper가 기억하고 있는 값을 초기화 해 주었습니다.
+
+  - 그런데.. 아래와 같이 코드를 작성할 시 재고를 수정하는 모달 창으로 넘어왔을 때 Stepper의 `-` 버튼을 눌러도 아무런 동작을 하지 않는 문제가 발생했습니다.
+      - `+` 버튼을 한 번이라도 누른 후 `-` 버튼을 누를 시 정상적으로 재고의 개수가 줄어들었지만, `-` 버튼만 누르면 아무 동작을 하지 않았습니다.
+      - `sender.value`를 출력하는 함수를 작성해보니, 맨 처음에 `-` 버튼을 누를 시 아무것도 출력되지 않는 것을 확인해 작동 자체를 하지 않았다는 것을 알 수 있었습니다.
+
+stepper의 작동 방식에 대해 열심히 구글링 해 보았지만 저희가 원하는 답을 찾을 수 없어, 동료 캠퍼들은 어떻게 구현했는지 질문해서 답을 얻을 수 있었습니다.
+
+```swift
+func assignStepperValue() {
+    for (stepper, fruit) in fruitStepper {
+        stepper.value = Double(FruitStore.sharedFruitStore.fetchStockOf(fruit))
+    }
+}
+
+@IBAction func changeFruitStock(_ sender: UIStepper) {
+    guard let fruit = fruitStepper[sender],
+        let fruitLabel = fruitLabel[fruit] else { return }
+        
+    let changedValue = Int(sender.value) - FruitStore.sharedFruitStore.fetchStockOf(fruit)
+    FruitStore.sharedFruitStore.changeStockOf(fruit: fruit, by: changedValue)
+        
+    fruitLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
+}
+```
+- 각 stepper에 각 과일의 재고를 value로 할당하면, stepper가 설계된 의도대로 `+`를 두 번 누를 시 +2가 되고, `-`를 5번 누르면 -5가 되도록 작동하는 것을 확인할 수 있었습니다.
+
+---
+
+### 7️⃣ Auto Layout: stackView 이용
+
+`과일 이미지, 과일 재고 label, stepper`가 담긴 `Stack View`의 `alignment`를 `fill`로 설정할 경우, 기기에 따라 과일 이미지와 과일 재고 label의 크기는 커지지만 stepper의 크기는 커지지 않았고, stepper는 `leading`으로 정렬된 것 처럼 보였습니다.
+
+Stepper는 크기를 변경할 수 없기 때문에, 세 요소의 너비를 일치시키기 위해 과일 재고 label과 과일 이미지의 크기를 stepper의 크기에 맞추는 제약을 설정한 후, `Stack View`의 `alignment`를 `center`로 변경하여 해결했습니다.
+
+
+---
+
+## 5.  🔗 참고 링크
+### Apple 공식문서
+- [Enumerations](https://docs.swift.org/swift-book/LanguageGuide/Enumerations.html)
+- [Choosing Between Structures and Classes](https://developer.apple.com/documentation/swift/choosing-between-structures-and-classes)
+- [Structures and Classes](https://docs.swift.org/swift-book/LanguageGuide/ClassesAndStructures.html)
+- [loadView()](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621454-loadview)
+
+### 그 외 출처
+- [구글의 Swift 컨벤션](https://google.github.io/swift/#braces)
+- https://stackoverflow.com/questions/52548196/shorten-long-switch-case
+- https://medium.com/@Alpaca_iOSStudy/viewcontroller-view-lifecycle-daed5766e02b

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 - AutoLayout을 적용해 디스플레이 사이즈가 변경되어도 각 view가 변경된 화면의 크기에 맞추어 리사이징됩니다.
     | **iPhone SE 시뮬레이터 예시**                            |
     | ---------------------------------------------------------- |
-    |<img width = 400, src = "https://i.imgur.com/ImLktxf.gif">|
+    |<img width = 400, src = "https://i.imgur.com/Iyac12q.gif">|
     | **iPhone 13 Pro 시뮬레이터 예시**                            |
     | |
     |<img width = 400, src = "https://i.imgur.com/1qlXlIb.gif"> |


### PR DESCRIPTION
@SungPyo (@웨더)
안녕하세요 웨더! 
추석은 잘 보내셨나요 ㅎㅎ

스텝3 PR 드립니다 🙇🏻‍♀️

---

## 1. 프로젝트 구성

### `FruitStockVC (재고 수정 화면) `
`navigation bar button` `닫기`를 통해 모달 방식으로 띄운 재고수정 View를 `dismiss`해 이전 화면으로 돌아갈 수 있습니다.

화면이 켜졌을 때 과일의 현재 재고를 각각 Label로 표기합니다.
- 창이 띄워질 때 호출되는 `viewDidLoad` 메서드 내부에서`updateFruitStockLabel`메서드를 호출합니다.
- `updateFruitStockLabel` 메서드는 과일과 과일 label로 짝지어 선언된 딕셔너리 `fruitLabel`을 이용해 labeling합니다.
    
stepper를 이용해 유저가 과일의 재고를 변경 할 수 있습니다.
- 처음에 stepper의 value를 셋팅 해주기 위해 창이 띄워질 때 호출되는 `viewDidLoad` 메서드에서`assignStepperValue` 메서드를 호출합니다. 
- `assignStepperValue` 메서드는 과일과 `해당 과일의 stepper`로 짝지어 선언된 `fruitStepper` 를 이용해 각 stepper의 value값을 할당합니다.
- 모든 과일의 stepper가 터치될 때 작동하는 `changeFruitStock` 메서드를 이용해 과일 재고 label과 및 실제 `sharedFruitStore`의 과일 재고를 변경합니다.

</br>

### `VC (쥬스 주문 화면)`
`FruitStockVC`에서 과일 재고를 변경한 후, `VC`의 과일 재고 label을 업데이트 하기 위해 `viewWillAppear` 메서드 내부에서 `updateFruitStockLabel` 메서드를 호출합니다.

`FruitStockVC` 모달이 dismiss될 때 `VC`에서 `viewWillAppear` 메서드를 호출할 수 있도록 modal스타일을 `fullScreen`으로 지정합니다.
- `fullScreen`으로 명시적으로 설정하지 않은 경우, modal로 present하면 기존 화면의 일부만을 가리고 새로운 창이 나타나는 형식이기 때문에, 새로운 창을 dismiss해도`viewWillAppear`하지 않기 때문입니다 (새로운 창을 띄웠을 때 기존의 view가 disappear하지 않았기 때문).

---

## 2. 실행 예시

- iphone SE 에서 실행 예시
<img width = 500, src = "https://i.imgur.com/ImLktxf.gif">


- iphone 13 Pro MaX에서 실행 예시
<img width = 500, src = "https://i.imgur.com/1qlXlIb.gif">

---

## 3. 고민한 부분


### 3-1 네비게이션 bar -> Navigation controller로 이동

#### **[방법1]** `VC -> FruitStockVC`로 직접 화면 전환
`FruitStockVC` 내비게이션 바가 보이지 않아 새로운 내비게이션 바를 화면에 추가해 보았습니다.
  - 이럴 경우, 한 VC에 2개의 내비게이션 바가 존재하는 다소 이상한 상황이라고 생각해 다른 방법을 찾아보기로 했습니다.
  - 스토리보드상에는 보였던 `FruitStockVC`의 내비게이션 바가 실행 화면에서 보이지 않았던 이유가, `FruitStockVC`가 어떤 내비게이션 스택 안에도 담기지 않았기 때문이라고 생각했습니다.
 
#### **[방법2]** `VC -> NavigationController -> FruitStockVC`로 이동
`VC`에서 `FruitStockVC`로 직접 이동하지 않고, `FruitStockVC`를 담고 있는 내비게이션 컨트롤러로 이동해 그 내비게이션 컨트롤러의 루트 뷰 컨트롤러인 `FruitStockVC`를 띄우도록 하면 `FruitStockVC`는 내비게이션 스택 안에 존재하게 되므로 내비게이션 바가 화면에 보일 것이라고 생각했습니다.

내비게이션 바를 새로 추가하지 않고도 스토리보드 상에 보이는 내비게이션 바가 실행 화면에서도 정상적으로 출력되어 title을 작성할 수 있었고 navigationBarButton을 이용해 '닫기'버튼을 구현할 수 있었습니다.



### 3-2 stepper `-` 버튼이 작동하지 않는 문제

Stepper를 이용해서 재고를 수정하기 위해 처음에 작성했던 코드는 아래와 같습니다.

```swift
@IBAction func changeFruitStock(_ sender: UIStepper) {
    let fruitStepper: [UIStepper: Fruit] = [
        strawberryStepper: .strawberry,
        bananaStepper: .banana,
        pineappleStepper: .pineapple,
        kiwiStepper: .kiwi,
        mangoStepper: .mango
    ]

    sender.minimumValue = -1

    guard let fruit = fruitStepper[sender],
        let fruitLabel = fruitLabel[fruit] else { return }

    FruitStore.sharedFruitStore.changeStockOf(fruit: fruit, by: Int(sender.value))

    fruitLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))

    sender.value = 0
}
```

  - `-` 값을 전달할 수 있도록 stepper가 전달하는 값의 최소값을 `-1`로 설정
 
  -  stepper를 누를 시, stepper는 값을 기억하고 있으므로 stepper를 누를 때마다 stepper의 value가 1 > 2 > 3 > 4 > ... 로 증가하게 되어 `changeStockOf`에 전달되는 값은 +1 > +3 > +6 > ... 로 변하게 됩니다.
        - 한 번 누를 때마다 `sender.value`를 통해 전달되는 값이 1 또는 -1이 되기를 원해서, 마지막에 `sender.value = 0`으로 stepper가 기억하고 있는 값을 초기화 해 주었습니다.

  - 그런데.. 아래와 같이 코드를 작성할 시 재고를 수정하는 모달 창으로 넘어왔을 때 Stepper의 `-` 버튼을 눌러도 아무런 동작을 하지 않는 문제가 발생했습니다.
      - `+` 버튼을 한 번이라도 누른 후 `-` 버튼을 누를 시 정상적으로 재고의 개수가 줄어들었지만, `-` 버튼만 누르면 아무 동작을 하지 않았습니다.
      - `sender.value`를 출력하는 함수를 작성해보니, 맨 처음에 `-` 버튼을 누를 시 아무것도 출력되지 않는 것을 확인해 작동 자체를 하지 않았다는 것을 알 수 있었습니다.

stepper의 작동 방식에 대해 열심히 구글링 해 보았지만 저희가 원하는 답을 찾을 수 없어, 동료 캠퍼들은 어떻게 구현했는지 질문해서 답을 얻을 수 있었습니다.

```swift
func assignStepperValue() {
    for (stepper, fruit) in fruitStepper {
        stepper.value = Double(FruitStore.sharedFruitStore.fetchStockOf(fruit))
    }
}

@IBAction func changeFruitStock(_ sender: UIStepper) {
    guard let fruit = fruitStepper[sender],
        let fruitLabel = fruitLabel[fruit] else { return }
        
    let changedValue = Int(sender.value) - FruitStore.sharedFruitStore.fetchStockOf(fruit)
    FruitStore.sharedFruitStore.changeStockOf(fruit: fruit, by: changedValue)
        
    fruitLabel.text = String(FruitStore.sharedFruitStore.fetchStockOf(fruit))
}
```
- 각 stepper에 각 과일의 재고를 value로 할당하면, stepper가 설계된 의도대로 `+`를 두 번 누를 시 +2가 되고, `-`를 5번 누르면 -5가 되도록 작동하는 것을 확인할 수 있었습니다.

### 3-3 AutoLayout -> stackView 이용

`과일 이미지, 과일 재고 label, stepper`가 담긴 `Stack View`의 `alignment`를 `fill`로 설정할 경우, 기기에 따라 과일 이미지와 과일 재고 label의 크기는 커지지만 stepper의 크기는 커지지 않았고, stepper는 `leading`으로 정렬된 것 처럼 보였습니다.

Stepper는 크기를 변경할 수 없기 때문에, 세 요소의 너비를 일치시키기 위해 과일 재고 label과 과일 이미지의 크기를 stepper의 크기에 맞추는 제약을 설정한 후, `Stack View`의 `alignment`를 `center`로 변경하여 해결했습니다.

---

## 4. 궁금한 점

### 타입 내에서 프로퍼티(변수, 메서드 등)의 배치 순서

타입(뷰 컨트롤러) 내에 프로퍼티가 어떤 순서로 배치되어야 하는지에 대한 고민을 해결하지 못했습니다.

변수/상수가 타입 구현부의 최상단에 모두 위치하는 것이 맞는지, 해당 변수/상수가 사용되는 함수와 가까운 곳에 위치하는 것이 맞는지 잘 모르겠습니다... 

메서드의 순서가 호출되는 순서대로 배치되는게 맞는지, 메서드1 안에서 호출되는 메서드2가 메서드 1보다 상단부에 배치되어야 하는게 맞는지 궁금합니다. 만약 개인 취향대로 배치하는 거라면 웨더는 어떤방식으로 배치하고 있는지 궁금합니다.

```swift
// 호출 순서대로 배치한 경우
class ViewController: UIViewController {
    
    func viewDidLoad() {
        super.viewDidLoad()
    }
    
    override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear()
        
        updateFruitStockLabel()
    }
    
    func updateFruitStockLabel() {
        for (fruit, label) in fruitLabel {
            label.text = String(FruitStore.sharedFruitStore.fetchSTockOf(fruit))
        }
    }
    
}
```

```swift
// 메서드2를 메서드1보다 위에 배치
class ViewController: UIViewController {
    
    func viewDidLoad() {
        super.viewDidLoad()
    }

    // 메서드2: 다른 메서드에서 호출되는 메서드
    func updateFruitStockLabel() {
        for (fruit, label) in fruitLabel {
            label.text = String(FruitStore.sharedFruitStore.fetchSTockOf(fruit))
        }
    }
    
    // 메서드1: 다른 메서드를 호출하는 메서드
    override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear()
        
        updateFruitStockLabel()
    }

}
```