### PR TITLE
쥬스메이커 [STEP03] 송준, Rowan

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
+		C73DAF3B255D0CDD00020D38 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* MainViewController.swift */; };
 		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
@@ -30,7 +30,7 @@
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C73DAF3A255D0CDD00020D38 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C73DAF3A255D0CDD00020D38 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		C73DAF3D255D0CDD00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -54,7 +54,7 @@
 			children = (
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
-				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				C73DAF3A255D0CDD00020D38 /* MainViewController.swift */,
 				AD7C78C32966A6DF00BA3808 /* ChangeStockViewController.swift */,
 			);
 			path = Controller;
@@ -181,7 +181,7 @@
 			files = (
 				1C8CD0012964464C00AF59C4 /* Fruits.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				C73DAF3B255D0CDD00020D38 /* MainViewController.swift in Sources */,
 				AD7C78C42966A6DF00BA3808 /* ChangeStockViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1C8CCFF82963BBCC00AF59C4 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C8CCFF72963BBCC00AF59C4 /* Error.swift */; };
 		1C8CD0012964464C00AF59C4 /* Fruits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C8CD0002964464C00AF59C4 /* Fruits.swift */; };
+		1CEA5834296FE2520063F72B /* NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CEA5833296FE2520063F72B /* NotificationCenter.swift */; };
 		AD7C78C42966A6DF00BA3808 /* ChangeStockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7C78C32966A6DF00BA3808 /* ChangeStockViewController.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
@@ -23,6 +24,7 @@
 /* Begin PBXFileReference section */
 		1C8CCFF72963BBCC00AF59C4 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		1C8CD0002964464C00AF59C4 /* Fruits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruits.swift; sourceTree = "<group>"; };
+		1CEA5833296FE2520063F72B /* NotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenter.swift; sourceTree = "<group>"; };
 		AD7C78C32966A6DF00BA3808 /* ChangeStockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeStockViewController.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -65,6 +67,7 @@
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				1C8CCFF72963BBCC00AF59C4 /* Error.swift */,
 				1C8CD0002964464C00AF59C4 /* Fruits.swift */,
+				1CEA5833296FE2520063F72B /* NotificationCenter.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -183,6 +186,7 @@
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				1C8CCFF82963BBCC00AF59C4 /* Error.swift in Sources */,
+				1CEA5834296FE2520063F72B /* NotificationCenter.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -14,8 +14,10 @@ final class ChangeStockViewController: UIViewController {
         super.viewDidLoad()
         displayStock()
         initializeSteppers()
+        setUpNavigationItem()
     }
     
+    @IBOutlet weak var navigationBar: UINavigationItem!
     @IBOutlet weak var stockOfStrawberry: UILabel!
     @IBOutlet weak var stockOfBanana: UILabel!
     @IBOutlet weak var stockOfPineapple: UILabel!
@@ -30,6 +32,12 @@ final class ChangeStockViewController: UIViewController {
     
     @IBOutlet var steppers: [UIStepper]!
     
+    func setUpNavigationItem() {
+        navigationBar.title = "재고 추가"
+        let dismissButton = UIBarButtonItem(title: "닫기", style: .plain, target: self, action: #selector(dismissCurrentView))
+        navigationBar.rightBarButtonItem = dismissButton
+    }
+
     func initializeSteppers() {
         for stepper in steppers {
             if let selectedFruit = identifyRelatedFruit(of: stepper),
@@ -68,7 +76,7 @@ final class ChangeStockViewController: UIViewController {
         }
     }
     
-    @IBAction func pushCloseButton() {
+    @objc func dismissCurrentView() {
         self.dismiss(animated: true)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -6,12 +6,58 @@ import UIKit
 
 final class ChangeStockViewController: UIViewController {
     
-    @IBOutlet weak var numberOfStrawberry: UILabel!
-    @IBOutlet weak var numberOfBanana: UILabel!
-    @IBOutlet weak var numberOfPineapple: UILabel!
-    @IBOutlet weak var numberOfKiwi: UILabel!
-    @IBOutlet weak var numberOfMango: UILabel!
+    private var fruitsStock: [Fruits: Int] {
+        return FruitStore.shared.fruitsStock
+    }
     
-
-   
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        displayStock()
+    }
+    
+    @IBOutlet weak var stockOfStrawberry: UILabel!
+    @IBOutlet weak var stockOfBanana: UILabel!
+    @IBOutlet weak var stockOfPineapple: UILabel!
+    @IBOutlet weak var stockOfKiwi: UILabel!
+    @IBOutlet weak var stockOfMango: UILabel!
+    
+    @IBOutlet weak var strawberryStepper: UIStepper!
+    @IBOutlet weak var bananaStepper: UIStepper!
+    @IBOutlet weak var pineappleStepper: UIStepper!
+    @IBOutlet weak var kiwiStepper: UIStepper!
+    @IBOutlet weak var mangoStepper: UIStepper!
+    
+    func displayStock() {
+        if let strawberryStock = fruitsStock[.strawberry],
+           let bananaStock = fruitsStock[.banana],
+           let pineappleStock = fruitsStock[.pineapple],
+           let kiwiStock = fruitsStock[.kiwi],
+           let mangoStock = fruitsStock[.mango] {
+            stockOfStrawberry.text = String(strawberryStock)
+            stockOfBanana.text = String(bananaStock)
+            stockOfPineapple.text = String(pineappleStock)
+            stockOfKiwi.text = String(kiwiStock)
+            stockOfMango.text = String(mangoStock)
+        }
+    }
+    
+    @IBAction func pushCloseButton() {
+        self.dismiss(animated: true)
+    }
+    
+    func identifyRelatedLabel(of stepper: UIStepper) -> UILabel? {
+        switch stepper {
+        case strawberryStepper: return stockOfStrawberry
+        case bananaStepper: return stockOfBanana
+        case pineappleStepper: return stockOfPineapple
+        case kiwiStepper: return stockOfKiwi
+        case mangoStepper: return stockOfMango
+        default: return nil
+        }
+    }
+    
+    @IBAction func pushStepper(_ sender: UIStepper) {
+        guard let fruitsLabel = identifyRelatedLabel(of: sender) else { return }
+        fruitsLabel.text = Int(sender.value).description
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -6,22 +6,6 @@ import UIKit
 
 final class ChangeStockViewController: UIViewController {
     
-    private var fruitsStock: [Fruits: Int] {
-        return FruitStore.shared.fruitsStock
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        displayStock()
-        initializeSteppers()
-        setUpNavigationBar()
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(true)
-        center.post(name: Notification.Name.fruitStockChanged, object: nil)
-    }
-    
     @IBOutlet weak var navigationBar: UINavigationItem!
     
     @IBOutlet weak var stockOfStrawberry: UILabel!
@@ -37,6 +21,22 @@ final class ChangeStockViewController: UIViewController {
     @IBOutlet weak var mangoStepper: UIStepper!
     
     @IBOutlet var steppers: [UIStepper]!
+    
+    private var fruitsStock: [Fruits: Int] {
+        return FruitStore.shared.fruitsStock
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        displayStock()
+        initializeSteppers()
+        setUpNavigationBar()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
+        center.post(name: Notification.Name.fruitStockChanged, object: nil)
+    }
     
     func displayStock() {
         if let strawberryStock = fruitsStock[.strawberry],

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -14,7 +14,7 @@ final class ChangeStockViewController: UIViewController {
         super.viewDidLoad()
         displayStock()
         initializeSteppers()
-        setUpNavigationItem()
+        setUpNavigationBar()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -56,7 +56,6 @@ final class ChangeStockViewController: UIViewController {
         for stepper in steppers {
             if let selectedFruit = identifyRelatedFruit(of: stepper),
                let initialValue = fruitsStock[selectedFruit] {
-                stepper.transform = stepper.transform.scaledBy(x: 1.0, y: 1.0)
                 stepper.value = Double(initialValue)
             }
         }
@@ -64,16 +63,22 @@ final class ChangeStockViewController: UIViewController {
     
     func identifyRelatedFruit(of stepper: UIStepper) -> Fruits? {
         switch stepper {
-        case strawberryStepper: return .strawberry
-        case bananaStepper: return .banana
-        case pineappleStepper: return .pineapple
-        case kiwiStepper: return .kiwi
-        case mangoStepper: return .mango
-        default: return nil
+        case strawberryStepper:
+            return .strawberry
+        case bananaStepper:
+            return .banana
+        case pineappleStepper:
+            return .pineapple
+        case kiwiStepper:
+            return .kiwi
+        case mangoStepper:
+            return .mango
+        default:
+            return nil
         }
     }
     
-    func setUpNavigationItem() {
+    func setUpNavigationBar() {
         navigationBar.title = "재고 추가"
         let dismissButton = UIBarButtonItem(title: "닫기",
                                             style: .plain,
@@ -96,12 +101,18 @@ final class ChangeStockViewController: UIViewController {
     
     func identifyRelatedLabel(of stepper: UIStepper) -> UILabel? {
         switch stepper {
-        case strawberryStepper: return stockOfStrawberry
-        case bananaStepper: return stockOfBanana
-        case pineappleStepper: return stockOfPineapple
-        case kiwiStepper: return stockOfKiwi
-        case mangoStepper: return stockOfMango
-        default: return nil
+        case strawberryStepper:
+            return stockOfStrawberry
+        case bananaStepper:
+            return stockOfBanana
+        case pineappleStepper:
+            return stockOfPineapple
+        case kiwiStepper:
+            return stockOfKiwi
+        case mangoStepper:
+            return stockOfMango
+        default:
+            return nil
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -35,7 +35,7 @@ final class ChangeStockViewController: UIViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(true)
-        center.post(name: Notification.Name.fruitStockChanged, object: nil)
+        NotificationCenter.default.post(name: Notification.Name.fruitStockChanged, object: nil)
     }
     
     private func displayStock() {

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -13,6 +13,7 @@ final class ChangeStockViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         displayStock()
+        initializeSteppers()
     }
     
     @IBOutlet weak var stockOfStrawberry: UILabel!
@@ -26,6 +27,31 @@ final class ChangeStockViewController: UIViewController {
     @IBOutlet weak var pineappleStepper: UIStepper!
     @IBOutlet weak var kiwiStepper: UIStepper!
     @IBOutlet weak var mangoStepper: UIStepper!
+    
+    @IBOutlet var steppers: [UIStepper]!
+    
+    func initializeSteppers() {
+        for stepper in steppers {
+            if let selectedFruit = identifyRelatedFruit(of: stepper),
+               let initialValue = fruitsStock[selectedFruit] {
+                stepper.maximumValue = 100
+                stepper.minimumValue = 0
+                stepper.stepValue = 1
+                stepper.value = Double(initialValue)
+            }
+        }
+    }
+    
+    func identifyRelatedFruit(of stepper: UIStepper) -> Fruits? {
+        switch stepper {
+        case strawberryStepper: return .strawberry
+        case bananaStepper: return .banana
+        case pineappleStepper: return .pineapple
+        case kiwiStepper: return .kiwi
+        case mangoStepper: return .mango
+        default: return nil
+        }
+    }
     
     func displayStock() {
         if let strawberryStock = fruitsStock[.strawberry],

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -83,7 +83,10 @@ final class ChangeStockViewController: UIViewController {
     }
     
     @IBAction func pushStepper(_ sender: UIStepper) {
-        guard let fruitsLabel = identifyRelatedLabel(of: sender) else { return }
+        guard let fruitsLabel = identifyRelatedLabel(of: sender),
+              let fruit = identifyRelatedFruit(of: sender) else { return }
+        
+        FruitStore.shared.fruitsStock[fruit] = Int(sender.value)
         fruitsLabel.text = Int(sender.value).description
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -17,6 +17,11 @@ final class ChangeStockViewController: UIViewController {
         setUpNavigationItem()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
+        center.post(name: Notification.Name.fruitStockChanged, object: nil)
+    }
+    
     @IBOutlet weak var navigationBar: UINavigationItem!
     
     @IBOutlet weak var stockOfStrawberry: UILabel!
@@ -87,7 +92,6 @@ final class ChangeStockViewController: UIViewController {
         
         FruitStore.shared.fruitsStock[fruit] = Int(sender.value)
         fruitsLabel.text = Int(sender.value).description
-        center.post(name: Notification.Name.fruitStockChanged, object: nil)
     }
     
     func identifyRelatedLabel(of stepper: UIStepper) -> UILabel? {

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -32,12 +32,20 @@ final class ChangeStockViewController: UIViewController {
     
     @IBOutlet var steppers: [UIStepper]!
     
-    func setUpNavigationItem() {
-        navigationBar.title = "재고 추가"
-        let dismissButton = UIBarButtonItem(title: "닫기", style: .plain, target: self, action: #selector(dismissCurrentView))
-        navigationBar.rightBarButtonItem = dismissButton
+    func displayStock() {
+        if let strawberryStock = fruitsStock[.strawberry],
+           let bananaStock = fruitsStock[.banana],
+           let pineappleStock = fruitsStock[.pineapple],
+           let kiwiStock = fruitsStock[.kiwi],
+           let mangoStock = fruitsStock[.mango] {
+            stockOfStrawberry.text = String(strawberryStock)
+            stockOfBanana.text = String(bananaStock)
+            stockOfPineapple.text = String(pineappleStock)
+            stockOfKiwi.text = String(kiwiStock)
+            stockOfMango.text = String(mangoStock)
+        }
     }
-
+    
     func initializeSteppers() {
         for stepper in steppers {
             if let selectedFruit = identifyRelatedFruit(of: stepper),
@@ -59,22 +67,26 @@ final class ChangeStockViewController: UIViewController {
         }
     }
     
-    func displayStock() {
-        if let strawberryStock = fruitsStock[.strawberry],
-           let bananaStock = fruitsStock[.banana],
-           let pineappleStock = fruitsStock[.pineapple],
-           let kiwiStock = fruitsStock[.kiwi],
-           let mangoStock = fruitsStock[.mango] {
-            stockOfStrawberry.text = String(strawberryStock)
-            stockOfBanana.text = String(bananaStock)
-            stockOfPineapple.text = String(pineappleStock)
-            stockOfKiwi.text = String(kiwiStock)
-            stockOfMango.text = String(mangoStock)
-        }
+    func setUpNavigationItem() {
+        navigationBar.title = "재고 추가"
+        let dismissButton = UIBarButtonItem(title: "닫기",
+                                            style: .plain,
+                                            target: self,
+                                            action: #selector(dismissCurrentView))
+        navigationBar.rightBarButtonItem = dismissButton
     }
     
     @objc func dismissCurrentView() {
         self.dismiss(animated: true)
+    }
+
+    @IBAction func pushStepper(_ sender: UIStepper) {
+        guard let fruitsLabel = identifyRelatedLabel(of: sender),
+              let fruit = identifyRelatedFruit(of: sender) else { return }
+        
+        FruitStore.shared.fruitsStock[fruit] = Int(sender.value)
+        fruitsLabel.text = Int(sender.value).description
+        center.post(name: Notification.Name.fruitStockChanged, object: nil)
     }
     
     func identifyRelatedLabel(of stepper: UIStepper) -> UILabel? {
@@ -88,14 +100,5 @@ final class ChangeStockViewController: UIViewController {
         }
     }
     
-    @IBAction func pushStepper(_ sender: UIStepper) {
-        guard let fruitsLabel = identifyRelatedLabel(of: sender),
-              let fruit = identifyRelatedFruit(of: sender) else { return }
-        
-        FruitStore.shared.fruitsStock[fruit] = Int(sender.value)
-        fruitsLabel.text = Int(sender.value).description
-        
-        let noti = Notification(name: Notification.Name.fruitStockChanged, object: nil)
-        center.post(noti)
-    }
+    
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -18,6 +18,7 @@ final class ChangeStockViewController: UIViewController {
     }
     
     @IBOutlet weak var navigationBar: UINavigationItem!
+    
     @IBOutlet weak var stockOfStrawberry: UILabel!
     @IBOutlet weak var stockOfBanana: UILabel!
     @IBOutlet weak var stockOfPineapple: UILabel!
@@ -99,6 +100,4 @@ final class ChangeStockViewController: UIViewController {
         default: return nil
         }
     }
-    
-    
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -6,7 +6,6 @@ import UIKit
 
 final class ChangeStockViewController: UIViewController {
     
-    
     private var fruitsStock: [Fruits: Int] {
         return FruitStore.shared.fruitsStock
     }
@@ -93,6 +92,5 @@ final class ChangeStockViewController: UIViewController {
         
         let noti = Notification(name: Notification.Name.fruitStockChanged, object: nil)
         center.post(noti)
-        
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 
 final class ChangeStockViewController: UIViewController {
     
+    
     private var fruitsStock: [Fruits: Int] {
         return FruitStore.shared.fruitsStock
     }
@@ -34,6 +35,7 @@ final class ChangeStockViewController: UIViewController {
         for stepper in steppers {
             if let selectedFruit = identifyRelatedFruit(of: stepper),
                let initialValue = fruitsStock[selectedFruit] {
+                stepper.transform = stepper.transform.scaledBy(x: 1.1, y: 1.25)
                 stepper.maximumValue = 100
                 stepper.minimumValue = 0
                 stepper.stepValue = 1
@@ -88,5 +90,9 @@ final class ChangeStockViewController: UIViewController {
         
         FruitStore.shared.fruitsStock[fruit] = Int(sender.value)
         fruitsLabel.text = Int(sender.value).description
+        
+        let noti = Notification(name: Notification.Name.fruitStockChanged, object: nil)
+        center.post(noti)
+        
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -12,35 +12,6 @@ final class ChangeStockViewController: UIViewController {
     @IBOutlet weak var numberOfKiwi: UILabel!
     @IBOutlet weak var numberOfMango: UILabel!
     
-    @IBAction func pushPlusStrawberry(_ sender: Any) {
-        //
-    }
-    @IBAction func pushMinusStrawberry(_ sender: Any) {
-        //
-    }
-    @IBAction func pushPlusBanana(_ sender: Any) {
-        //
-    }
-    @IBAction func pushMinusBanana(_ sender: Any) {
-        //
-    }
-    @IBAction func pushPlusPineApple(_ sender: Any) {
-        //
-    }
-    @IBAction func pushMinusPineApple(_ sender: Any) {
-        //
-    }
-    @IBAction func pushPlusKiwi(_ sender: Any) {
-        //
-    }
-    @IBAction func pushMinusKiwi(_ sender: Any) {
-        //
-    }
-    @IBAction func pushPlusMango(_ sender: Any) {
-        //
-    }
-    @IBAction func pushMinusMango(_ sender: Any) {
-        //
-    }
+
    
 }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -42,10 +42,7 @@ final class ChangeStockViewController: UIViewController {
         for stepper in steppers {
             if let selectedFruit = identifyRelatedFruit(of: stepper),
                let initialValue = fruitsStock[selectedFruit] {
-                stepper.transform = stepper.transform.scaledBy(x: 1.1, y: 1.25)
-                stepper.maximumValue = 100
-                stepper.minimumValue = 0
-                stepper.stepValue = 1
+                stepper.transform = stepper.transform.scaledBy(x: 1.0, y: 1.0)
                 stepper.value = Double(initialValue)
             }
         }

--- a/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ChangeStockViewController.swift
@@ -38,7 +38,7 @@ final class ChangeStockViewController: UIViewController {
         center.post(name: Notification.Name.fruitStockChanged, object: nil)
     }
     
-    func displayStock() {
+    private func displayStock() {
         if let strawberryStock = fruitsStock[.strawberry],
            let bananaStock = fruitsStock[.banana],
            let pineappleStock = fruitsStock[.pineapple],
@@ -52,7 +52,7 @@ final class ChangeStockViewController: UIViewController {
         }
     }
     
-    func initializeSteppers() {
+    private func initializeSteppers() {
         for stepper in steppers {
             if let selectedFruit = identifyRelatedFruit(of: stepper),
                let initialValue = fruitsStock[selectedFruit] {
@@ -61,7 +61,7 @@ final class ChangeStockViewController: UIViewController {
         }
     }
     
-    func identifyRelatedFruit(of stepper: UIStepper) -> Fruits? {
+    private func identifyRelatedFruit(of stepper: UIStepper) -> Fruits? {
         switch stepper {
         case strawberryStepper:
             return .strawberry
@@ -78,7 +78,7 @@ final class ChangeStockViewController: UIViewController {
         }
     }
     
-    func setUpNavigationBar() {
+    private func setUpNavigationBar() {
         navigationBar.title = "재고 추가"
         let dismissButton = UIBarButtonItem(title: "닫기",
                                             style: .plain,
@@ -87,7 +87,7 @@ final class ChangeStockViewController: UIViewController {
         navigationBar.rightBarButtonItem = dismissButton
     }
     
-    @objc func dismissCurrentView() {
+    @objc private func dismissCurrentView() {
         self.dismiss(animated: true)
     }
 
@@ -99,7 +99,7 @@ final class ChangeStockViewController: UIViewController {
         fruitsLabel.text = Int(sender.value).description
     }
     
-    func identifyRelatedLabel(of stepper: UIStepper) -> UILabel? {
+    private func identifyRelatedLabel(of stepper: UIStepper) -> UILabel? {
         switch stepper {
         case strawberryStepper:
             return stockOfStrawberry

--- a/JuiceMaker/JuiceMaker/Controller/MainViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MainViewController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-final class ViewController: UIViewController {
+final class MainViewController: UIViewController {
     
     private let juiceMaker = JuiceMaker()
     private var fruitsStock: [Fruits: Int] {

--- a/JuiceMaker/JuiceMaker/Controller/MainViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MainViewController.swift
@@ -62,12 +62,12 @@ final class MainViewController: UIViewController {
         moveToChangeStockViewController()
     }
     
-    func moveToChangeStockViewController() {
+    private func moveToChangeStockViewController() {
         guard let nextVC = self.storyboard?.instantiateViewController(withIdentifier: "ChangeStock") as? ChangeStockViewController else { return }
         self.navigationController?.present(nextVC, animated: true)
     }
     
-    func setSuccessAlert(juice: JuiceMaker.Juice) {
+    private func setSuccessAlert(juice: JuiceMaker.Juice) {
         let successAlert = UIAlertController(title: AlertMessege.success,
                                              message: juice.name + AlertMessege.madeJuice,
                                              preferredStyle: UIAlertController.Style.alert)
@@ -80,7 +80,7 @@ final class MainViewController: UIViewController {
         present(successAlert, animated: true, completion: nil)
     }
     
-    func setFailAlert() {
+    private func setFailAlert() {
         let failAlert = UIAlertController(title: AlertMessege.failure,
                                           message: AlertMessege.lackOfStock,
                                           preferredStyle: UIAlertController.Style.alert)
@@ -104,7 +104,7 @@ final class MainViewController: UIViewController {
         order(selectedJuice)
     }
     
-    func identifyJuice(of button: UIButton) -> JuiceMaker.Juice? {
+    private func identifyJuice(of button: UIButton) -> JuiceMaker.Juice? {
         switch button {
         case orderStrawberry:
             return .strawberry
@@ -125,7 +125,7 @@ final class MainViewController: UIViewController {
         }
     }
     
-    func order(_ juice: JuiceMaker.Juice) {
+    private func order(_ juice: JuiceMaker.Juice) {
         do {
             try juiceMaker.make(juice: juice)
             setSuccessAlert(juice: juice)

--- a/JuiceMaker/JuiceMaker/Controller/MainViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MainViewController.swift
@@ -38,7 +38,7 @@ final class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         displayStock()
-        center.addObserver(self,
+        NotificationCenter.default.addObserver(self,
                            selector: #selector(displayStock),
                            name: Notification.Name.fruitStockChanged,
                            object: nil)

--- a/JuiceMaker/JuiceMaker/Controller/MainViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MainViewController.swift
@@ -106,14 +106,22 @@ final class MainViewController: UIViewController {
     
     func identifyJuice(of button: UIButton) -> JuiceMaker.Juice? {
         switch button {
-        case orderStrawberry: return .strawberry
-        case orderBanana: return .banana
-        case orderPineapple: return .pineapple
-        case orderKiwi: return .kiwi
-        case orderMango: return .mango
-        case orderStrawberryBanana: return .strawberryBanana
-        case orderMangoKiwi: return .mangoKiwi
-        default: return nil
+        case orderStrawberry:
+            return .strawberry
+        case orderBanana:
+            return .banana
+        case orderPineapple:
+            return .pineapple
+        case orderKiwi:
+            return .kiwi
+        case orderMango:
+            return .mango
+        case orderStrawberryBanana:
+            return .strawberryBanana
+        case orderMangoKiwi:
+            return .mangoKiwi
+        default:
+            return nil
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/MainViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/MainViewController.swift
@@ -6,18 +6,19 @@ import UIKit
 
 final class MainViewController: UIViewController {
     
+    private enum AlertMessege {
+        static let confirm = "확인"
+        static let yes = "예"
+        static let no = "아니오"
+        static let madeJuice = "가 나왔습니다. 맛있게 드세요!"
+        static let lackOfStock = "재료가 모자라요. 재고를 수정할까요?"
+        static let success = "성공"
+        static let failure = "실패"
+    }
+    
     private let juiceMaker = JuiceMaker()
     private var fruitsStock: [Fruits: Int] {
         return FruitStore.shared.fruitsStock
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        displayStock()
-        center.addObserver(self,
-                           selector: #selector(displayStock),
-                           name: Notification.Name.fruitStockChanged,
-                           object: nil)
     }
     
     @IBOutlet weak var stockOfStrawberry: UILabel!
@@ -34,14 +35,13 @@ final class MainViewController: UIViewController {
     @IBOutlet weak var orderKiwi: UIButton!
     @IBOutlet weak var orderMango: UIButton!
     
-    private enum AlertMessege {
-        static let confirm = "확인"
-        static let yes = "예"
-        static let no = "아니오"
-        static let madeJuice = "가 나왔습니다. 맛있게 드세요!"
-        static let lackOfStock = "재료가 모자라요. 재고를 수정할까요?"
-        static let success = "성공"
-        static let failure = "실패"
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        displayStock()
+        center.addObserver(self,
+                           selector: #selector(displayStock),
+                           name: Notification.Name.fruitStockChanged,
+                           object: nil)
     }
     
     @objc func displayStock() {
@@ -65,37 +65,6 @@ final class MainViewController: UIViewController {
     private func moveToChangeStockViewController() {
         guard let nextVC = self.storyboard?.instantiateViewController(withIdentifier: "ChangeStock") as? ChangeStockViewController else { return }
         self.navigationController?.present(nextVC, animated: true)
-    }
-    
-    private func setSuccessAlert(juice: JuiceMaker.Juice) {
-        let successAlert = UIAlertController(title: AlertMessege.success,
-                                             message: juice.name + AlertMessege.madeJuice,
-                                             preferredStyle: UIAlertController.Style.alert)
-        
-        let offAction = UIAlertAction(title: AlertMessege.confirm,
-                                      style: UIAlertAction.Style.default,
-                                      handler: nil)
-        
-        successAlert.addAction(offAction)
-        present(successAlert, animated: true, completion: nil)
-    }
-    
-    private func setFailAlert() {
-        let failAlert = UIAlertController(title: AlertMessege.failure,
-                                          message: AlertMessege.lackOfStock,
-                                          preferredStyle: UIAlertController.Style.alert)
-        
-        let yesAction = UIAlertAction(title: AlertMessege.yes,
-                                      style: UIAlertAction.Style.default,
-                                      handler: { Action in self.moveToChangeStockViewController() })
-        
-        let noAction = UIAlertAction(title: AlertMessege.no,
-                                     style: UIAlertAction.Style.default,
-                                     handler: nil)
-        
-        failAlert.addAction(yesAction)
-        failAlert.addAction(noAction)
-        present(failAlert, animated: true, completion: nil)
     }
     
     @IBAction func pushOrderButton(_ sender: UIButton) {
@@ -135,5 +104,36 @@ final class MainViewController: UIViewController {
         } catch {
             print(error)
         }
+    }
+    
+    private func setSuccessAlert(juice: JuiceMaker.Juice) {
+        let successAlert = UIAlertController(title: AlertMessege.success,
+                                             message: juice.name + AlertMessege.madeJuice,
+                                             preferredStyle: UIAlertController.Style.alert)
+        
+        let offAction = UIAlertAction(title: AlertMessege.confirm,
+                                      style: UIAlertAction.Style.default,
+                                      handler: nil)
+        
+        successAlert.addAction(offAction)
+        present(successAlert, animated: true, completion: nil)
+    }
+    
+    private func setFailAlert() {
+        let failAlert = UIAlertController(title: AlertMessege.failure,
+                                          message: AlertMessege.lackOfStock,
+                                          preferredStyle: UIAlertController.Style.alert)
+        
+        let yesAction = UIAlertAction(title: AlertMessege.yes,
+                                      style: UIAlertAction.Style.default,
+                                      handler: { Action in self.moveToChangeStockViewController() })
+        
+        let noAction = UIAlertAction(title: AlertMessege.no,
+                                     style: UIAlertAction.Style.default,
+                                     handler: nil)
+        
+        failAlert.addAction(yesAction)
+        failAlert.addAction(noAction)
+        present(failAlert, animated: true, completion: nil)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -10,10 +10,15 @@ final class ViewController: UIViewController {
         return FruitStore.shared.fruitsStock
     }
     
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         displayStock()
-        print("뷰디드로드요~")
+        center.addObserver(self,
+                           selector: #selector(displayStock),
+                           name: Notification.Name.fruitStockChanged,
+                           object: nil)
     }
     
     @IBOutlet weak var stockOfStrawberry: UILabel!
@@ -39,7 +44,7 @@ final class ViewController: UIViewController {
         static let failure = "실패"
     }
     
-    func displayStock() {
+    @objc func displayStock() {
         if let strawberryStock = fruitsStock[.strawberry],
            let bananaStock = fruitsStock[.banana],
            let pineappleStock = fruitsStock[.pineapple],
@@ -122,3 +127,6 @@ final class ViewController: UIViewController {
         }
     }
 }
+
+
+// viewcontroller -> observer // singleton notification을 보내는 친구들

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -16,8 +16,6 @@ final class ViewController: UIViewController {
         print("뷰디드로드요~")
     }
     
-    
-    
     @IBOutlet weak var stockOfStrawberry: UILabel!
     @IBOutlet weak var stockOfBanana: UILabel!
     @IBOutlet weak var stockOfPineapple: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -10,8 +10,6 @@ final class ViewController: UIViewController {
         return FruitStore.shared.fruitsStock
     }
     
-    
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         displayStock()
@@ -34,7 +32,7 @@ final class ViewController: UIViewController {
     @IBOutlet weak var orderKiwi: UIButton!
     @IBOutlet weak var orderMango: UIButton!
     
-    enum AlertMessege {
+    private enum AlertMessege {
         static let confirm = "확인"
         static let yes = "예"
         static let no = "아니오"
@@ -71,9 +69,11 @@ final class ViewController: UIViewController {
         let successAlert = UIAlertController(title: AlertMessege.success,
                                              message: juice.name + AlertMessege.madeJuice,
                                              preferredStyle: UIAlertController.Style.alert)
+        
         let offAction = UIAlertAction(title: AlertMessege.confirm,
                                       style: UIAlertAction.Style.default,
                                       handler: nil)
+        
         successAlert.addAction(offAction)
         present(successAlert, animated: true, completion: nil)
     }
@@ -82,6 +82,7 @@ final class ViewController: UIViewController {
         let failAlert = UIAlertController(title: AlertMessege.failure,
                                           message: AlertMessege.lackOfStock,
                                           preferredStyle: UIAlertController.Style.alert)
+        
         let yesAction = UIAlertAction(title: AlertMessege.yes,
                                       style: UIAlertAction.Style.default,
                                       handler: { Action in self.moveToChangeStockViewController() })
@@ -89,12 +90,11 @@ final class ViewController: UIViewController {
         let noAction = UIAlertAction(title: AlertMessege.no,
                                      style: UIAlertAction.Style.default,
                                      handler: nil)
+        
         failAlert.addAction(yesAction)
         failAlert.addAction(noAction)
         present(failAlert, animated: true, completion: nil)
     }
-    
-    
     
     @IBAction func pushOrderButton(_ sender: UIButton) {
         guard let selectedJuice = identifyJuice(of: sender) else { return }
@@ -127,6 +127,3 @@ final class ViewController: UIViewController {
         }
     }
 }
-
-
-// viewcontroller -> observer // singleton notification을 보내는 친구들

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -58,7 +58,7 @@ final class ViewController: UIViewController {
     
     func moveToChangeStockViewController() {
         guard let nextVC = self.storyboard?.instantiateViewController(withIdentifier: "ChangeStock") as? ChangeStockViewController else { return }
-        self.navigationController?.pushViewController(nextVC, animated: false)
+        self.navigationController?.present(nextVC, animated: true)
     }
     
     func setSuccessAlert(juice: JuiceMaker.Juice) {

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -13,11 +13,14 @@ final class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         displayStock()
+        print("뷰디드로드요~")
     }
+    
+    
     
     @IBOutlet weak var stockOfStrawberry: UILabel!
     @IBOutlet weak var stockOfBanana: UILabel!
-    @IBOutlet weak var stockOfPineApple: UILabel!
+    @IBOutlet weak var stockOfPineapple: UILabel!
     @IBOutlet weak var stockOfKiwi: UILabel!
     @IBOutlet weak var stockOfMango: UILabel!
     @IBOutlet weak var orderStrawberryBanana: UIButton!
@@ -46,7 +49,7 @@ final class ViewController: UIViewController {
            let mangoStock = fruitsStock[.mango] {
             stockOfStrawberry.text = String(strawberryStock)
             stockOfBanana.text = String(bananaStock)
-            stockOfPineApple.text = String(pineappleStock)
+            stockOfPineapple.text = String(pineappleStock)
             stockOfKiwi.text = String(kiwiStock)
             stockOfMango.text = String(mangoStock)
         }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -5,6 +5,7 @@
 import UIKit
 
 final class ViewController: UIViewController {
+    
     private let juiceMaker = JuiceMaker()
     private var fruitsStock: [Fruits: Int] {
         return FruitStore.shared.fruitsStock
@@ -24,6 +25,7 @@ final class ViewController: UIViewController {
     @IBOutlet weak var stockOfPineapple: UILabel!
     @IBOutlet weak var stockOfKiwi: UILabel!
     @IBOutlet weak var stockOfMango: UILabel!
+    
     @IBOutlet weak var orderStrawberryBanana: UIButton!
     @IBOutlet weak var orderMangoKiwi: UIButton!
     @IBOutlet weak var orderStrawberry: UIButton!

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -7,7 +7,7 @@ class FruitStore {
     
     var fruitsStock = [Fruits: Int]()
     
-    func fillFruitsStock() {
+    private func fillFruitsStock() {
         for fruit in Fruits.allCases {
             fruitsStock[fruit] = 10
         }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -11,25 +11,39 @@ struct JuiceMaker {
         
         var ingredients: [Fruits: Int] {
             switch self {
-            case .mango: return [.mango: 3]
-            case .pineapple: return [.pineapple: 2]
-            case .banana: return [.banana: 2]
-            case .kiwi: return [.kiwi: 3]
-            case .strawberry: return [.strawberry: 16]
-            case .strawberryBanana: return [.strawberry: 10, .banana: 1]
-            case .mangoKiwi: return [.mango: 2, .kiwi: 1]
+            case .mango:
+                return [.mango: 3]
+            case .pineapple:
+                return [.pineapple: 2]
+            case .banana:
+                return [.banana: 2]
+            case .kiwi:
+                return [.kiwi: 3]
+            case .strawberry:
+                return [.strawberry: 16]
+            case .strawberryBanana:
+                return [.strawberry: 10, .banana: 1]
+            case .mangoKiwi:
+                return [.mango: 2, .kiwi: 1]
             }
         }
         
         var name: String {
             switch self {
-            case .mango: return "망고쥬스"
-            case .pineapple: return "파인애플쥬스"
-            case .banana: return "바나나쥬스"
-            case .kiwi: return "키위쥬스"
-            case .strawberry: return "딸기쥬스"
-            case .strawberryBanana: return "딸바쥬스"
-            case .mangoKiwi: return "망키쥬스"
+            case .mango:
+                return "망고쥬스"
+            case .pineapple:
+                return "파인애플쥬스"
+            case .banana:
+                return "바나나쥬스"
+            case .kiwi:
+                return "키위쥬스"
+            case .strawberry:
+                return "딸기쥬스"
+            case .strawberryBanana:
+                return "딸바쥬스"
+            case .mangoKiwi:
+                return "망키쥬스"
             }
         }
     }

--- a/JuiceMaker/JuiceMaker/Model/NotificationCenter.swift
+++ b/JuiceMaker/JuiceMaker/Model/NotificationCenter.swift
@@ -1,0 +1,15 @@
+//  JuiceMaker - NotificationCenter.swift
+//  Created by 송준, Rowan on 2023/01/12.
+//  Copyright © yagom academy. All rights reserved.
+
+import Foundation
+
+let center: NotificationCenter = NotificationCenter.default
+
+
+
+extension Notification.Name {
+    static let fruitStockChanged = Notification.Name("과일재고변경")
+}
+
+

--- a/JuiceMaker/JuiceMaker/Model/NotificationCenter.swift
+++ b/JuiceMaker/JuiceMaker/Model/NotificationCenter.swift
@@ -6,8 +6,6 @@ import Foundation
 
 let center: NotificationCenter = NotificationCenter.default
 
-
-
 extension Notification.Name {
     static let fruitStockChanged = Notification.Name("과일재고변경")
 }

--- a/JuiceMaker/JuiceMaker/Model/NotificationCenter.swift
+++ b/JuiceMaker/JuiceMaker/Model/NotificationCenter.swift
@@ -4,8 +4,6 @@
 
 import Foundation
 
-let center: NotificationCenter = NotificationCenter.default
-
 extension Notification.Name {
     static let fruitStockChanged = Notification.Name("과일재고변경")
 }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -253,7 +253,7 @@
                         <outlet property="stockOfBanana" destination="gvk-pA-Lw5" id="chv-7N-37j"/>
                         <outlet property="stockOfKiwi" destination="FZq-de-TJG" id="nxQ-uG-N8q"/>
                         <outlet property="stockOfMango" destination="3Ce-SU-JeH" id="trl-6V-cdi"/>
-                        <outlet property="stockOfPineApple" destination="ccQ-Dk-PuY" id="qzv-2l-fu9"/>
+                        <outlet property="stockOfPineapple" destination="ccQ-Dk-PuY" id="0xP-M0-OH5"/>
                         <outlet property="stockOfStrawberry" destination="Qas-vP-td6" id="uuF-Kg-W6s"/>
                     </connections>
                 </viewController>
@@ -287,82 +287,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                <rect key="frame" x="720" y="107" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="752" y="198" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="710" y="229" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                <rect key="frame" x="559" y="107" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="591" y="198" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                <rect key="frame" x="540" y="229" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                <rect key="frame" x="401" y="107" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="433" y="197" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                <rect key="frame" x="391" y="229" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                <rect key="frame" x="295" y="115" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                <rect key="frame" x="284" y="229" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="326" y="200" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b8c-KA-XG9">
                                 <rect key="frame" x="0.0" y="0.0" width="844" height="65"/>
                                 <subviews>
@@ -376,6 +300,9 @@
                                         <rect key="frame" x="760.33333333333337" y="15.333333333333332" width="53.666666666666629" height="34.333333333333343"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="닫기"/>
+                                        <connections>
+                                            <action selector="pushCloseButton" destination="Yu1-lM-nqp" eventType="touchUpInside" id="DJF-Pt-u0m"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -387,48 +314,183 @@
                                     <constraint firstAttribute="height" constant="65" id="f6P-ub-W0X"/>
                                 </constraints>
                             </view>
-                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="rXf-bu-L7n">
-                                <rect key="frame" x="80" y="107" width="100" height="206.33333333333337"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="588-bf-dxo">
+                                <rect key="frame" x="72" y="92.000000000000014" width="700" height="206.33333333333337"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                        <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="100" id="ikq-jt-cIn"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                        <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
-                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="100" id="6S4-ZP-zXa"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                        <rect key="frame" x="3" y="174.33333333333334" width="94" height="32"/>
-                                    </stepper>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="rXf-bu-L7n">
+                                        <rect key="frame" x="0.0" y="0.0" width="100" height="206.33333333333334"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                                <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="100" id="ikq-jt-cIn"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                                <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="100" id="6S4-ZP-zXa"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="3" y="174.33333333333331" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="pushStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="1sD-Vx-VS3"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="u3I-ly-h2G">
+                                        <rect key="frame" x="150" y="0.0" width="100" height="206.33333333333334"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
+                                                <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="100" id="7Tc-3n-cIw"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                                <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="100" id="S10-60-nP1"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="3" y="174.33333333333331" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="pushStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="wk2-Cs-sq9"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="olJ-lQ-qO1">
+                                        <rect key="frame" x="300" y="0.0" width="100" height="206.33333333333334"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
+                                                <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="100" id="Yrp-BO-DU7"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mhC-tN-ZWQ">
+                                                <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="100" id="kX4-6F-Bwb"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="fSD-DF-u7o">
+                                                <rect key="frame" x="3" y="174.33333333333331" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="pushStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="sv9-eS-l0i"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="xxd-hO-IPu">
+                                        <rect key="frame" x="450" y="0.0" width="100" height="206.33333333333334"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
+                                                <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="100" id="D9F-xR-nCj"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2C4-Un-lbA">
+                                                <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="100" id="tje-7t-eo7"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="DnZ-NO-X4Y">
+                                                <rect key="frame" x="3" y="174.33333333333331" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="pushStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="HYT-OF-Nfe"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="D0E-BB-ZuJ">
+                                        <rect key="frame" x="600" y="0.0" width="100" height="206.33333333333334"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
+                                                <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="100" id="vgt-kQ-6WV"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="8oa-O9-7aj">
+                                                <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="100" id="w2f-j4-MaG"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="aDz-cj-Hhe">
+                                                <rect key="frame" x="3" y="174.33333333333331" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="pushStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="cNd-lX-FBD"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="588-bf-dxo" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="IdH-lb-QiG"/>
+                            <constraint firstItem="b8c-KA-XG9" firstAttribute="trailing" secondItem="tKV-4l-Vtc" secondAttribute="trailing" id="MPu-Ej-BCD"/>
                             <constraint firstItem="b8c-KA-XG9" firstAttribute="top" secondItem="tKV-4l-Vtc" secondAttribute="top" id="ONC-hf-olc"/>
-                            <constraint firstItem="b8c-KA-XG9" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" id="boV-eW-PQE"/>
-                            <constraint firstItem="b8c-KA-XG9" firstAttribute="trailing" secondItem="gcO-Xb-kNs" secondAttribute="trailing" id="m7c-TI-jpb"/>
+                            <constraint firstItem="b8c-KA-XG9" firstAttribute="leading" secondItem="tKV-4l-Vtc" secondAttribute="leading" id="U4P-rN-GIC"/>
+                            <constraint firstItem="588-bf-dxo" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="wHN-zG-TXO"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="numberOfBanana" destination="gKu-86-RhI" id="X5W-5j-IfR"/>
-                        <outlet property="numberOfKiwi" destination="ZDv-1m-HBY" id="C7O-rQ-qky"/>
-                        <outlet property="numberOfMango" destination="YJI-ER-LJR" id="uw0-8p-c8A"/>
-                        <outlet property="numberOfPineapple" destination="MpT-VW-hCb" id="hAw-L3-cFo"/>
-                        <outlet property="numberOfStrawberry" destination="0yV-kn-zaT" id="QSI-Eh-p91"/>
+                        <outlet property="bananaStepper" destination="O5s-2N-3iP" id="eCJ-bi-snY"/>
+                        <outlet property="kiwiStepper" destination="DnZ-NO-X4Y" id="qwa-9c-fiY"/>
+                        <outlet property="mangoStepper" destination="aDz-cj-Hhe" id="SGY-bz-bQf"/>
+                        <outlet property="pineappleStepper" destination="fSD-DF-u7o" id="AaG-nV-J7X"/>
+                        <outlet property="stockOfBanana" destination="gKu-86-RhI" id="FWd-pT-RMk"/>
+                        <outlet property="stockOfKiwi" destination="2C4-Un-lbA" id="YEB-bJ-B5M"/>
+                        <outlet property="stockOfMango" destination="8oa-O9-7aj" id="yL7-8s-Hdm"/>
+                        <outlet property="stockOfPineapple" destination="mhC-tN-ZWQ" id="l2k-fO-Wdl"/>
+                        <outlet property="stockOfStrawberry" destination="0yV-kn-zaT" id="U41-qv-D5Y"/>
+                        <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="bbE-FQ-hil"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -491,6 +491,11 @@
                         <outlet property="stockOfPineapple" destination="mhC-tN-ZWQ" id="l2k-fO-Wdl"/>
                         <outlet property="stockOfStrawberry" destination="0yV-kn-zaT" id="U41-qv-D5Y"/>
                         <outlet property="strawberryStepper" destination="ZQk-f4-zrz" id="bbE-FQ-hil"/>
+                        <outletCollection property="Steppers" destination="ZQk-f4-zrz" collectionClass="NSMutableArray" id="8j3-Lq-XOj"/>
+                        <outletCollection property="Steppers" destination="O5s-2N-3iP" collectionClass="NSMutableArray" id="K7T-0f-Iec"/>
+                        <outletCollection property="Steppers" destination="fSD-DF-u7o" collectionClass="NSMutableArray" id="VYp-R6-iZi"/>
+                        <outletCollection property="Steppers" destination="DnZ-NO-X4Y" collectionClass="NSMutableArray" id="nix-Ou-kyd"/>
+                        <outletCollection property="Steppers" destination="aDz-cj-Hhe" collectionClass="NSMutableArray" id="FWg-xr-XXq"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="MainViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -287,33 +287,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b8c-KA-XG9">
-                                <rect key="frame" x="0.0" y="0.0" width="844" height="65"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="재고 수정" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gUD-By-EDw">
-                                        <rect key="frame" x="385" y="20.666666666666671" width="74.333333333333314" height="24"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f5G-MA-arm">
-                                        <rect key="frame" x="760.33333333333337" y="15.333333333333332" width="53.666666666666629" height="34.333333333333343"/>
-                                        <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" title="닫기"/>
-                                        <connections>
-                                            <action selector="pushCloseButton" destination="Yu1-lM-nqp" eventType="touchUpInside" id="DJF-Pt-u0m"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="gUD-By-EDw" firstAttribute="centerY" secondItem="b8c-KA-XG9" secondAttribute="centerY" id="Hbb-dt-QxJ"/>
-                                    <constraint firstItem="gUD-By-EDw" firstAttribute="centerX" secondItem="b8c-KA-XG9" secondAttribute="centerX" id="ZQ4-7W-vcX"/>
-                                    <constraint firstItem="f5G-MA-arm" firstAttribute="centerX" secondItem="b8c-KA-XG9" secondAttribute="centerX" constant="365" id="aNS-Fs-e1F"/>
-                                    <constraint firstItem="f5G-MA-arm" firstAttribute="centerY" secondItem="b8c-KA-XG9" secondAttribute="centerY" id="cKW-qe-FVe"/>
-                                    <constraint firstAttribute="height" constant="65" id="f6P-ub-W0X"/>
-                                </constraints>
-                            </view>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="588-bf-dxo">
                                 <rect key="frame" x="72" y="92.000000000000014" width="700" height="206.33333333333337"/>
                                 <subviews>
@@ -469,14 +442,18 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vel-Zv-bQE">
+                                <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <items>
+                                    <navigationItem title="Title" id="ZGO-uQ-vcf"/>
+                                </items>
+                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="588-bf-dxo" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="IdH-lb-QiG"/>
-                            <constraint firstItem="b8c-KA-XG9" firstAttribute="trailing" secondItem="tKV-4l-Vtc" secondAttribute="trailing" id="MPu-Ej-BCD"/>
-                            <constraint firstItem="b8c-KA-XG9" firstAttribute="top" secondItem="tKV-4l-Vtc" secondAttribute="top" id="ONC-hf-olc"/>
-                            <constraint firstItem="b8c-KA-XG9" firstAttribute="leading" secondItem="tKV-4l-Vtc" secondAttribute="leading" id="U4P-rN-GIC"/>
                             <constraint firstItem="588-bf-dxo" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="wHN-zG-TXO"/>
                         </constraints>
                     </view>
@@ -484,6 +461,7 @@
                         <outlet property="bananaStepper" destination="O5s-2N-3iP" id="eCJ-bi-snY"/>
                         <outlet property="kiwiStepper" destination="DnZ-NO-X4Y" id="qwa-9c-fiY"/>
                         <outlet property="mangoStepper" destination="aDz-cj-Hhe" id="SGY-bz-bQf"/>
+                        <outlet property="navigationBar" destination="ZGO-uQ-vcf" id="Ref-GR-plm"/>
                         <outlet property="pineappleStepper" destination="fSD-DF-u7o" id="AaG-nV-J7X"/>
                         <outlet property="stockOfBanana" destination="gKu-86-RhI" id="FWd-pT-RMk"/>
                         <outlet property="stockOfKiwi" destination="2C4-Un-lbA" id="YEB-bJ-B5M"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
-    <device id="retina6_0" orientation="landscape" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+    <device id="retina6_1" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -15,23 +15,23 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="16" y="98.999999999999986" width="812" height="136.66666666666663"/>
+                                <rect key="frame" x="16" y="112" width="864" height="145"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="160" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="160" height="110.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="118.5" width="160" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
+                                        <rect key="frame" x="176" y="0.0" width="160" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="160" height="110.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="118.5" width="160" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="136.66666666666666"/>
+                                        <rect key="frame" x="352" y="0.0" width="160" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.33333333333334" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="160" height="110.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="10" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.33333333333334" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="118.5" width="160" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="136.66666666666666"/>
+                                        <rect key="frame" x="528" y="0.0" width="160" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="160" height="110.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="118.5" width="160" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="136.66666666666666"/>
+                                        <rect key="frame" x="704" y="0.0" width="160" height="145"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="102.33333333333333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="160" height="110.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="149.66666666666666" height="26.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="118.5" width="160" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="16" y="255.66666666666666" width="812" height="80.333333333333343"/>
+                                <rect key="frame" x="16" y="277" width="864" height="83"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="812" height="36"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="864" height="37.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="315.33333333333331" height="36"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="336" height="37.5"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36"/>
+                                                <rect key="frame" x="352" y="0.0" width="160" height="37.5"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="496.66666666666663" y="0.0" width="315.33333333333337" height="36"/>
+                                                <rect key="frame" x="528" y="0.0" width="336" height="37.5"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -148,13 +148,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="44.000000000000028" width="812" height="36.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="45.5" width="864" height="37.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="812" height="36.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="864" height="37.5"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="149.66666666666666" height="36.333333333333336"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="160" height="37.5"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -165,7 +165,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="165.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
+                                                        <rect key="frame" x="176" y="0.0" width="160" height="37.5"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -176,7 +176,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="331.33333333333331" y="0.0" width="149.33333333333331" height="36.333333333333336"/>
+                                                        <rect key="frame" x="352" y="0.0" width="160" height="37.5"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -187,7 +187,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="496.66666666666669" y="0.0" width="149.66666666666669" height="36.333333333333336"/>
+                                                        <rect key="frame" x="528" y="0.0" width="160" height="37.5"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -198,7 +198,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="662.33333333333337" y="0.0" width="149.66666666666663" height="36.333333333333336"/>
+                                                        <rect key="frame" x="704" y="0.0" width="160" height="37.5"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -267,7 +267,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="47" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="48" width="896" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -284,167 +284,166 @@
             <objects>
                 <viewController storyboardIdentifier="ChangeStock" id="Yu1-lM-nqp" customClass="ChangeStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="588-bf-dxo">
-                                <rect key="frame" x="72" y="92.000000000000014" width="700" height="206.33333333333337"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="588-bf-dxo">
+                                <rect key="frame" x="16" y="113" width="864" height="202"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="rXf-bu-L7n">
-                                        <rect key="frame" x="0.0" y="0.0" width="100" height="206.33333333333334"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="rXf-bu-L7n">
+                                        <rect key="frame" x="0.0" y="0.0" width="149" height="202"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="100" id="ikq-jt-cIn"/>
-                                                </constraints>
+                                                <rect key="frame" x="15" y="0.0" width="119" height="86"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
+                                                <rect key="frame" x="15" y="106" width="119" height="42"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="100" id="6S4-ZP-zXa"/>
-                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="3" y="174.33333333333331" width="94" height="32"/>
+                                                <rect key="frame" x="27.5" y="168" width="94" height="34"/>
                                                 <connections>
                                                     <action selector="pushStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="1sD-Vx-VS3"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="dCK-AJ-zGU" firstAttribute="leading" secondItem="rXf-bu-L7n" secondAttribute="leading" constant="15" id="HIh-Yt-zym"/>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="leading" secondItem="rXf-bu-L7n" secondAttribute="leading" constant="15" id="Jbo-Rw-kuL"/>
+                                            <constraint firstAttribute="trailing" secondItem="0yV-kn-zaT" secondAttribute="trailing" constant="15" id="cNM-DN-9V8"/>
+                                            <constraint firstAttribute="trailing" secondItem="dCK-AJ-zGU" secondAttribute="trailing" constant="15" id="sos-F0-fX9"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="u3I-ly-h2G">
-                                        <rect key="frame" x="150" y="0.0" width="100" height="206.33333333333334"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="u3I-ly-h2G">
+                                        <rect key="frame" x="179" y="0.0" width="148.5" height="202"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="100" id="7Tc-3n-cIw"/>
-                                                </constraints>
+                                                <rect key="frame" x="15" y="0.0" width="118.5" height="86"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
+                                                <rect key="frame" x="15" y="106" width="118.5" height="42"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="100" id="S10-60-nP1"/>
-                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="3" y="174.33333333333331" width="94" height="32"/>
+                                                <rect key="frame" x="27" y="168" width="94" height="34"/>
                                                 <connections>
                                                     <action selector="pushStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="wk2-Cs-sq9"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="gKu-86-RhI" secondAttribute="trailing" constant="15" id="5qu-7V-X5E"/>
+                                            <constraint firstItem="y33-ND-gz2" firstAttribute="leading" secondItem="u3I-ly-h2G" secondAttribute="leading" constant="15" id="5vP-ha-X4R"/>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="leading" secondItem="u3I-ly-h2G" secondAttribute="leading" constant="15" id="aCC-2E-zUC"/>
+                                            <constraint firstAttribute="trailing" secondItem="y33-ND-gz2" secondAttribute="trailing" constant="15" id="t5N-QY-AwN"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="olJ-lQ-qO1">
-                                        <rect key="frame" x="300" y="0.0" width="100" height="206.33333333333334"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="olJ-lQ-qO1">
+                                        <rect key="frame" x="357.5" y="0.0" width="149" height="202"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="100" id="Yrp-BO-DU7"/>
-                                                </constraints>
+                                                <rect key="frame" x="15" y="0.0" width="119" height="86"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mhC-tN-ZWQ">
-                                                <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
+                                                <rect key="frame" x="15" y="106" width="119" height="42"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="100" id="kX4-6F-Bwb"/>
-                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="fSD-DF-u7o">
-                                                <rect key="frame" x="3" y="174.33333333333331" width="94" height="32"/>
+                                                <rect key="frame" x="27.5" y="168" width="94" height="34"/>
                                                 <connections>
                                                     <action selector="pushStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="sv9-eS-l0i"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="mhC-tN-ZWQ" secondAttribute="trailing" constant="15" id="5iv-wh-b4W"/>
+                                            <constraint firstItem="mhC-tN-ZWQ" firstAttribute="leading" secondItem="olJ-lQ-qO1" secondAttribute="leading" constant="15" id="Gt9-hu-jHj"/>
+                                            <constraint firstAttribute="trailing" secondItem="rac-Ji-vZK" secondAttribute="trailing" constant="15" id="hH1-Hz-cU6"/>
+                                            <constraint firstItem="rac-Ji-vZK" firstAttribute="leading" secondItem="olJ-lQ-qO1" secondAttribute="leading" constant="15" id="lLn-V6-HgB"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="xxd-hO-IPu">
-                                        <rect key="frame" x="450" y="0.0" width="100" height="206.33333333333334"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="xxd-hO-IPu">
+                                        <rect key="frame" x="536.5" y="0.0" width="148.5" height="202"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="100" id="D9F-xR-nCj"/>
-                                                </constraints>
+                                                <rect key="frame" x="15" y="0.0" width="118.5" height="86"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2C4-Un-lbA">
-                                                <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
+                                                <rect key="frame" x="15" y="106" width="118.5" height="42"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="100" id="tje-7t-eo7"/>
-                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="DnZ-NO-X4Y">
-                                                <rect key="frame" x="3" y="174.33333333333331" width="94" height="32"/>
+                                                <rect key="frame" x="27.5" y="168" width="94" height="34"/>
                                                 <connections>
                                                     <action selector="pushStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="HYT-OF-Nfe"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="2C4-Un-lbA" secondAttribute="trailing" constant="15" id="4Se-LB-J2X"/>
+                                            <constraint firstAttribute="trailing" secondItem="EHe-D1-1xN" secondAttribute="trailing" constant="15" id="594-aO-BGJ"/>
+                                            <constraint firstItem="EHe-D1-1xN" firstAttribute="leading" secondItem="xxd-hO-IPu" secondAttribute="leading" constant="15" id="9jM-WR-H6U"/>
+                                            <constraint firstItem="2C4-Un-lbA" firstAttribute="leading" secondItem="xxd-hO-IPu" secondAttribute="leading" constant="15" id="nM4-Oj-RPi"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="D0E-BB-ZuJ">
-                                        <rect key="frame" x="600" y="0.0" width="100" height="206.33333333333334"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="D0E-BB-ZuJ">
+                                        <rect key="frame" x="715" y="0.0" width="149" height="202"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="100" id="vgt-kQ-6WV"/>
-                                                </constraints>
+                                                <rect key="frame" x="15" y="0.0" width="119" height="86"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="8oa-O9-7aj">
-                                                <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
+                                                <rect key="frame" x="15" y="106" width="119" height="42"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="100" id="w2f-j4-MaG"/>
-                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="aDz-cj-Hhe">
-                                                <rect key="frame" x="3" y="174.33333333333331" width="94" height="32"/>
+                                                <rect key="frame" x="27.5" y="168" width="94" height="34"/>
                                                 <connections>
                                                     <action selector="pushStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="cNd-lX-FBD"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="w1F-9o-qJR" secondAttribute="trailing" constant="15" id="1gH-1w-WkR"/>
+                                            <constraint firstAttribute="trailing" secondItem="8oa-O9-7aj" secondAttribute="trailing" constant="15" id="Vo2-pV-j0n"/>
+                                            <constraint firstItem="8oa-O9-7aj" firstAttribute="leading" secondItem="D0E-BB-ZuJ" secondAttribute="leading" constant="15" id="nbz-Hd-kh6"/>
+                                            <constraint firstItem="w1F-9o-qJR" firstAttribute="leading" secondItem="D0E-BB-ZuJ" secondAttribute="leading" constant="15" id="sx4-nv-uon"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vel-Zv-bQE">
-                                <rect key="frame" x="0.0" y="0.0" width="844" height="44"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <navigationBar contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vel-Zv-bQE">
+                                <rect key="frame" x="0.0" y="0.0" width="896" height="32"/>
                                 <items>
                                     <navigationItem title="Title" id="ZGO-uQ-vcf"/>
                                 </items>
@@ -453,8 +452,13 @@
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="588-bf-dxo" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="IdH-lb-QiG"/>
-                            <constraint firstItem="588-bf-dxo" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="wHN-zG-TXO"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="bottom" secondItem="588-bf-dxo" secondAttribute="bottom" constant="65" id="7uJ-ep-ZbT"/>
+                            <constraint firstItem="vel-Zv-bQE" firstAttribute="top" secondItem="gcO-Xb-kNs" secondAttribute="top" id="OKj-pM-hDA"/>
+                            <constraint firstItem="588-bf-dxo" firstAttribute="top" secondItem="gcO-Xb-kNs" secondAttribute="top" constant="65" id="Qc5-6I-L7y"/>
+                            <constraint firstItem="vel-Zv-bQE" firstAttribute="leading" secondItem="tKV-4l-Vtc" secondAttribute="leading" id="Y9s-XV-2pj"/>
+                            <constraint firstItem="vel-Zv-bQE" firstAttribute="centerX" secondItem="588-bf-dxo" secondAttribute="centerX" id="n4p-Gv-bQC"/>
+                            <constraint firstItem="588-bf-dxo" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="16" id="she-Tt-2bq"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" secondItem="588-bf-dxo" secondAttribute="trailing" constant="16" id="uAU-eS-4dQ"/>
                         </constraints>
                     </view>
                     <connections>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -239,7 +239,6 @@
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
                                 <action selector="ClickChangeStock:" destination="BYZ-38-t0r" id="9TO-xP-cmT"/>
-                                <segue destination="Yu1-lM-nqp" kind="show" id="xUH-7Y-UVq"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -288,14 +288,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                <rect key="frame" x="590" y="65" width="75" height="83.666666666666671"/>
+                                <rect key="frame" x="720" y="107" width="75" height="83.666666666666671"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="622" y="156" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="752" y="198" width="11.666666666666664" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -303,18 +303,18 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="580" y="187" width="94" height="32"/>
+                                <rect key="frame" x="710" y="229" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
+                                <rect key="frame" x="559" y="107" width="75" height="83.666666666666671"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="461" y="156" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="591" y="198" width="11.666666666666664" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -322,18 +322,18 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                <rect key="frame" x="410" y="187" width="94" height="32"/>
+                                <rect key="frame" x="540" y="229" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
+                                <rect key="frame" x="401" y="107" width="75" height="83.666666666666671"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="303" y="155" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="433" y="197" width="11.666666666666664" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
@@ -341,52 +341,88 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                <rect key="frame" x="261" y="187" width="94" height="32"/>
+                                <rect key="frame" x="391" y="229" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
+                                <rect key="frame" x="295" y="115" width="75" height="83.666666666666671"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                <rect key="frame" x="154" y="187" width="94" height="32"/>
+                                <rect key="frame" x="284" y="229" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="98" y="161" width="11.666666666666664" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                <rect key="frame" x="60" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="196" y="158" width="11.666666666666664" height="23"/>
+                                <rect key="frame" x="326" y="200" width="11.666666666666664" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                <rect key="frame" x="50" y="192" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stepper>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b8c-KA-XG9">
+                                <rect key="frame" x="0.0" y="0.0" width="844" height="65"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="재고 수정" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gUD-By-EDw">
+                                        <rect key="frame" x="385" y="20.666666666666671" width="74.333333333333314" height="24"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f5G-MA-arm">
+                                        <rect key="frame" x="760.33333333333337" y="15.333333333333332" width="53.666666666666629" height="34.333333333333343"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="닫기"/>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="gUD-By-EDw" firstAttribute="centerY" secondItem="b8c-KA-XG9" secondAttribute="centerY" id="Hbb-dt-QxJ"/>
+                                    <constraint firstItem="gUD-By-EDw" firstAttribute="centerX" secondItem="b8c-KA-XG9" secondAttribute="centerX" id="ZQ4-7W-vcX"/>
+                                    <constraint firstItem="f5G-MA-arm" firstAttribute="centerX" secondItem="b8c-KA-XG9" secondAttribute="centerX" constant="365" id="aNS-Fs-e1F"/>
+                                    <constraint firstItem="f5G-MA-arm" firstAttribute="centerY" secondItem="b8c-KA-XG9" secondAttribute="centerY" id="cKW-qe-FVe"/>
+                                    <constraint firstAttribute="height" constant="65" id="f6P-ub-W0X"/>
+                                </constraints>
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="rXf-bu-L7n">
+                                <rect key="frame" x="80" y="107" width="100" height="206.33333333333337"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                        <rect key="frame" x="0.0" y="0.0" width="100" height="83.666666666666671"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="100" id="ikq-jt-cIn"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                        <rect key="frame" x="0.0" y="108.66666666666667" width="100" height="40.666666666666671"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="100" id="6S4-ZP-zXa"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                        <rect key="frame" x="3" y="174.33333333333334" width="94" height="32"/>
+                                    </stepper>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="b8c-KA-XG9" firstAttribute="top" secondItem="tKV-4l-Vtc" secondAttribute="top" id="ONC-hf-olc"/>
+                            <constraint firstItem="b8c-KA-XG9" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" id="boV-eW-PQE"/>
+                            <constraint firstItem="b8c-KA-XG9" firstAttribute="trailing" secondItem="gcO-Xb-kNs" secondAttribute="trailing" id="m7c-TI-jpb"/>
+                        </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
                     <connections>
                         <outlet property="numberOfBanana" destination="gKu-86-RhI" id="X5W-5j-IfR"/>
                         <outlet property="numberOfKiwi" destination="ZDv-1m-HBY" id="C7O-rQ-qky"/>
@@ -397,7 +433,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1553" y="92"/>
+            <point key="canvasLocation" x="1552.6066350710901" y="90.769230769230759"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
@wongbingg
웡빙! 드디어 Step3 PR입니다! 웡빙의 날카로운 리뷰를 볼 때마다 무릎을 탁 친답니다ㅎ
이번 리뷰도 잘부탁드리겠습니다!😎

## 고민했던 점 
### 1. ```stepper```의 초기화 위치
stepper의 값을 현재 과일 재고 수량으로 초기화하기 위해 ```@IBAction func pushStepper(_ sender: UIStepper)```에서 ```stepper.value```값을 변경해주었습니다. 하지만```@IBAction func pushStepper(_ sender: UIStepper)```로 초기화할 경우 ```stepper```를 누를 때마다 초기화되는 문제점이 발견되었습니다. 이를 해결하기 위해 ViewController가 초기화될 때, 즉 viewDidLoad에 ```stepper.value```를 함께 초기화해주었습니다.
```swift
override func viewDidLoad() {
    super.viewDidLoad()
    displayStock()
    initializeSteppers()
    setUpNavigationItem()
}
```

### 2. IBOutlet Collection
Stepper의 초기화를 한 번에 구현하기 위해 ```initializeSteppers()```메서드에서 모든 Stepper에 접근할 수 있도록 IBOutlet Collection에 담아주었습니다.

```swift
@IBOutlet var steppers: [UIStepper]!

func initializeSteppers() {
    for stepper in steppers {
        if let selectedFruit = identifyRelatedFruit(of: stepper),
           let initialValue = fruitsStock[selectedFruit] {
                stepper.transform = stepper.transform.scaledBy(x: 1.0, y: 1.0)
                stepper.value = Double(initialValue)
        }
    }
}
```

### 3. Navigation Bar 
요구사항 화면에는 NavigationBar의 크기가 저희가 사용하는 NavigationBar보다 컸습니다. 처음에는 요구사항에 맞춰서 NavigationBar대신 View를 이용해서 만들었습니다. 하지만 근본적인 원인을 해결한거 같지 않아서 NavigationBar를 사용하여 height 값을 높여주려 했습니다. height값을 올려주기 위해 조사해본 결과 iOS11 이상부터는 높이 커스터마이징을 할 수 없다라는 결론이 나와 height값을 올려주지 못했습니다.

### 4. Notification
```ChangeStockViewController```에서 ```MainViewController```으로 화면전환 시 변경된 사항을 전달하기 위해 ViewWillAppear를 사용하려 했습니다. 하지만 Modal의 경우 Full-Screen Modal이 아닐 경우 이전 화면으로 돌아갈 때, 이전 화면이 새로 표현되는 것이 아니기 때문에 ViewWillAppear, ViewDidAppear 등의 메서드를 오버라이딩할 수 없었습니다. 이를 해결하기 위해 Notification을 활용하여 ```ChangeStockViewController```의 변경사항이 있을 시 과일의 재고를 갱신했습니다. <br/> <br/> 변경사항의 ```post``` 시점은 재고 변경사항을 한 번에 전달할 수 있도록 ```viewWillDisappear```메서드를 override하여 정해주었습니다.


### 5. 재고변경 뷰컨에서 레이블을 각각 초기화 or 모두 초기화
```displayStock()```메서드를 통해 모든 Label을 초기화 할 수 있지만 하나의 Stepper의 IBAction으로 재고의 변경이 있을 때, 전체를 초기화하기 보다는 해당하는 과일의 재고만 업데이트 할 수 있도록 ```pushStepper(_:)```메서드에서 해당 Label을 업데이트 해주었습니다. 
```swift
@IBAction func pushStepper(_ sender: UIStepper) {
        guard let fruitsLabel = identifyRelatedLabel(of: sender),
              let fruit = identifyRelatedFruit(of: sender) else { return }
        
        FruitStore.shared.fruitsStock[fruit] = Int(sender.value)
        fruitsLabel.text = Int(sender.value).description
    }
```