### PR TITLE
쥬스 메이커 [STEP 1] Mint, Zion

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		92BE81552A0CE6A9005A66F3 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BE81542A0CE6A9005A66F3 /* Fruit.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		92BE81542A0CE6A9005A66F3 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -56,6 +58,7 @@
 			children = (
 				C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */,
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
+				92BE81542A0CE6A9005A66F3 /* Fruit.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -167,6 +170,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92BE81552A0CE6A9005A66F3 /* Fruit.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -7,12 +7,9 @@
 import UIKit
 
 class ViewController: UIViewController {
-
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
     }
-
-
 }
 

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -1,0 +1,14 @@
+//
+//  Fruit.swift
+//  JuiceMaker
+//
+//  Created by Zion, Mint = 형민트 on 2023/05/11.
+//
+
+enum Fruit {
+    case strawberry
+    case banana
+    case pineapple
+    case kiwi
+    case mango
+}

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -13,41 +13,27 @@ enum Fruit {
 }
 
 class FruitStore {
-    private var strawberry: Int = 10
-    private var banana: Int = 10
-    private var pineapple: Int = 10
-    private var kiwi: Int = 10
-    private var mango: Int = 10
+    private var fruitStocks: [Fruit : Int] = [.strawberry : 10,
+                                             .banana : 10,
+                                             .pineapple : 10,
+                                             .kiwi : 10,
+                                             .mango : 10]
     
     func verifyFruitCount(_ fruit: Fruit, count: Int) -> Bool {
-        switch fruit {
-        case .strawberry:
-            return strawberry >= count ? true : false
-        case .banana:
-            return banana >= count ? true : false
-        case .pineapple:
-            return pineapple >= count ? true : false
-        case .kiwi:
-            return kiwi >= count ? true : false
-        case .mango:
-            return mango >= count ? true : false
+        guard let stock = fruitStocks[fruit] else {
+            return false
         }
+        
+        return stock >= count ? true : false
     }
     
     func changeFruitCount(_ fruit: Fruit, count: Int, isUseFruit: Bool = true) {
-        let amount = isUseFruit ? (count * -1) : count
-        
-        switch fruit {
-        case .strawberry:
-            strawberry += amount
-        case .banana:
-            banana += amount
-        case .pineapple:
-            pineapple += amount
-        case .kiwi:
-            kiwi += amount
-        case .mango:
-            mango += amount
+        guard let stock = fruitStocks[fruit] else {
+            return
         }
+        
+        let fruitAmount = isUseFruit ? (count * -1) : count
+        
+        fruitStocks[fruit] = stock + fruitAmount
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -35,19 +35,19 @@ class FruitStore {
     }
     
     func changeFruitCount(_ fruit: Fruit, count: Int, isUseFruit: Bool = true) {
-        let fruitCount = isUseFruit ? count * (-1) : count
+        let amount = isUseFruit ? (count * -1) : count
         
         switch fruit {
         case .strawberry:
-            strawberry += fruitCount
+            strawberry += amount
         case .banana:
-            banana += fruitCount
+            banana += amount
         case .pineapple:
-            pineapple += fruitCount
+            pineapple += amount
         case .kiwi:
-            kiwi += fruitCount
+            kiwi += amount
         case .mango:
-            mango += fruitCount
+            mango += amount
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -23,6 +23,21 @@ class FruitStore {
     private var kiwi: Int = 10
     private var mango: Int = 10
     
+    func verifyFruitCount(_ fruit: Fruit, count: Int) -> Bool {
+        switch fruit {
+        case .strawberry:
+            return strawberry >= count ? true : false
+        case .banana:
+            return banana >= count ? true : false
+        case .pineapple:
+            return pineapple >= count ? true : false
+        case .kiwi:
+            return kiwi >= count ? true : false
+        case .mango:
+            return mango >= count ? true : false
+        }
+    }
+    
     func changeFruitCount(_ fruit: Fruit, count: Int) {
         switch fruit {
         case .strawberry:

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -6,7 +6,35 @@
 
 import Foundation
 
+enum Fruit {
+    case strawberry
+    case banana
+    case pineapple
+    case kiwi
+    case mango
+}
+
+
 // 과일 저장소 타입
 class FruitStore {
+    private var strawberry: Int = 10
+    private var banana: Int = 10
+    private var pineapple: Int = 10
+    private var kiwi: Int = 10
+    private var mango: Int = 10
     
+    func changeFruitCount(_ fruit: Fruit, count: Int) {
+        switch fruit {
+        case .strawberry:
+            strawberry -= count
+        case .banana:
+            banana -= count
+        case .pineapple:
+            pineapple -= count
+        case .kiwi:
+            kiwi -= count
+        case .mango:
+            mango -= count
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -4,8 +4,6 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
-import Foundation
-
 enum Fruit {
     case strawberry
     case banana
@@ -14,8 +12,6 @@ enum Fruit {
     case mango
 }
 
-
-// 과일 저장소 타입
 class FruitStore {
     private var strawberry: Int = 10
     private var banana: Int = 10

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -34,18 +34,20 @@ class FruitStore {
         }
     }
     
-    func changeFruitCount(_ fruit: Fruit, count: Int) {
+    func changeFruitCount(_ fruit: Fruit, count: Int, isUseFruit: Bool = true) {
+        let fruitCount = isUseFruit ? count * (-1) : count
+        
         switch fruit {
         case .strawberry:
-            strawberry -= count
+            strawberry += fruitCount
         case .banana:
-            banana -= count
+            banana += fruitCount
         case .pineapple:
-            pineapple -= count
+            pineapple += fruitCount
         case .kiwi:
-            kiwi -= count
+            kiwi += fruitCount
         case .mango:
-            mango -= count
+            mango += fruitCount
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -4,35 +4,23 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
-enum Fruit {
-    case strawberry
-    case banana
-    case pineapple
-    case kiwi
-    case mango
-}
-
-class FruitStore {
-    private var fruitStocks: [Fruit : Int] = [.strawberry : 10,
-                                             .banana : 10,
-                                             .pineapple : 10,
-                                             .kiwi : 10,
-                                             .mango : 10]
+final class FruitStore {
+    private var fruitStocks: [Fruit : Int] 
     
-    func verifyFruitCount(_ fruit: Fruit, count: Int) -> Bool {
-        guard let stock = fruitStocks[fruit] else {
-            return false
-        }
+    init(fruitStocks: [Fruit : Int]) {
+        self.fruitStocks = fruitStocks
+    }
+    
+    func isEnoughFruits(_ fruit: Fruit, count: Int) -> Bool {
+        guard let stock = fruitStocks[fruit] else { return false }
         
-        return stock >= count ? true : false
+        return stock >= count
     }
     
     func changeFruitCount(_ fruit: Fruit, count: Int, isUseFruit: Bool = true) {
-        guard let stock = fruitStocks[fruit] else {
-            return
-        }
+        guard let stock = fruitStocks[fruit] else { return }
         
-        let fruitAmount = isUseFruit ? (count * -1) : count
+        let fruitAmount = isUseFruit ? -count : count
         
         fruitStocks[fruit] = stock + fruitAmount
     }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -15,52 +15,38 @@ enum Menu {
 }
 
 struct JuiceMaker {
+    typealias Recipe = [(Fruit, Int)]
     private let store: FruitStore
     
     init(fruitStore: FruitStore) {
         self.store = fruitStore
     }
-    
-    typealias Recipe = [(Fruit, Int)]
-    
-    let strawberryJuiceRecipe: Recipe = [(.strawberry, 16)]
-    let bananaJuiceRecipe: Recipe = [(.banana, 2)]
-    let pineappleJuiceRecipe: Recipe = [(.pineapple, 2)]
-    let kiwiJuiceRecipe: Recipe = [(.kiwi, 3)]
-    let mangoJuiceRecipe: Recipe = [(.mango, 3)]
-    let strawberryAndBananaJuice: Recipe = [(.strawberry, 10), (.banana, 1)]
-    let mangoAndKiwiJuice: Recipe = [(.mango, 2), (.kiwi, 1)]
+
+    private func getRecipe(_ menu: Menu) -> Recipe {
+        switch menu {
+            case .strawberryJuice:
+                return [(.strawberry, 16)]
+            case .bananaJuice:
+                return [(.banana, 2)]
+            case .pineappleJuice:
+                return [(.pineapple, 2)]
+            case .kiwiJuice:
+                return [(.kiwi, 3)]
+            case .mangoJuice:
+                return [(.mango, 3)]
+            case .strawberryAndBananaJuice:
+                return [(.strawberry, 10), (.banana, 1)]
+            case .mangoAndKiwiJuice:
+                return [(.mango, 2), (.kiwi, 1)]
+        }
+    }
     
     func makeJuice(menu: Menu) -> Bool {
-        let isSuccess: Bool
+        let recipe = getRecipe(menu)
         
-        switch menu {
-        case .strawberryJuice:
-            isSuccess = followRecipe(strawberryJuiceRecipe)
-        case .bananaJuice:
-            isSuccess = followRecipe(bananaJuiceRecipe)
-        case .pineappleJuice:
-            isSuccess = followRecipe(pineappleJuiceRecipe)
-        case .kiwiJuice:
-            isSuccess = followRecipe(kiwiJuiceRecipe)
-        case .mangoJuice:
-            isSuccess = followRecipe(mangoJuiceRecipe)
-        case .strawberryAndBananaJuice:
-            isSuccess = followRecipe(strawberryAndBananaJuice)
-        case .mangoAndKiwiJuice:
-            isSuccess = followRecipe(mangoAndKiwiJuice)
-        }
-        
-        return isSuccess
-    }
-}
+        guard recipe.allSatisfy({ store.verifyFruitCount($0, count: $1) }) else { return false }
 
-// MARK: - Make Juice
-extension JuiceMaker {
-    private func followRecipe(_ receipe: [(fruit: Fruit, count: Int)]) -> Bool {
-        guard receipe.allSatisfy({ store.verifyFruitCount($0, count: $1) }) else { return false }
-
-        receipe.forEach { store.changeFruitCount($0, count: $1) }
+        recipe.forEach { store.changeFruitCount($0, count: $1) }
         return true
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -1,21 +1,21 @@
 //
 //  JuiceMaker - JuiceMaker.swift
-//  Created by Zion, Mint.
+//  Created by yagom.
 //  Copyright © yagom academy. All rights reserved.
 //
 
-enum Menu {
-    case strawberryJuice
-    case bananaJuice
-    case pineappleJuice
-    case kiwiJuice
-    case mangoJuice
-    case strawberryAndBananaJuice
-    case mangoAndKiwiJuice
-}
-
 struct JuiceMaker {
-    typealias Recipe = [(Fruit, Int)]
+    enum Menu {
+        case strawberryJuice
+        case bananaJuice
+        case pineappleJuice
+        case kiwiJuice
+        case mangoJuice
+        case strawberryAndBananaJuice
+        case mangoAndKiwiJuice
+    }
+    
+    typealias Recipe = [(fruit: Fruit, amount: Int)]
     private let store: FruitStore
     
     init(fruitStore: FruitStore) {
@@ -41,10 +41,10 @@ struct JuiceMaker {
         }
     }
     
-    func makeJuice(menu: Menu) -> Bool {
+    func canMakeJuice(menu: Menu) -> Bool {
         let recipe = provideRecipe(menu)
         
-        guard recipe.allSatisfy({ store.verifyFruitCount($0, count: $1) }) else { return false }
+        guard recipe.allSatisfy({ store.isEnoughFruits($0, count: $1) }) else { return false }
 
         recipe.forEach { store.changeFruitCount($0, count: $1) }
         return true

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -6,7 +6,42 @@
 
 import Foundation
 
+enum Menu {
+    case strawberryJuice
+    case bananaJuice
+    case pineappleJuice
+    case strawberryAndBananaJuice
+    case kiwiJuice
+    case mangoJuice
+    case mangoAndKiwiJuice
+}
+
 // 쥬스 메이커 타입
 struct JuiceMaker {
+    private let store: FruitStore
     
+    init(fruitStore: FruitStore) {
+        self.store = fruitStore
+    }
+    
+    func makeFruitJuice(menu: Menu) {
+        switch menu {
+        case .strawberryJuice:
+            store.changeFruitCount(.strawberry, count: 16)
+        case .bananaJuice:
+            store.changeFruitCount(.banana, count: 2)
+        case .pineappleJuice:
+            store.changeFruitCount(.pineapple, count: 2)
+        case .strawberryAndBananaJuice:
+            store.changeFruitCount(.strawberry, count: 10)
+            store.changeFruitCount(.banana, count: 2)
+        case .kiwiJuice:
+            store.changeFruitCount(.kiwi, count: 3)
+        case .mangoJuice:
+            store.changeFruitCount(.mango, count: 3)
+        case .mangoAndKiwiJuice:
+            store.changeFruitCount(.mango, count: 2)
+            store.changeFruitCount(.kiwi, count: 1)
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -27,21 +27,33 @@ struct JuiceMaker {
     func makeFruitJuice(menu: Menu) {
         switch menu {
         case .strawberryJuice:
-            store.changeFruitCount(.strawberry, count: 16)
+            makeJuice(menu: .strawberry, count: 16)
         case .bananaJuice:
-            store.changeFruitCount(.banana, count: 2)
+            makeJuice(menu: .banana, count: 2)
         case .pineappleJuice:
-            store.changeFruitCount(.pineapple, count: 2)
+            makeJuice(menu: .pineapple, count: 2)
         case .strawberryAndBananaJuice:
-            store.changeFruitCount(.strawberry, count: 10)
-            store.changeFruitCount(.banana, count: 2)
+            makeCollaborateJuice(main: (.strawberry, 10), sub: (.banana, 1))
         case .kiwiJuice:
-            store.changeFruitCount(.kiwi, count: 3)
+            makeJuice(menu: .kiwi, count: 3)
         case .mangoJuice:
-            store.changeFruitCount(.mango, count: 3)
+            makeJuice(menu: .mango, count: 3)
         case .mangoAndKiwiJuice:
-            store.changeFruitCount(.mango, count: 2)
-            store.changeFruitCount(.kiwi, count: 1)
+            makeCollaborateJuice(main: (.mango, 2), sub: (.kiwi, 1))
+        }
+    }
+    
+    func makeJuice(menu: Fruit, count: Int) {
+        if store.verifyFruitCount(menu, count: count) {
+            store.changeFruitCount(menu, count: count)
+        }
+    }
+    
+    func makeCollaborateJuice(main: (fruit: Fruit, count: Int), sub: (fruit: Fruit, count: Int)) {
+        if store.verifyFruitCount(main.fruit, count: main.count) &&
+            store.verifyFruitCount(sub.fruit, count: sub.count) {
+            store.changeFruitCount(main.fruit, count: main.count)
+            store.changeFruitCount(sub.fruit, count: sub.count)
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -2,9 +2,7 @@
 //  JuiceMaker - JuiceMaker.swift
 //  Created by yagom. 
 //  Copyright © yagom academy. All rights reserved.
-// 
-
-import Foundation
+//
 
 enum Menu {
     case strawberryJuice
@@ -16,7 +14,6 @@ enum Menu {
     case mangoAndKiwiJuice
 }
 
-// 쥬스 메이커 타입
 struct JuiceMaker {
     private let store: FruitStore
     
@@ -24,36 +21,51 @@ struct JuiceMaker {
         self.store = fruitStore
     }
     
-    func makeFruitJuice(menu: Menu) {
+    func orderJuice(menu: Menu) -> Bool {
+        let isSuccess: Bool
+        
         switch menu {
         case .strawberryJuice:
-            makeJuice(menu: .strawberry, count: 16)
+            isSuccess = makeJuice(menu: .strawberry, count: 16)
         case .bananaJuice:
-            makeJuice(menu: .banana, count: 2)
+            isSuccess = makeJuice(menu: .banana, count: 2)
         case .pineappleJuice:
-            makeJuice(menu: .pineapple, count: 2)
+            isSuccess = makeJuice(menu: .pineapple, count: 2)
         case .strawberryAndBananaJuice:
-            makeCollaborateJuice(main: (.strawberry, 10), sub: (.banana, 1))
+            isSuccess = makeCollaborateJuice(main: (.strawberry, 10), sub: (.banana, 1))
         case .kiwiJuice:
-            makeJuice(menu: .kiwi, count: 3)
+            isSuccess = makeJuice(menu: .kiwi, count: 3)
         case .mangoJuice:
-            makeJuice(menu: .mango, count: 3)
+            isSuccess = makeJuice(menu: .mango, count: 3)
         case .mangoAndKiwiJuice:
-            makeCollaborateJuice(main: (.mango, 2), sub: (.kiwi, 1))
+            isSuccess = makeCollaborateJuice(main: (.mango, 2), sub: (.kiwi, 1))
         }
+        
+        return isSuccess
     }
     
-    func makeJuice(menu: Fruit, count: Int) {
-        if store.verifyFruitCount(menu, count: count) {
-            store.changeFruitCount(menu, count: count)
+
+}
+
+// MARK: - Make Juice
+extension JuiceMaker {
+    private func makeJuice(menu: Fruit, count: Int) -> Bool {
+        guard store.verifyFruitCount(menu, count: count) else {
+            return false
         }
+        
+        store.changeFruitCount(menu, count: count)
+        return true
     }
     
-    func makeCollaborateJuice(main: (fruit: Fruit, count: Int), sub: (fruit: Fruit, count: Int)) {
-        if store.verifyFruitCount(main.fruit, count: main.count) &&
-            store.verifyFruitCount(sub.fruit, count: sub.count) {
-            store.changeFruitCount(main.fruit, count: main.count)
-            store.changeFruitCount(sub.fruit, count: sub.count)
+    private func makeCollaborateJuice(main: (fruit: Fruit, count: Int), sub: (fruit: Fruit, count: Int)) -> Bool {
+        guard store.verifyFruitCount(main.fruit, count: main.count),
+              store.verifyFruitCount(sub.fruit, count: sub.count) else {
+            return false
         }
+        
+        store.changeFruitCount(main.fruit, count: main.count)
+        store.changeFruitCount(sub.fruit, count: sub.count)
+        return true
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -44,9 +44,11 @@ struct JuiceMaker {
     func canMakeJuice(menu: Menu) -> Bool {
         let recipe = provideRecipe(menu)
         
-        guard recipe.allSatisfy({ store.isEnoughFruits($0, count: $1) }) else { return false }
+        guard recipe.allSatisfy({ fruit, amount in return store.isEnoughFruits(fruit, count: amount) }) else { return false }
 
-        recipe.forEach { store.changeFruitCount($0, count: $1) }
+        recipe.forEach { fruit, amount in
+            store.changeFruitCount(fruit, count: amount)
+        }
         return true
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -22,7 +22,7 @@ struct JuiceMaker {
         self.store = fruitStore
     }
 
-    private func getRecipe(_ menu: Menu) -> Recipe {
+    private func provideRecipe(_ menu: Menu) -> Recipe {
         switch menu {
             case .strawberryJuice:
                 return [(.strawberry, 16)]
@@ -42,7 +42,7 @@ struct JuiceMaker {
     }
     
     func makeJuice(menu: Menu) -> Bool {
-        let recipe = getRecipe(menu)
+        let recipe = provideRecipe(menu)
         
         guard recipe.allSatisfy({ store.verifyFruitCount($0, count: $1) }) else { return false }
 

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -21,24 +21,34 @@ struct JuiceMaker {
         self.store = fruitStore
     }
     
+    typealias Recipe = [(Fruit, Int)]
+    
+    let strawberryJuiceRecipe: Recipe = [(.strawberry, 16)]
+    let bananaJuiceRecipe: Recipe = [(.banana, 2)]
+    let pineappleJuiceRecipe: Recipe = [(.pineapple, 2)]
+    let kiwiJuiceRecipe: Recipe = [(.kiwi, 3)]
+    let mangoJuiceRecipe: Recipe = [(.mango, 3)]
+    let strawberryAndBananaJuice: Recipe = [(.strawberry, 10), (.banana, 1)]
+    let mangoAndKiwiJuice: Recipe = [(.mango, 2), (.kiwi, 1)]
+    
     func makeJuice(menu: Menu) -> Bool {
         let isSuccess: Bool
         
         switch menu {
         case .strawberryJuice:
-            isSuccess = followReceipe([(.strawberry, 16)])
+            isSuccess = followRecipe(strawberryJuiceRecipe)
         case .bananaJuice:
-            isSuccess = followReceipe([(.banana, 2)])
+            isSuccess = followRecipe(bananaJuiceRecipe)
         case .pineappleJuice:
-            isSuccess = followReceipe([(.pineapple, 2)])
-        case .strawberryAndBananaJuice:
-            isSuccess = followReceipe([(.strawberry, 10), (.banana, 1)])
+            isSuccess = followRecipe(pineappleJuiceRecipe)
         case .kiwiJuice:
-            isSuccess = followReceipe([(.kiwi, 3)])
+            isSuccess = followRecipe(kiwiJuiceRecipe)
         case .mangoJuice:
-            isSuccess = followReceipe([(.mango, 3)])
+            isSuccess = followRecipe(mangoJuiceRecipe)
+        case .strawberryAndBananaJuice:
+            isSuccess = followRecipe(strawberryAndBananaJuice)
         case .mangoAndKiwiJuice:
-            isSuccess = followReceipe([(.mango, 2), (.kiwi, 1)])
+            isSuccess = followRecipe(mangoAndKiwiJuice)
         }
         
         return isSuccess
@@ -47,7 +57,7 @@ struct JuiceMaker {
 
 // MARK: - Make Juice
 extension JuiceMaker {
-    private func followReceipe(_ receipe: [(fruit: Fruit, count: Int)]) -> Bool {
+    private func followRecipe(_ receipe: [(fruit: Fruit, count: Int)]) -> Bool {
         guard receipe.allSatisfy({ store.verifyFruitCount($0, count: $1) }) else { return false }
 
         receipe.forEach { store.changeFruitCount($0, count: $1) }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -8,9 +8,9 @@ enum Menu {
     case strawberryJuice
     case bananaJuice
     case pineappleJuice
-    case strawberryAndBananaJuice
     case kiwiJuice
     case mangoJuice
+    case strawberryAndBananaJuice
     case mangoAndKiwiJuice
 }
 

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -26,17 +26,17 @@ struct JuiceMaker {
         
         switch menu {
         case .strawberryJuice:
-            isSuccess = makeJuice(menu: .strawberry, count: 16)
+            isSuccess = makeBasicJuice(menu: .strawberry, count: 16)
         case .bananaJuice:
-            isSuccess = makeJuice(menu: .banana, count: 2)
+            isSuccess = makeBasicJuice(menu: .banana, count: 2)
         case .pineappleJuice:
-            isSuccess = makeJuice(menu: .pineapple, count: 2)
+            isSuccess = makeBasicJuice(menu: .pineapple, count: 2)
         case .strawberryAndBananaJuice:
             isSuccess = makeCollaborateJuice(main: (.strawberry, 10), sub: (.banana, 1))
         case .kiwiJuice:
-            isSuccess = makeJuice(menu: .kiwi, count: 3)
+            isSuccess = makeBasicJuice(menu: .kiwi, count: 3)
         case .mangoJuice:
-            isSuccess = makeJuice(menu: .mango, count: 3)
+            isSuccess = makeBasicJuice(menu: .mango, count: 3)
         case .mangoAndKiwiJuice:
             isSuccess = makeCollaborateJuice(main: (.mango, 2), sub: (.kiwi, 1))
         }
@@ -49,7 +49,7 @@ struct JuiceMaker {
 
 // MARK: - Make Juice
 extension JuiceMaker {
-    private func makeJuice(menu: Fruit, count: Int) -> Bool {
+    private func makeBasicJuice(menu: Fruit, count: Int) -> Bool {
         guard store.verifyFruitCount(menu, count: count) else {
             return false
         }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -1,6 +1,6 @@
 //
 //  JuiceMaker - JuiceMaker.swift
-//  Created by yagom. 
+//  Created by Zion, Mint.
 //  Copyright © yagom academy. All rights reserved.
 //
 
@@ -21,51 +21,36 @@ struct JuiceMaker {
         self.store = fruitStore
     }
     
-    func orderJuice(menu: Menu) -> Bool {
+    func makeJuice(menu: Menu) -> Bool {
         let isSuccess: Bool
         
         switch menu {
         case .strawberryJuice:
-            isSuccess = makeBasicJuice(menu: .strawberry, count: 16)
+            isSuccess = followReceipe([(.strawberry, 16)])
         case .bananaJuice:
-            isSuccess = makeBasicJuice(menu: .banana, count: 2)
+            isSuccess = followReceipe([(.banana, 2)])
         case .pineappleJuice:
-            isSuccess = makeBasicJuice(menu: .pineapple, count: 2)
+            isSuccess = followReceipe([(.pineapple, 2)])
         case .strawberryAndBananaJuice:
-            isSuccess = makeCollaborateJuice(main: (.strawberry, 10), sub: (.banana, 1))
+            isSuccess = followReceipe([(.strawberry, 10), (.banana, 1)])
         case .kiwiJuice:
-            isSuccess = makeBasicJuice(menu: .kiwi, count: 3)
+            isSuccess = followReceipe([(.kiwi, 3)])
         case .mangoJuice:
-            isSuccess = makeBasicJuice(menu: .mango, count: 3)
+            isSuccess = followReceipe([(.mango, 3)])
         case .mangoAndKiwiJuice:
-            isSuccess = makeCollaborateJuice(main: (.mango, 2), sub: (.kiwi, 1))
+            isSuccess = followReceipe([(.mango, 2), (.kiwi, 1)])
         }
         
         return isSuccess
     }
-    
-
 }
 
 // MARK: - Make Juice
 extension JuiceMaker {
-    private func makeBasicJuice(menu: Fruit, count: Int) -> Bool {
-        guard store.verifyFruitCount(menu, count: count) else {
-            return false
-        }
-        
-        store.changeFruitCount(menu, count: count)
-        return true
-    }
-    
-    private func makeCollaborateJuice(main: (fruit: Fruit, count: Int), sub: (fruit: Fruit, count: Int)) -> Bool {
-        guard store.verifyFruitCount(main.fruit, count: main.count),
-              store.verifyFruitCount(sub.fruit, count: sub.count) else {
-            return false
-        }
-        
-        store.changeFruitCount(main.fruit, count: main.count)
-        store.changeFruitCount(sub.fruit, count: sub.count)
+    private func followReceipe(_ receipe: [(fruit: Fruit, count: Int)]) -> Bool {
+        guard receipe.allSatisfy({ store.verifyFruitCount($0, count: $1) }) else { return false }
+
+        receipe.forEach { store.changeFruitCount($0, count: $1) }
         return true
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# ios-juice-maker
+iOS 쥬스 메이커 재고관리 시작 저장소


### PR DESCRIPTION
@Gundy93 
안녕하세요 건디! Zion, Mint - `형민트` 입니다.
Step1 첫 PR을 올립니다 . 3주동안 잘 부탁드립니다 !

# STEP 1
## 고민되었던 점
### typealias
코드의 직관성을 위해 고민하다가 레시피에 들어가는 과일의 종류와 개수를 튜플 배열로 선언하면서 더 명확한 명시를 위해서 `typealias`를 사용하였습니다.

### recipe의 분류
처음 주스를 만들 때 `makeJuice` 함수에 매개변수로 소모되는 과일의 종류와 개수를 넣어 recipe를 따로 분류하지는 않았습니다. 추후에 레시피에 들어가는 과일의 종류가 몇 개가 되든 상관없게 하기 위해 튜플 배열을 사용하면서 레시피를 따로 부르는 방법으로 변경하였습니다. 레시피의 내용들을 변수로 선언하여 사용하려다가 함수를 통해 메뉴를 받으면 그 메뉴에 해당하는 레시피를 넘겨주는 것 까지가 레시피의 역할과 책임으로 선언하여 사용하였습니다. 

### 확장성
`makeJuice` 메서드 구현당시 각각의 쥬스를 만들 과일의 갯수를 체크하는 로직을 과일이 1개인지 2개인지로 나누어서 구현했었습니다. 그 결과 하나의 쥬스에 2개의 과일이 들어가는 쥬스까지는 무리없이 돌아가지만 하나의 쥬스에 그 이상의 과일이 들어가게 될 경우 코드의 수정이 불가피했습니다. 확장성이 떨이질 수 있다는 리뷰를 들었습니다.

처음 그 말을 들었을 때는 요구사항이 바뀌는 것이 확장성과 연관이 있나? 라는 생각이 들었지만, (Step이 넘어간다고 해서 하나의 쥬스에 들어가는 과일의 갯수가 바뀌진 않기 때문에, 또한 요구사항이 개발단계까지 넘어왔다면 바뀌지 않는 것이 당연하다고 생각했기 때문에)

 요구사항은 언제나 항상 바뀌게 되고 그에 따른 대응은 개발자가 해야하는 것이므로 당연히 확장성과 연관이 있을텐데... 너무나 중요하고 당연한 부분을 숙제 하듯이 개발해나가면서 놓쳤다는 생각이 들었습니다. 그 결과 하나의 쥬스에 몇개의 과일이 들어오더라도 문제없이 쥬스가 만들어질 수 있도록 로직을 수정했고, 오히려 가독성이 좀더 나은 코드를 구현할 수 있었습니다.
감사합니다 건디.

### 객체지향
최대한 객체지향적으로 프로그램이 동작할 수 있도록 설계했습니다.
유저는 메뉴만을 보고 주문만할 수 있고, `JuiceMaker`에서는 가지고 있는 레시피를 가지고 `FruitStore`을 통해 쥬스를 만들고, `FruitStore`에서는 가지고 있는 과일의 갯수를 수정하거나, 과일이 해당 `JuiceMaker`에서 원하는 만큼을 가지고 있는지 판단하는 로직을 두었습니다. 그 결과 `User`, `JuiceMaker`, `FruitStore`가 서로 상호작용을 하는 것처럼, 즉 객체를 지향하는 설계가 가능했습니다.

## 조언을 얻고 싶은 부분
### OCP
```swift=
enum Fruit {
    case strawberry
    case banana
    case pineapple
    case kiwi
    case mango
    //case orange 확장
}

func verifyFruitCount(_ fruit: Fruit, count: Int) -> Bool {
        switch fruit {
        case .strawberry:
            return strawberry >= count ? true : false
        case .banana:
            return banana >= count ? true : false
        case .pineapple:
            return pineapple >= count ? true : false
        case .kiwi:
            return kiwi >= count ? true : false
        case .mango:
            return mango >= count ? true : false
        }
    }
    
    func changeFruitCount(_ fruit: Fruit, count: Int, isUseFruit: Bool = true) {
        let amount = isUseFruit ? (count * -1) : count
        
        switch fruit {
        case .strawberry:
            strawberry += amount
        case .banana:
            banana += amount
        case .pineapple:
            pineapple += amount
        case .kiwi:
            kiwi += amount
        case .mango:
            mango += amount
        }
    }
```

안녕하세요 건디! OCP와 관련하여 질문사항이 있습니다!
제가 알고 있는 OCP의 개념은 ``'확장성에는 열려있어야 하지만 그로인한 로직의 수정은 최소화하거나 없어야한다.'`` 의 개념으로 알고있습니다. 위의 예로 제시한 코드로 살펴 본다면 `enum` 값에 `case orange`가 추가 되었을 때 `verifyFruitCount()`, `changeFruitCount()`가 최소한을 수정되거나 수정되는 부분이 없는 경우 OCP를 잘 준수한 것으로 볼 수 있을 것 같아요! 이러한 부분으로 본다면 현재 저희가 작성한 코드에는 위의 예시코드와는 달리 `fruitsStock` 라는 `Dictionary` 형식으로 과일재고에 접근하고 있기 때문에 orange의 case가 늘었을 경우 `fruitsStock`만 수정하면되므로 수정을 최소한 줄일 수 있었다고 생각합니다.

하지만 위와 같이 코드를 수정하면서 고민이 되었던 부분이 있습니다. 
위의 예시에서처럼 `switch`를 사용하여 로직을 구현했을 경우 새로운 case로 orange가 들어왔을 때, 컴파일 오류가 발생하게 됩니다. 그 이유는 현재 사용되고 있는 `switch`에서는 orange case를 다루는 구문이 없기 때문이에요. 이 컴파일 에러는 개발자로 하여금 `switch`의 모든 경우에 대해 구문을 작성해야한다는 의무를 부여하기도 한다고 생각합니다 마치 `Optional` 값을 `Binding`해서 사용해야한다고 강요하는 것 처럼. PR로 올린 `Dictionary`로 통해 접근하는 부분을 생각해봤을 때 해당 코드는 확장되고자 했을 때, 코드 수정을 최소한으로 줄인 것은 맞지만 오히려 개발자로 하여금 '찾고 고쳐야할 부분을 직접 분석하고 탐색하여야 하는 불편함을 줄 수 있지는 않을까?' 라는 생각도 하게 되었습니다. 

이와 관련된 부분에 대해서 음성으로 대화할 수 있을까요?