### PR TITLE
쥬스 메이커 [STEP 2] Karen, myungsun

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */; };
 		F01A11CC2A0A0FAC0064E0ED /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01A11CB2A0A0FAC0064E0ED /* Fruit.swift */; };
 		F01A11CE2A0A0FE10064E0ED /* FruitStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01A11CD2A0A0FE10064E0ED /* FruitStoreError.swift */; };
+		F0B048F22A124076003BAC85 /* StockChangeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B048F12A124076003BAC85 /* StockChangeViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		C73DAF4B255D0D0400020D38 /* JuiceMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceMaker.swift; sourceTree = "<group>"; };
 		F01A11CB2A0A0FAC0064E0ED /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		F01A11CD2A0A0FE10064E0ED /* FruitStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStoreError.swift; sourceTree = "<group>"; };
+		F0B048F12A124076003BAC85 /* StockChangeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockChangeViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +55,7 @@
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */,
+				F0B048F12A124076003BAC85 /* StockChangeViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -184,6 +187,7 @@
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				9C912AFA2A0A114D00893CFF /* Juice.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,
+				F0B048F22A124076003BAC85 /* StockChangeViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
+		C73DAF3B255D0CDD00020D38 /* JuiceOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */; };
 		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
@@ -26,7 +26,7 @@
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C73DAF3A255D0CDD00020D38 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceOrderViewController.swift; sourceTree = "<group>"; };
 		C73DAF3D255D0CDD00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -52,7 +52,7 @@
 			children = (
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
-				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -178,7 +178,7 @@
 			files = (
 				F01A11CC2A0A0FAC0064E0ED /* Fruit.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				C73DAF3B255D0CDD00020D38 /* JuiceOrderViewController.swift in Sources */,
 				F01A11CE2A0A0FE10064E0ED /* FruitStoreError.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class JuiceOrderViewController: UIViewController {
+final class JuiceOrderViewController: UIViewController {
     @IBOutlet var fruitStockLabels: [UILabel] = []
     let juiceMaker = JuiceMaker(fruitStore: FruitStore(fruitInventory: [
         .strawberry: 10,

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -8,6 +8,8 @@ import UIKit
 
 final class JuiceOrderViewController: UIViewController {
     @IBOutlet var fruitStockLabels: [UILabel] = []
+    @IBOutlet var juiceOrderButtons: [UIButton] = []
+    
     let juiceMaker = JuiceMaker(fruitStore: FruitStore(fruitInventory: [.strawberry: 10,
                                                                         .banana: 10,
                                                                         .pineapple: 10,
@@ -17,6 +19,7 @@ final class JuiceOrderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         updateFruitStockLabels()
+        setJuiceOrderButtonTag()
     }
     
     private func updateFruitStockLabels() {
@@ -24,6 +27,12 @@ final class JuiceOrderViewController: UIViewController {
             guard let fruit = Fruit(rawValue: index),
                   let fruitCount = juiceMaker.fruitStore.getCurrentStock(of: fruit) else { return }
             fruitStockLabel.text = "\(fruitCount)"
+        }
+    }
+    
+    private func setJuiceOrderButtonTag() {
+        for (tag, juiceOrderButton) in juiceOrderButtons.enumerated() {
+            juiceOrderButton.tag = tag
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -38,5 +38,26 @@ class JuiceOrderViewController: UIViewController {
     @IBAction func tapStockChangeButton(_ sender: UIBarButtonItem) {
         pushStockChangeViewController()
     }
+    
+    private func presentInsufficientStockAlert(with message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let confirmButton = UIAlertAction(title: "예", style: .default) { _ in
+            self.pushStockChangeViewController()
+        }
+        let cancelButton = UIAlertAction(title: "아니오", style: .cancel)
+        
+        alert.addAction(confirmButton)
+        alert.addAction(cancelButton)
+        present(alert, animated: true)
+    }
+    
+    private func presentJuiceReadyAlert(with juice: Juice) {
+        let message = "\(juice.description) 나왔습니다! 맛있게 드세요!"
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let confirmButton = UIAlertAction(title: "확인", style: .default)
+        
+        alert.addAction(confirmButton)
+        present(alert, animated: true)
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -10,7 +10,7 @@ final class JuiceOrderViewController: UIViewController {
     @IBOutlet var fruitStockLabels: [UILabel] = []
     @IBOutlet var juiceOrderButtons: [UIButton] = []
     
-    let juiceMaker = JuiceMaker(fruitStore: FruitStore(fruitInventory: [.strawberry: 10,
+    private let juiceMaker = JuiceMaker(fruitStore: FruitStore(fruitInventory: [.strawberry: 10,
                                                                         .banana: 10,
                                                                         .pineapple: 10,
                                                                         .kiwi: 10,

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -8,13 +8,11 @@ import UIKit
 
 final class JuiceOrderViewController: UIViewController {
     @IBOutlet var fruitStockLabels: [UILabel] = []
-    let juiceMaker = JuiceMaker(fruitStore: FruitStore(fruitInventory: [
-        .strawberry: 10,
-        .banana: 10,
-        .pineapple: 10,
-        .kiwi: 10,
-        .mango: 10
-    ]))
+    let juiceMaker = JuiceMaker(fruitStore: FruitStore(fruitInventory: [.strawberry: 10,
+                                                                        .banana: 10,
+                                                                        .pineapple: 10,
+                                                                        .kiwi: 10,
+                                                                        .mango: 10]))
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,8 +21,8 @@ final class JuiceOrderViewController: UIViewController {
     
     private func updateFruitStockLabels() {
         for (index, fruitStockLabel) in fruitStockLabels.enumerated() {
-            guard let fruit = Fruit(rawValue: index) else { return }
-            guard let fruitCount = juiceMaker.fruitStore.getCurrentStock(of: fruit) else { return }
+            guard let fruit = Fruit(rawValue: index),
+                  let fruitCount = juiceMaker.fruitStore.getCurrentStock(of: fruit) else { return }
             fruitStockLabel.text = "\(fruitCount)"
         }
     }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -18,6 +18,15 @@ class JuiceOrderViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        updateFruitStockLabels()
+    }
+    
+    private func updateFruitStockLabels() {
+        for (index, fruitStockLabel) in fruitStockLabels.enumerated() {
+            guard let fruit = Fruit(rawValue: index) else { return }
+            guard let fruitCount = juiceMaker.fruitStore.getCurrentStock(of: fruit) else { return }
+            fruitStockLabel.text = "\(fruitCount)"
+        }
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -59,5 +59,18 @@ class JuiceOrderViewController: UIViewController {
         alert.addAction(confirmButton)
         present(alert, animated: true)
     }
+    
+    @IBAction func orderJuice(_ sender: UIButton) {
+        guard let selectedJuice = Juice(rawValue: sender.tag) else { return }
+        let result = juiceMaker.make(selectedJuice)
+        
+        switch result {
+        case .success(let juice):
+            presentJuiceReadyAlert(with: juice)
+            updateFruitStockLabels()
+        case .failure(let error):
+            presentInsufficientStockAlert(with: error.description)
+        }
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -7,12 +7,17 @@
 import UIKit
 
 class JuiceOrderViewController: UIViewController {
-
+    @IBOutlet var fruitStockLabels: [UILabel] = []
+    let juiceMaker = JuiceMaker(fruitStore: FruitStore(fruitInventory: [
+        .strawberry: 10,
+        .banana: 10,
+        .pineapple: 10,
+        .kiwi: 10,
+        .mango: 10
+    ]))
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
     }
-
-
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -21,6 +21,24 @@ final class JuiceOrderViewController: UIViewController {
         updateFruitStockLabels()
         setJuiceOrderButtonTag()
     }
+
+    @IBAction func tapStockChangeButton(_ sender: UIBarButtonItem) {
+        presentStockChangeViewController()
+    }
+    
+    @IBAction func orderJuice(_ sender: UIButton) {
+        guard let selectedJuice = Juice(rawValue: sender.tag) else { return }
+        let result = juiceMaker.make(selectedJuice)
+        
+        switch result {
+        case .success(let juice):
+            presentJuiceReadyAlert(with: juice)
+            updateFruitStockLabels()
+        case .failure(let error):
+            guard let errorMessage = error.errorDescription else { return }
+            presentInsufficientStockAlert(with: errorMessage)
+        }
+    }
     
     private func updateFruitStockLabels() {
         for (index, fruitStockLabel) in fruitStockLabels.enumerated() {
@@ -42,8 +60,13 @@ final class JuiceOrderViewController: UIViewController {
         present(stockChangeViewController, animated: true)
     }
     
-    @IBAction func tapStockChangeButton(_ sender: UIBarButtonItem) {
-        presentStockChangeViewController()
+    private func presentJuiceReadyAlert(with juice: Juice) {
+        let message = "\(juice) 나왔습니다! 맛있게 드세요!"
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let confirmAction = UIAlertAction(title: "확인", style: .default)
+        
+        alert.addAction(confirmAction)
+        present(alert, animated: true)
     }
     
     private func presentInsufficientStockAlert(with message: String) {
@@ -56,29 +79,6 @@ final class JuiceOrderViewController: UIViewController {
         alert.addAction(confirmAction)
         alert.addAction(cancelAction)
         present(alert, animated: true)
-    }
-    
-    private func presentJuiceReadyAlert(with juice: Juice) {
-        let message = "\(juice) 나왔습니다! 맛있게 드세요!"
-        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        let confirmAction = UIAlertAction(title: "확인", style: .default)
-        
-        alert.addAction(confirmAction)
-        present(alert, animated: true)
-    }
-    
-    @IBAction func orderJuice(_ sender: UIButton) {
-        guard let selectedJuice = Juice(rawValue: sender.tag) else { return }
-        let result = juiceMaker.make(selectedJuice)
-        
-        switch result {
-        case .success(let juice):
-            presentJuiceReadyAlert(with: juice)
-            updateFruitStockLabels()
-        case .failure(let error):
-            guard let errorMessage = error.errorDescription else { return }
-            presentInsufficientStockAlert(with: errorMessage)
-        }
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -28,5 +28,15 @@ class JuiceOrderViewController: UIViewController {
             fruitStockLabel.text = "\(fruitCount)"
         }
     }
+    
+    private func pushStockChangeViewController() {
+        guard let stockChangeVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "StockChangeViewController") as? StockChangeViewController else { return }
+        
+        self.navigationController?.pushViewController(stockChangeVC, animated: true)
+    }
+    
+    @IBAction func tapStockChangeButton(_ sender: UIBarButtonItem) {
+        pushStockChangeViewController()
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -25,7 +25,7 @@ final class JuiceOrderViewController: UIViewController {
     private func updateFruitStockLabels() {
         for (index, fruitStockLabel) in fruitStockLabels.enumerated() {
             guard let fruit = Fruit(rawValue: index),
-                  let fruitCount = juiceMaker.fruitStore.getCurrentStock(of: fruit) else { return }
+                  let fruitCount = juiceMaker.getCurrentStock(of: fruit) else { return }
             fruitStockLabel.text = "\(fruitCount)"
         }
     }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -36,20 +36,20 @@ final class JuiceOrderViewController: UIViewController {
         }
     }
     
-    private func pushStockChangeViewController() {
-        guard let stockChangeVC = storyboard?.instantiateViewController(withIdentifier: "StockChangeViewController") as? StockChangeViewController else { return }
+    private func presentStockChangeViewController() {
+        guard let stockChangeViewController = storyboard?.instantiateViewController(withIdentifier: "StockChangeViewController") as? StockChangeViewController else { return }
         
-        self.navigationController?.pushViewController(stockChangeVC, animated: true)
+        present(stockChangeViewController, animated: true)
     }
     
     @IBAction func tapStockChangeButton(_ sender: UIBarButtonItem) {
-        pushStockChangeViewController()
+        presentStockChangeViewController()
     }
     
     private func presentInsufficientStockAlert(with message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let confirmAction = UIAlertAction(title: "예", style: .default) { _ in
-            self.pushStockChangeViewController()
+            self.presentStockChangeViewController()
         }
         let cancelAction = UIAlertAction(title: "아니오", style: .cancel)
         

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -37,7 +37,7 @@ final class JuiceOrderViewController: UIViewController {
     }
     
     private func pushStockChangeViewController() {
-        guard let stockChangeVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "StockChangeViewController") as? StockChangeViewController else { return }
+        guard let stockChangeVC = storyboard?.instantiateViewController(withIdentifier: "StockChangeViewController") as? StockChangeViewController else { return }
         
         self.navigationController?.pushViewController(stockChangeVC, animated: true)
     }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class JuiceOrderViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -59,7 +59,7 @@ final class JuiceOrderViewController: UIViewController {
     }
     
     private func presentJuiceReadyAlert(with juice: Juice) {
-        let message = "\(juice.description) 나왔습니다! 맛있게 드세요!"
+        let message = "\(juice) 나왔습니다! 맛있게 드세요!"
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let confirmAction = UIAlertAction(title: "확인", style: .default)
         

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -48,22 +48,22 @@ final class JuiceOrderViewController: UIViewController {
     
     private func presentInsufficientStockAlert(with message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        let confirmButton = UIAlertAction(title: "예", style: .default) { _ in
+        let confirmAction = UIAlertAction(title: "예", style: .default) { _ in
             self.pushStockChangeViewController()
         }
-        let cancelButton = UIAlertAction(title: "아니오", style: .cancel)
+        let cancelAction = UIAlertAction(title: "아니오", style: .cancel)
         
-        alert.addAction(confirmButton)
-        alert.addAction(cancelButton)
+        alert.addAction(confirmAction)
+        alert.addAction(cancelAction)
         present(alert, animated: true)
     }
     
     private func presentJuiceReadyAlert(with juice: Juice) {
         let message = "\(juice.description) 나왔습니다! 맛있게 드세요!"
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        let confirmButton = UIAlertAction(title: "확인", style: .default)
+        let confirmAction = UIAlertAction(title: "확인", style: .default)
         
-        alert.addAction(confirmButton)
+        alert.addAction(confirmAction)
         present(alert, animated: true)
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -69,7 +69,8 @@ class JuiceOrderViewController: UIViewController {
             presentJuiceReadyAlert(with: juice)
             updateFruitStockLabels()
         case .failure(let error):
-            presentInsufficientStockAlert(with: error.description)
+            guard let errorMessage = error.errorDescription else { return }
+            presentInsufficientStockAlert(with: errorMessage)
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockChangeViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockChangeViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class StockChangeViewController: UIViewController {
+final class StockChangeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/JuiceMaker/JuiceMaker/Controller/StockChangeViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockChangeViewController.swift
@@ -1,0 +1,15 @@
+//
+//  StockChangeViewController.swift
+//  JuiceMaker
+//
+//  Created by myungsun on 2023/05/15.
+//
+
+import UIKit
+
+class StockChangeViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -5,10 +5,10 @@
 //  Created by Karen, myungsun on 2023/05/09.
 //
 
-enum Fruit {
-    case strawberry
-    case banana
-    case pineapple
-    case kiwi
-    case mango
+enum Fruit: Int {
+    case strawberry = 0
+    case banana = 1
+    case pineapple = 2
+    case kiwi = 3
+    case mango = 4
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -5,7 +5,7 @@
 //
 
 final class FruitStore {
-    private(set) var fruitInventory: [Fruit: Int]
+    private var fruitInventory: [Fruit: Int]
     
     init(fruitInventory: [Fruit: Int]) {
         self.fruitInventory = fruitInventory

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -4,7 +4,7 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
-class FruitStore {
+final class FruitStore {
     private var fruitInventory: [Fruit: Int]
     
     init(fruitInventory: [Fruit: Int]) {
@@ -12,13 +12,18 @@ class FruitStore {
     }
     
     func changeStock(of fruit: Fruit, by quantity: Int) throws {
-        guard let currentStock = fruitInventory[fruit],
-              currentStock + quantity >= 0 else { throw FruitStoreError.outOfStock }
+        guard let currentStock = fruitInventory[fruit] else { return }
         fruitInventory[fruit] = currentStock + quantity
     }
     
     func getCurrentStock(of fruit: Fruit) -> Int? {
         guard let currentStock = fruitInventory[fruit] else { return nil }
         return currentStock
+    }
+    
+    func checkStock(of fruit: Fruit, for amount: Int) -> Bool {
+        guard let currentStock = fruitInventory[fruit],
+              currentStock >= amount else { return false }
+        return true
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -11,7 +11,7 @@ final class FruitStore {
         self.fruitInventory = fruitInventory
     }
     
-    func changeStock(of fruit: Fruit, by quantity: Int) throws {
+    func changeStock(of fruit: Fruit, by quantity: Int) {
         guard let currentStock = fruitInventory[fruit] else { return }
         fruitInventory[fruit] = currentStock + quantity
     }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -5,7 +5,7 @@
 //
 
 final class FruitStore {
-    private var fruitInventory: [Fruit: Int]
+    private(set) var fruitInventory: [Fruit: Int]
     
     init(fruitInventory: [Fruit: Int]) {
         self.fruitInventory = fruitInventory

--- a/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
@@ -5,6 +5,13 @@
 //  Created by Karen, myungsun on 2023/05/09.
 //
 
-enum FruitStoreError: Error {
+enum FruitStoreError: Error, CustomStringConvertible {
     case outOfStock
+    
+    var description: String {
+        switch self {
+        case.outOfStock:
+            return "재료가 모자라요. 재고를 수정할까요?"
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
@@ -5,10 +5,12 @@
 //  Created by Karen, myungsun on 2023/05/09.
 //
 
-enum FruitStoreError: Error, CustomStringConvertible {
+import Foundation
+
+enum FruitStoreError: Error, LocalizedError {
     case outOfStock
     
-    var description: String {
+    var errorDescription: String? {
         switch self {
         case.outOfStock:
             return "재료가 모자라요. 재고를 수정할까요?"

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -5,7 +5,7 @@
 //  Created by Karen, myungsun on 2023/05/09.
 //
 
-enum Juice {
+enum Juice: CustomStringConvertible {
     case strawberry
     case banana
     case kiwi
@@ -30,6 +30,25 @@ enum Juice {
             return [.mango: 3]
         case .mangoKiwi:
             return [.mango: 2, .kiwi: 1]
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .strawberry:
+            return "딸기 쥬스"
+        case .banana:
+            return "바나나 쥬스"
+        case .kiwi:
+            return "키위 쥬스"
+        case .pineapple:
+            return "파인애플 쥬스"
+        case .strawberryBanana:
+            return "딸바 쥬스"
+        case .mango:
+            return "망고 쥬스"
+        case .mangoKiwi:
+            return "망고키위 쥬스"
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -5,14 +5,14 @@
 //  Created by Karen, myungsun on 2023/05/09.
 //
 
-enum Juice: CustomStringConvertible {
-    case strawberry
-    case banana
-    case kiwi
-    case pineapple
-    case strawberryBanana
-    case mango
-    case mangoKiwi
+enum Juice: Int, CustomStringConvertible {
+    case strawberry = 2
+    case banana = 3
+    case kiwi = 5
+    case pineapple = 4
+    case strawberryBanana = 0
+    case mango = 6
+    case mangoKiwi = 1
     
     var recipe: [Fruit: Int] {
         switch self {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -11,24 +11,22 @@ struct JuiceMaker {
         self.fruitStore = fruitStore
     }
     
-    private func canMake(_ juice: Juice) -> Result<Bool, FruitStoreError> {
+    private func canMake(_ juice: Juice) -> Bool {
         for (fruit, amount) in juice.recipe {
-            guard fruitStore.checkStock(of: fruit, for: amount) else { return .failure(FruitStoreError.outOfStock) }
+            guard fruitStore.checkStock(of: fruit, for: amount) else { return false }
         }
-        return .success(true)
+        return true
     }
     
     func make(_ juice: Juice) -> Result<Juice, FruitStoreError> {
         let result = canMake(juice)
         
-        switch result {
-        case .success(_):
+        if canMake(juice) {
             for (fruit, amount) in juice.recipe {
                 fruitStore.changeStock(of: fruit, by: -amount)
             }
             return .success(juice)
-        case .failure(let error):
-            return .failure(error)
         }
+        return .failure(FruitStoreError.outOfStock)
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,7 +5,7 @@
 // 
 
 struct JuiceMaker {
-    private let fruitStore: FruitStore
+    private(set) var fruitStore: FruitStore
     
     init(fruitStore: FruitStore) {
         self.fruitStore = fruitStore

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,7 +5,7 @@
 // 
 
 struct JuiceMaker {
-    private(set) var fruitStore: FruitStore
+    private let fruitStore: FruitStore
     
     init(fruitStore: FruitStore) {
         self.fruitStore = fruitStore
@@ -26,5 +26,9 @@ struct JuiceMaker {
             return .success(juice)
         }
         return .failure(FruitStoreError.outOfStock)
+    }
+    
+    func getCurrentStock(of fruit: Fruit) -> Int? {
+        return fruitStore.getCurrentStock(of: fruit)
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -11,15 +11,11 @@ struct JuiceMaker {
         self.fruitStore = fruitStore
     }
     
-    private func canMake(_ juice: Juice) -> Bool {
+    private func canMake(_ juice: Juice) -> Result<Bool, FruitStoreError> {
         for (fruit, amount) in juice.recipe {
-            guard let currentStock = fruitStore.getCurrentStock(of: fruit) else { return false }
-            
-            if currentStock < amount {
-                return false
-            }
+            guard fruitStore.checkStock(of: fruit, for: amount) else { return .failure(FruitStoreError.outOfStock) }
         }
-        return true
+        return .success(true)
     }
     
     func make(_ juice: Juice) throws -> Juice? {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -19,8 +19,6 @@ struct JuiceMaker {
     }
     
     func make(_ juice: Juice) -> Result<Juice, FruitStoreError> {
-        let result = canMake(juice)
-        
         if canMake(juice) {
             for (fruit, amount) in juice.recipe {
                 fruitStore.changeStock(of: fruit, by: -amount)

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -18,13 +18,17 @@ struct JuiceMaker {
         return .success(true)
     }
     
-    func make(_ juice: Juice) throws -> Juice? {
-        if canMake(juice) {
+    func make(_ juice: Juice) -> Result<Juice, FruitStoreError> {
+        let result = canMake(juice)
+        
+        switch result {
+        case .success(_):
             for (fruit, amount) in juice.recipe {
-                try fruitStore.changeStock(of: fruit, by: -amount)
+                fruitStore.changeStock(of: fruit, by: -amount)
             }
-            return juice
+            return .success(juice)
+        case .failure(let error):
+            return .failure(error)
         }
-        return nil
     }
 }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -12,7 +13,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="JuiceOrderViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -216,6 +217,13 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
                     </navigationItem>
+                    <connections>
+                        <outletCollection property="fruitStockLabels" destination="Qas-vP-td6" collectionClass="NSMutableArray" id="2ee-BP-ROc"/>
+                        <outletCollection property="fruitStockLabels" destination="gvk-pA-Lw5" collectionClass="NSMutableArray" id="dVR-50-G54"/>
+                        <outletCollection property="fruitStockLabels" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="cu0-id-XQt"/>
+                        <outletCollection property="fruitStockLabels" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="a7F-qn-qqQ"/>
+                        <outletCollection property="fruitStockLabels" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="di7-rX-Ajk"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -215,7 +215,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
+                            <connections>
+                                <action selector="tapStockChangeButton:" destination="BYZ-38-t0r" id="E7C-id-xmQ"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outletCollection property="fruitStockLabels" destination="Qas-vP-td6" collectionClass="NSMutableArray" id="2ee-BP-ROc"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -134,7 +134,7 @@
                                                 <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
                                                 <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -153,7 +153,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
                                                 <rect key="frame" x="0.0" y="0.0" width="718" height="66.333333333333329"/>
                                                 <subviews>
-                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
                                                         <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -164,7 +164,7 @@
                                                             <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fOe-RZ-4bt"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -175,7 +175,7 @@
                                                             <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Jl4-Xb-9gx"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -186,7 +186,7 @@
                                                             <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="yCA-e3-dTE"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -197,7 +197,7 @@
                                                             <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="oux-0N-X6u"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -248,6 +248,13 @@
                         <outletCollection property="fruitStockLabels" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="cu0-id-XQt"/>
                         <outletCollection property="fruitStockLabels" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="a7F-qn-qqQ"/>
                         <outletCollection property="fruitStockLabels" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="di7-rX-Ajk"/>
+                        <outletCollection property="juiceOrderButtons" destination="hrc-2F-fzl" collectionClass="NSMutableArray" id="kio-nT-WFD"/>
+                        <outletCollection property="juiceOrderButtons" destination="ngP-kF-Yii" collectionClass="NSMutableArray" id="Ayv-D0-5Hh"/>
+                        <outletCollection property="juiceOrderButtons" destination="avd-o5-3JM" collectionClass="NSMutableArray" id="21B-BC-jZD"/>
+                        <outletCollection property="juiceOrderButtons" destination="y2A-PH-DJY" collectionClass="NSMutableArray" id="Hfx-zi-msc"/>
+                        <outletCollection property="juiceOrderButtons" destination="BFb-ka-wGA" collectionClass="NSMutableArray" id="cuL-h0-Iua"/>
+                        <outletCollection property="juiceOrderButtons" destination="wcW-7H-RXw" collectionClass="NSMutableArray" id="fE6-7k-MEV"/>
+                        <outletCollection property="juiceOrderButtons" destination="q6G-4X-bVm" collectionClass="NSMutableArray" id="O6E-AZ-1PJ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -247,10 +247,10 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--View Controller-->
+        <!--Stock Change View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="StockChangeViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Yu1-lM-nqp" customClass="StockChangeViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -19,19 +18,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="60" y="52" width="724" height="136.66666666666666"/>
+                                <rect key="frame" x="63" y="52" width="718" height="136.66666666666666"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +39,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="148" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +57,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="296" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +75,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="444" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +93,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="592" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +113,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="60" y="208.66666666666663" width="724" height="140.33333333333337"/>
+                                <rect key="frame" x="63" y="208.66666666666663" width="718" height="140.33333333333337"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="724" height="66"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="718" height="66"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -128,11 +127,11 @@
                                                 </state>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="296" y="0.0" width="132" height="66"/>
+                                                <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="444" y="0.0" width="280" height="66"/>
+                                                <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -142,13 +141,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="74.000000000000028" width="724" height="66.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="74.000000000000028" width="718" height="66.333333333333343"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="724" height="66.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="718" height="66.333333333333329"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -156,7 +155,7 @@
                                                         </state>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -164,7 +163,7 @@
                                                         </state>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -172,7 +171,7 @@
                                                         </state>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -180,7 +179,7 @@
                                                         </state>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -126,18 +126,24 @@
                                                 <state key="normal" title="딸바쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dYL-BK-0k7"/>
+                                                </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
                                                 <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                            <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
                                                 <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="F2u-lh-CYL"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -147,45 +153,60 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
                                                 <rect key="frame" x="0.0" y="0.0" width="718" height="66.333333333333329"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
+                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
                                                         <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fOe-RZ-4bt"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Jl4-Xb-9gx"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                    <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="yCA-e3-dTE"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="oux-0N-X6u"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                    <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuice:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Qat-bh-a1Z"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                             </stackView>


### PR DESCRIPTION
안녕하세요~! 건디(@Gundy93)
키로미타 Karen, myungsun 입니다:) 
이번 STEP2 리뷰도 잘 부탁드리겠습니다!

### **코드를 작성하면서 어려웠던 점 및 고민했던 점**
- '쥬스 주문 화면' 에서 '재고 추가 화면' 으로 이동할 때 이동 방식에 대해서 고민했습니다. iOS-Swift에서 화면을 전환할 때 사용하는 대표적인 2가지 방식으로는 `Navigation(Push & Pop)`과 `Modal(Present & Dismiss)`가 있습니다. `Navigation(Push & Pop)` 방식은 주로 계층적이고 연속적인 화면 전환에 사용됩니다. 이때, `NavigationController`가 `Navigation Stack` 구조를 사용해 `ViewController`를 관리합니다. 예를 들어, 아이폰 설정 앱 내에서 발생되는 이동 방식도 `Navigation` 방식에 해당합니다. 이 방식으로 장점으로는 연관된 화면들을 계층적인 구조로 관리할 수 있고, 계층 구조 안에서 원하는 화면으로 쉽게 돌아갈 수 있습니다. A(화면)->B(화면)->C(화면)으로 이동하고, C화면에서 A화면으로 이동해야 하는 상황에서 `popToViewController(_:animated:)`를 사용해 손쉽게 돌아갈 수 있습니다. `Modal(Present & Dismiss)` 방식은 현재 화면 위에 새로운 화면을 덮는 방식입니다.이 방식은 다양한 `modalPresentationStyle`과 `modalTransitionStyle` 프로퍼티를 통해 화면을 이동할 수 있지만, `Navigation` 방식과 달리 특정 구조 내에서 관리되는 것이 아니여서 각 `ViewController`들을 관리하기 어렵다는 단점이 있습니다. 따라서, 현재 저희 상황에서는 '쥬스 주문 화면'과 '재고 추가' 화면은 연관된 화면이고, '쥬스 주문 화면' ==> '재고 추가 화면'의 계층 속에서 `Navigation Stack`을 통해 관리하면 좋을 거 같아 `Navigation(Push & Pop)` 방식을 사용했습니다.
- 각 과일의 재고를 나타내는 `Label`들을 모두 `@IBOutlet` 변수로 생성하여 코드를 작성하려고 했으나, `Label`의 `text`를 넣어주는 코드 중복이 많이 발생하고, 각 `Label` 관리가 힘들어 각 과일의 재고를 나타내는 `Label`들을 `UILabel` 배열로 묶어서 코드를 작성했습니다.
    - 변경 전
    
    ```swift
    @IBOutlet weak var strawberryStockLabel: UILabel!
    @IBOutlet weak var bananaStockLabel: UILabel!
    @IBOutlet weak var pineappleStockLabel: UILabel!
    @IBOutlet weak var kiwiStockLabel: UILabel!
    @IBOutlet weak var mangoStockLabel: UILabel!
    ```
    
    - 변경 후
    
    ```swift
    @IBOutlet var fruitStockLabels: [UILabel] = []
    ```
    
- 각 쥬스에 대한 주문 버튼을 클릭하면 호출되는 `@IBAction` 메서드를 모든 쥬스에 대해 정의해주려고 했으나, 각 쥬스를 주문하는 로직이 중복이 되고, 코드 재사용성이 떨어진다고 판단되어 하나의 `@IBAction` 메서드를 정의해주고, 각 버튼의 `tag` 프로퍼티를 다르게 설정하고, 하나의 `@IBAction` 메서드에서 `tag` 프로퍼티 값을 받아 처리하도록 코드를 작성했습니다. `UIButton` 클래스에는 `tag`라는 프로퍼티가 있습니다. 이 프로퍼티는 `UIView`로부터 상속 받은 프로퍼티입니다. `tag` 프로퍼티는 특정 뷰를 식별할 수 있도록 도와주는 역할을 합니다. 주로 여러 개의 뷰가 있고, 각 뷰가 눌릴 때마다 동일한 메서드가 호출되는 경우에 어떤 뷰가 눌렸는 지 확인하는 경우에 많이 사용한다고 공부했습니다.
    - 변경 전
    
    ```swift
    @IBAction func orderStrawberryJuice(_ sender: UIButton) { ... }
    @IBAction func orderBananaJuice(_ sender: UIButton) { ... }
    @IBAction func orderKiwiJuice(_ sender: UIButton) { ... }
    @IBAction func orderPineappleJuice(_ sender: UIButton) { ... }
    @IBAction func orderStrawberryBananaJuice(_ sender: UIButton) { ... }
    @IBAction func orderMangoJuice(_ sender: UIButton) { ... }
    @IBAction func orderMangoKiwiJuice(_ sender: UIButton) { ... }
    ```
    
    - 변경 후
    
    ```swift
    @IBAction func orderJuice(_ sender: UIButton) { ... }
    ```
    
- 처음에 쥬스를 생성하는 `orderJuice(_:)` 메서드 내에서 사용자가 주문을 한 `Juice` 케이스를 가져오기 위해 배열을 사용했습니다.하지만, 이렇게 하면 개발자가 실수 할 수도 있고, 시스템 적으로 `IndexOutOfRange` 에러가 발생할 위험이 있다고 판단했습니다. 그래서 `Juice` 열거형에 `Int` 타입의 원시 값을 설정한 뒤, 사용자가 주문한 `Juice case`를 원시 값을 통해 생성했습니다. `rawValue`를 통해 `case`를 생성하게 되면 `Optional Type`으로 반환되기 때문에 실수할 일이 줄어들고 안정성이 더 높아진다고 생각했습니다.
    - 변경 전
    
    ```swift
    @IBAction func orderJuice(_ sender: UIButton) {
        let juiceMaker: JuiceMaker = JuiceMaker(fruitStore: fruitStore)
        let juices: [Juice] = [.strawberryBanana, .mangoKiwi, .strawberry, .banana, .pineapple, .kiwi, .mango]
        let selectedJuice = juices[sender.tag]
    }
    ```
    
    - 변경 후
    
    ```swift
    @IBAction func orderJuice(_ sender: UIButton) {
        let juiceMaker: JuiceMaker = JuiceMaker(fruitStore: fruitStore)
        guard let selectedJuice = Juice(rawValue: sender.tag) else { return }
    }
    ```
    
- ‘`FruitStore`가 왜 `Class` 로 정의되어 있고, `JuiceMaker`가 왜 `Struct`로 정의되어 있을까?’를 고민해봤습니다. 먼저, `FruitStore`가 `Class`인 이유는 `identity`(주소 값)가 필요하기 때문인 거 같습니다. 만약, `FruitStore`가 구조체 타입이고, A라는 `FruitStore` 타입 인스턴스를 생성하고, B라는 새로운 `FruitStore` 타입 인스턴스에 A 인스턴스를 바인딩한 뒤, A 라는 인스턴스를 통해 과일의 재고를 바꾼 뒤에 B라는 인스턴스 안에 있는 과일 재고를 확인하게 되면 A 인스턴스 안에 있는 과일 재고와 다르기 때문에 동일한 과일 재고로 관리할 수 없게 됩니다. 따라서, `FruitStore`는 `class`로 정의 되야한다고 생각합니다. 반대로 `JuiceMaker`는  `JuiceMaker` 타입의 인스턴스가 생성이 되는 상황에서도 `identity`(주소 값)가 유지되어야 하는 필요성이 없기 때문이라고 생각합니다.

### 조언을 얻고 싶은 부분
- 현재 `JuiceOrderViewController`에서 `Alert`을 띄워주는 메서드인 `presentInsufficientStockAlert(with:)`와 `presentJuiceReadyAlert(with:)`가 정의되어 있습니다. 그런데, `Alert`은 앱의 여러 `ViewController`에서 자주 사용될 수도 있기 때문에 `SingleTon class`로 아래와 같이 구현하게 된다면 `Alert`이 필요한 `ViewController`에서 `AlertManager`의 인스턴스에 접근해서 메서드만 호출하면 되니깐 편할거 같은데? 라는 생각을 해봤는데, 이에 대한 Gundy(건디) 생각이 궁금합니다!

```swift
import UIKit

class AlertManager {
    static let shared = AlertManager()
    
    private init() {}
    
    func presentSingleButtonAlertWith(title: String?,
                                      message: String?,
                                      buttonTitle: String,
                                      handler: @escaping (_ alert: UIAlertController) -> ()) {
        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
        let confirmButton = UIAlertAction(title: buttonTitle, style: .default)
        alert.addAction(confirmButton)

        handler(alert)
    }
    
    func presentTwoButtonAlertWith(title: String?,
                                   message: String?,
                                   firstButtonTitle: String,
                                   secondButtonTitle: String,
                                   buttonHandler: @escaping () -> (),
                                   handler: @escaping (_ alert: UIAlertController) -> ()) {
        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
        let confirmButton = UIAlertAction(title: firstButtonTitle, style: .default) { _ in
            buttonHandler()
        }
        let cancelButton = UIAlertAction(title: secondButtonTitle, style: .cancel)
        
        alert.addAction(confirmButton)
        alert.addAction(cancelButton)
        handler(alert)
    }
}
```

