### PR TITLE
쥬스 메이커 [STEP 2] MINT, Zion

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -7,11 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5BCC476A2A0E0F4E00908898 /* FruitStockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCC47692A0E0F4E00908898 /* FruitStockViewController.swift */; };
 		92BE81552A0CE6A9005A66F3 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BE81542A0CE6A9005A66F3 /* Fruit.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
+		C73DAF3B255D0CDD00020D38 /* JuiceOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */; };
 		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
@@ -19,12 +20,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		5BCC47692A0E0F4E00908898 /* FruitStockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStockViewController.swift; sourceTree = "<group>"; };
 		92BE81542A0CE6A9005A66F3 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C73DAF3A255D0CDD00020D38 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceOrderViewController.swift; sourceTree = "<group>"; };
 		C73DAF3D255D0CDD00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -48,7 +50,8 @@
 			children = (
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
-				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */,
+				5BCC47692A0E0F4E00908898 /* FruitStockViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -172,7 +175,8 @@
 			files = (
 				92BE81552A0CE6A9005A66F3 /* Fruit.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				5BCC476A2A0E0F4E00908898 /* FruitStockViewController.swift in Sources */,
+				C73DAF3B255D0CDD00020D38 /* JuiceOrderViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -9,7 +9,19 @@ import UIKit
 
 class FruitStockViewController: UIViewController {
     
+    
+    @IBOutlet weak var strawberryLabel: UILabel!
+    @IBOutlet var bananaLabel: UIView!
+    @IBOutlet weak var pineappleLabel: UILabel!
+    @IBOutlet weak var kiwiLabel: UILabel!
+    @IBOutlet weak var mangoLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }
+    
+    @IBAction func test(_ sender: UIStepper) {
+        print(sender.value)
+    }
+    
 }

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -2,7 +2,7 @@
 //  FruitStockViewController.swift
 //  JuiceMaker
 //
-//  Created by Hyungmin Lee on 2023/05/12.
+//  Created by Zion, Mint = 형민트 on 2023/05/12.
 //
 
 import UIKit

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -1,0 +1,15 @@
+//
+//  FruitStockViewController.swift
+//  JuiceMaker
+//
+//  Created by Hyungmin Lee on 2023/05/12.
+//
+
+import UIKit
+
+class FruitStockViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class FruitStockViewController: UIViewController {
+final class FruitStockViewController: UIViewController {
     @IBOutlet weak var strawberryLabel: UILabel!
     @IBOutlet var bananaLabel: UIView!
     @IBOutlet weak var pineappleLabel: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -8,8 +8,6 @@
 import UIKit
 
 class FruitStockViewController: UIViewController {
-    
-    
     @IBOutlet weak var strawberryLabel: UILabel!
     @IBOutlet var bananaLabel: UIView!
     @IBOutlet weak var pineappleLabel: UILabel!
@@ -19,9 +17,4 @@ class FruitStockViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-    
-    @IBAction func test(_ sender: UIStepper) {
-        print(sender.value)
-    }
-    
 }

--- a/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/FruitStockViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class FruitStockViewController: UIViewController {
     @IBOutlet weak var strawberryLabel: UILabel!
-    @IBOutlet var bananaLabel: UIView!
+    @IBOutlet weak var bananaLabel: UILabel!
     @IBOutlet weak var pineappleLabel: UILabel!
     @IBOutlet weak var kiwiLabel: UILabel!
     @IBOutlet weak var mangoLabel: UILabel!

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -7,38 +7,54 @@
 import UIKit
 
 final class JuiceOrderViewController: UIViewController {
-    @IBOutlet var fruitLabels: [UILabel]!
+    @IBOutlet weak var strawberryLabel: UILabel!
+    @IBOutlet weak var bananaLabel: UILabel!
+    @IBOutlet weak var pineappleLabel: UILabel!
+    @IBOutlet weak var kiwiLabel: UILabel!
+    @IBOutlet weak var mangoLabel: UILabel!
     
-    private let recipe: [JuiceMaker.Menu: [(Fruit, Int)]] = ([.strawberryJuice         : [(.strawberry, 16)],
-                                                              .bananaJuice             : [(.banana, 2)],
-                                                              .pineappleJuice          : [(.pineapple, 2)],
-                                                              .kiwiJuice               : [(.kiwi, 3)],
-                                                              .mangoJuice              : [(.mango, 3)],
-                                                              .strawberryAndBananaJuice: [(.strawberry, 10), (.banana, 1)],
-                                                              .mangoAndKiwiJuice       : [(.mango, 2), (.kiwi, 1)]])
+    private let recipe: [JuiceMaker.Menu: JuiceMaker.Recipe] = [.strawberryJuice         : [(.strawberry, 16)],
+                                                                 .bananaJuice             : [(.banana, 2)],
+                                                                 .pineappleJuice          : [(.pineapple, 2)],
+                                                                 .kiwiJuice               : [(.kiwi, 3)],
+                                                                 .mangoJuice              : [(.mango, 3)],
+                                                                 .strawberryAndBananaJuice: [(.strawberry, 10), (.banana, 1)],
+                                                                 .mangoAndKiwiJuice       : [(.mango, 2), (.kiwi, 1)]]
     
-    private let fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
-    private lazy var yagombucks = JuiceMaker(fruitStore, recipe)
+    private let fruitStore: FruitStore// = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
+    private var yagomJuiceStore: JuiceMaker// = JuiceMaker(fruitStore, recipe)
+    
+//    init() {
+//        fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
+//        yagomJuiceStore = JuiceMaker(fruitStore, recipe)
+//    }
+
+    required init?(coder: NSCoder) {
+        fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
+        yagomJuiceStore = JuiceMaker(fruitStore, recipe)
+        
+        super.init(coder: coder)
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        yagombucks.delegate = self
-        loadFruitStock()
+        yagomJuiceStore.delegate = self
+        setUpFruitLabelsText()
     }
     
-    private func loadFruitStock() {
-        for (index, fruit) in fruitLabels.enumerated() {
-            guard let pick = Fruit(rawValue: index) else { return }
-
-            fruit.text = String(fruitStore.provideFruitStock(pick))
-        }
+    private func setUpFruitLabelsText() {
+        strawberryLabel.text = String(fruitStore.provideFruitStock(.strawberry))
+        bananaLabel.text = String(fruitStore.provideFruitStock(.banana))
+        pineappleLabel.text = String(fruitStore.provideFruitStock(.pineapple))
+        kiwiLabel.text = String(fruitStore.provideFruitStock(.kiwi))
+        mangoLabel.text = String(fruitStore.provideFruitStock(.mango))
     }
     
-    private func moveToFruitStockViewController() {
-        guard let pushFruitStockViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController") else { return }
- 
-        self.navigationController?.pushViewController(pushFruitStockViewController, animated: true)
+    private func navigateToFruitStockViewController() {
+        guard let fruitStockViewController = storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController") else { return }
+        
+        navigationController?.pushViewController(fruitStockViewController, animated: true)
     }
 }
 
@@ -47,11 +63,11 @@ extension JuiceOrderViewController {
     @IBAction func tappedOrderButton(_ sender: UIButton) {
         guard let juice = JuiceMaker.Menu(rawValue: sender.tag) else { return }
         
-        yagombucks.makeJuice(menu: juice)
+        yagomJuiceStore.makeJuice(menu: juice)
     }
     
     @IBAction func tappedChangeStockButton(_ sender: Any) {
-        moveToFruitStockViewController()
+        navigateToFruitStockViewController()
     }
 }
 
@@ -75,18 +91,27 @@ extension JuiceOrderViewController: JuiceMakerDelegate {
         present(failAlert, animated: false)
     }
     
-    func changeFruitStock(fruit: Fruit, amount: String) {
-        let fruitIndex = fruit.rawValue
+    func changeFruitStock(fruit: Fruit, amount: Int) {
+        let stockLabelText = String(amount)
         
-        guard fruitIndex < fruitLabels.count else { return }
-        
-        fruitLabels[fruitIndex].text = amount
+        switch fruit {
+        case .strawberry:
+            strawberryLabel.text = stockLabelText
+        case .banana:
+            bananaLabel.text = stockLabelText
+        case .pineapple:
+            pineappleLabel.text = stockLabelText
+        case .kiwi:
+            kiwiLabel.text = stockLabelText
+        case .mango:
+            mangoLabel.text = stockLabelText
+        }
     }
 }
 
 // MARK: - Alert Handler
 extension JuiceOrderViewController {
     private func tappedYesButton(action: UIAlertAction) {
-        moveToFruitStockViewController()
+        navigateToFruitStockViewController()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -21,4 +21,3 @@ class JuiceOrderViewController: UIViewController {
         guard let juice = JuiceMaker.Menu(rawValue: sender.tag) else { return }
     }
 }
-

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -7,16 +7,15 @@
 import UIKit
 
 final class JuiceOrderViewController: UIViewController {
-    @IBOutlet var fruitLabel: [UILabel]!
+    @IBOutlet var fruitLabels: [UILabel]!
     
-    let recipe: [JuiceMaker.Menu: [(Fruit, Int)]] =
-    ([.strawberryJuice         : [(.strawberry, 16)],
-      .bananaJuice             : [(.banana, 2)],
-      .pineappleJuice          : [(.pineapple, 2)],
-      .kiwiJuice               : [(.kiwi, 3)],
-      .mangoJuice              : [(.mango, 3)],
-      .strawberryAndBananaJuice: [(.strawberry, 10), (.banana, 1)],
-      .mangoAndKiwiJuice       : [(.mango, 2), (.kiwi, 1)]])
+    private let recipe: [JuiceMaker.Menu: [(Fruit, Int)]] = ([.strawberryJuice         : [(.strawberry, 16)],
+                                                              .bananaJuice             : [(.banana, 2)],
+                                                              .pineappleJuice          : [(.pineapple, 2)],
+                                                              .kiwiJuice               : [(.kiwi, 3)],
+                                                              .mangoJuice              : [(.mango, 3)],
+                                                              .strawberryAndBananaJuice: [(.strawberry, 10), (.banana, 1)],
+                                                              .mangoAndKiwiJuice       : [(.mango, 2), (.kiwi, 1)]])
     
     private let fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
     private lazy var yagombucks = JuiceMaker(fruitStore, recipe)
@@ -29,7 +28,7 @@ final class JuiceOrderViewController: UIViewController {
     }
     
     private func loadFruitStock() {
-        for (index, fruit) in fruitLabel.enumerated() {
+        for (index, fruit) in fruitLabels.enumerated() {
             guard let pick = Fruit(rawValue: index) else { return }
 
             fruit.text = String(fruitStore.provideFruitStock(pick))
@@ -37,27 +36,27 @@ final class JuiceOrderViewController: UIViewController {
     }
     
     private func moveToFruitStockViewController() {
-        guard let pushJuiceOrderViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController") else { return }
+        guard let pushFruitStockViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController") else { return }
  
-        self.navigationController?.pushViewController(pushJuiceOrderViewController, animated: true)
+        self.navigationController?.pushViewController(pushFruitStockViewController, animated: true)
     }
 }
 
 // MARK: - Button Action
 extension JuiceOrderViewController {
-    @IBAction func orderButtonTapped(_ sender: UIButton) {
+    @IBAction func tappedOrderButton(_ sender: UIButton) {
         guard let juice = JuiceMaker.Menu(rawValue: sender.tag) else { return }
         
         yagombucks.makeJuice(menu: juice)
     }
     
-    @IBAction func changeStockButtonTapped(_ sender: Any) {
+    @IBAction func tappedChangeStockButton(_ sender: Any) {
         moveToFruitStockViewController()
     }
 }
 
 // MARK: - JuiceMake Delegate
-extension JuiceOrderViewController: JuiceMakeDelegate {
+extension JuiceOrderViewController: JuiceMakerDelegate {
     func successJuiceMake(_ menu: JuiceMaker.Menu) {
         let successAlert = UIAlertController(title: "주문 성공!", message: "\(menu.koreanName) 나왔습니다! 맛있게 드세요!", preferredStyle: .alert)
         let okButton = UIAlertAction(title: "확인", style: .default)
@@ -69,7 +68,7 @@ extension JuiceOrderViewController: JuiceMakeDelegate {
     func failJuiceMake() {
         let failAlert = UIAlertController(title: "주문 실패!", message: "재료가 모자라요. 재고를 수정할까요?", preferredStyle: .alert)
         let noButton = UIAlertAction(title: "아니오", style: .default)
-        let yesButton = UIAlertAction(title: "예", style: .default, handler: yesButtonTapped)
+        let yesButton = UIAlertAction(title: "예", style: .default, handler: tappedYesButton)
         
         failAlert.addAction(noButton)
         failAlert.addAction(yesButton)
@@ -79,15 +78,15 @@ extension JuiceOrderViewController: JuiceMakeDelegate {
     func changeFruitStock(fruit: Fruit, amount: String) {
         let fruitIndex = fruit.rawValue
         
-        guard fruitIndex < fruitLabel.count else { return }
+        guard fruitIndex < fruitLabels.count else { return }
         
-        fruitLabel[fruitIndex].text = amount
+        fruitLabels[fruitIndex].text = amount
     }
 }
 
 // MARK: - Alert Handler
 extension JuiceOrderViewController {
-    private func yesButtonTapped(action: UIAlertAction) {
+    private func tappedYesButton(action: UIAlertAction) {
         moveToFruitStockViewController()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -7,11 +7,8 @@
 import UIKit
 
 final class JuiceOrderViewController: UIViewController {
-    @IBOutlet weak var strawberryLabel: UILabel!
-    @IBOutlet weak var bananaLabel: UILabel!
-    @IBOutlet weak var pineappleLabel: UILabel!
-    @IBOutlet weak var kiwiLabel: UILabel!
-    @IBOutlet weak var mangoLabel: UILabel!
+    
+    @IBOutlet var fruitLabel: [UILabel]!
     
     private let fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
     private lazy var yagombucks = JuiceMaker(fruitStore: fruitStore)
@@ -24,11 +21,11 @@ final class JuiceOrderViewController: UIViewController {
     }
     
     private func loadFruitStock() {
-        strawberryLabel.text = String(fruitStore.provideFruitStock(.strawberry))
-        bananaLabel.text = String(fruitStore.provideFruitStock(.banana))
-        kiwiLabel.text = String(fruitStore.provideFruitStock(.kiwi))
-        mangoLabel.text = String(fruitStore.provideFruitStock(.mango))
-        pineappleLabel.text = String(fruitStore.provideFruitStock(.pineapple))
+        for (index, fruit) in fruitLabel.enumerated() {
+            guard let pick = Fruit(rawValue: index) else { return }
+
+            fruit.text = String(fruitStore.provideFruitStock(pick))
+        }
     }
 }
 
@@ -51,24 +48,27 @@ extension JuiceOrderViewController {
 extension JuiceOrderViewController: JuiceMakeDelegate {
     func successJuiceMake() {
         // Alert
+        let successAlert = UIAlertController(title: "주스 나왔습니다.", message: "맛있게 드세요!", preferredStyle: .alert)
+        let okButton = UIAlertAction(title: "확인", style: .default)
+        
+        successAlert.addAction(okButton)
+        present(successAlert, animated: false)
     }
     
     func failJuiceMake() {
         // Alert
+        let failAlert = UIAlertController(title: "재고가 없습니다.", message: "재고를 추가할까요?", preferredStyle: .alert)
+        let noButton = UIAlertAction(title: "아니오", style: .default)
+        let yesButton = UIAlertAction(title: "예", style: .default)
+        
+        failAlert.addAction(noButton)
+        failAlert.addAction(yesButton)
+        present(failAlert, animated: false)
     }
     
     func changeFruitStock(fruit: Fruit, amount: String) {
-        switch fruit {
-            case .strawberry:
-                strawberryLabel.text = amount
-            case .banana:
-                bananaLabel.text = amount
-            case .kiwi:
-                kiwiLabel.text = amount
-            case .mango:
-                mangoLabel.text = amount
-            case .pineapple:
-                pineappleLabel.text = amount
-        }
+        let fruitIndex = fruit.rawValue
+        
+        fruitLabel[fruitIndex].text = amount
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -7,7 +7,6 @@
 import UIKit
 
 final class JuiceOrderViewController: UIViewController {
-    
     @IBOutlet var fruitLabel: [UILabel]!
     
     private let fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
@@ -27,6 +26,12 @@ final class JuiceOrderViewController: UIViewController {
             fruit.text = String(fruitStore.provideFruitStock(pick))
         }
     }
+    
+    private func moveToFruitStockViewController() {
+        let pushJuiceOrderViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController")
+        
+        self.navigationController?.pushViewController(pushJuiceOrderViewController!, animated: true)
+    }
 }
 
 // MARK: - Button Action
@@ -38,16 +43,13 @@ extension JuiceOrderViewController {
     }
     
     @IBAction func changeStockButtonTapped(_ sender: Any) {
-        let pushJuiceOrderViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController")
-        
-        self.navigationController?.pushViewController(pushJuiceOrderViewController!, animated: true)
+        moveToFruitStockViewController()
     }
 }
 
 // MARK: - JuiceMake Delegate
 extension JuiceOrderViewController: JuiceMakeDelegate {
     func successJuiceMake() {
-        // Alert
         let successAlert = UIAlertController(title: "주스 나왔습니다.", message: "맛있게 드세요!", preferredStyle: .alert)
         let okButton = UIAlertAction(title: "확인", style: .default)
         
@@ -56,10 +58,9 @@ extension JuiceOrderViewController: JuiceMakeDelegate {
     }
     
     func failJuiceMake() {
-        // Alert
         let failAlert = UIAlertController(title: "재고가 없습니다.", message: "재고를 추가할까요?", preferredStyle: .alert)
         let noButton = UIAlertAction(title: "아니오", style: .default)
-        let yesButton = UIAlertAction(title: "예", style: .default)
+        let yesButton = UIAlertAction(title: "예", style: .default, handler: yesButtonTapped)
         
         failAlert.addAction(noButton)
         failAlert.addAction(yesButton)
@@ -70,5 +71,12 @@ extension JuiceOrderViewController: JuiceMakeDelegate {
         let fruitIndex = fruit.rawValue
         
         fruitLabel[fruitIndex].text = amount
+    }
+}
+
+// MARK: - Alert Handler
+extension JuiceOrderViewController {
+    private func yesButtonTapped(action: UIAlertAction) {
+        moveToFruitStockViewController()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -13,8 +13,22 @@ class JuiceOrderViewController: UIViewController {
     @IBOutlet weak var kiwiLabel: UILabel!
     @IBOutlet weak var mangoLabel: UILabel!
     
+    let fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
+    lazy var yagombucks = JuiceMaker(fruitStore: fruitStore)
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        yagombucks.delegate = self
+        showFirstStock()
+    }
+    
+    func showFirstStock() {
+        strawberryLabel.text = String(fruitStore.provideFruitStock(.strawberry))
+        bananaLabel.text = String(fruitStore.provideFruitStock(.banana))
+        kiwiLabel.text = String(fruitStore.provideFruitStock(.kiwi))
+        mangoLabel.text = String(fruitStore.provideFruitStock(.mango))
+        pineappleLabel.text = String(fruitStore.provideFruitStock(.pineapple))
     }
 }
 
@@ -22,6 +36,8 @@ class JuiceOrderViewController: UIViewController {
 extension JuiceOrderViewController {
     @IBAction func orderButtonTapped(_ sender: UIButton) {
         guard let juice = JuiceMaker.Menu(rawValue: sender.tag) else { return }
+        
+        yagombucks.makeJuice(menu: juice)
     }
     
     @IBAction func changeStockButtonTapped(_ sender: Any) {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -21,21 +21,9 @@ final class JuiceOrderViewController: UIViewController {
                                                                  .strawberryAndBananaJuice: [(.strawberry, 10), (.banana, 1)],
                                                                  .mangoAndKiwiJuice       : [(.mango, 2), (.kiwi, 1)]]
     
-    private let fruitStore: FruitStore// = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
-    private var yagomJuiceStore: JuiceMaker// = JuiceMaker(fruitStore, recipe)
-    
-//    init() {
-//        fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
-//        yagomJuiceStore = JuiceMaker(fruitStore, recipe)
-//    }
+    private let fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
+    private lazy var yagomJuiceStore = JuiceMaker(fruitStore, recipe)
 
-    required init?(coder: NSCoder) {
-        fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
-        yagomJuiceStore = JuiceMaker(fruitStore, recipe)
-        
-        super.init(coder: coder)
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -29,7 +29,7 @@ final class JuiceOrderViewController: UIViewController {
     
     private func moveToFruitStockViewController() {
         let pushJuiceOrderViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController")
-        
+ 
         self.navigationController?.pushViewController(pushJuiceOrderViewController!, animated: true)
     }
 }
@@ -58,7 +58,7 @@ extension JuiceOrderViewController: JuiceMakeDelegate {
     }
     
     func failJuiceMake() {
-        let failAlert = UIAlertController(title: "재고가 모자라요.", message: "재고를 수정할까요?", preferredStyle: .alert)
+        let failAlert = UIAlertController(title: "주문 실패!", message: "재료가 모자라요. 재고를 수정할까요?", preferredStyle: .alert)
         let noButton = UIAlertAction(title: "아니오", style: .default)
         let yesButton = UIAlertAction(title: "예", style: .default, handler: yesButtonTapped)
         

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -7,23 +7,18 @@
 import UIKit
 
 class JuiceOrderViewController: UIViewController {
-    
-    
     @IBOutlet weak var strawberryLabel: UILabel!
-    
     @IBOutlet weak var bananaLabel: UILabel!
-    
     @IBOutlet weak var pineappleLabel: UILabel!
-    
     @IBOutlet weak var kiwiLabel: UILabel!
-    
     @IBOutlet weak var mangoLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
     }
     
-    
+    @IBAction func orderButtonTapped(_ sender: UIButton) {
+        guard let juice = JuiceMaker.Menu(rawValue: sender.tag) else { return }
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -20,4 +20,9 @@ class JuiceOrderViewController: UIViewController {
     @IBAction func orderButtonTapped(_ sender: UIButton) {
         guard let juice = JuiceMaker.Menu(rawValue: sender.tag) else { return }
     }
+    
+    @IBAction func changeStockButtonTapped(_ sender: Any) {
+        let pushJuiceOrderViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController")
+        self.navigationController?.pushViewController(pushJuiceOrderViewController!, animated: true)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -6,24 +6,24 @@
 
 import UIKit
 
-class JuiceOrderViewController: UIViewController {
+final class JuiceOrderViewController: UIViewController {
     @IBOutlet weak var strawberryLabel: UILabel!
     @IBOutlet weak var bananaLabel: UILabel!
     @IBOutlet weak var pineappleLabel: UILabel!
     @IBOutlet weak var kiwiLabel: UILabel!
     @IBOutlet weak var mangoLabel: UILabel!
     
-    let fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
-    lazy var yagombucks = JuiceMaker(fruitStore: fruitStore)
+    private let fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
+    private lazy var yagombucks = JuiceMaker(fruitStore: fruitStore)
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         yagombucks.delegate = self
-        showFirstStock()
+        loadFruitStock()
     }
     
-    func showFirstStock() {
+    private func loadFruitStock() {
         strawberryLabel.text = String(fruitStore.provideFruitStock(.strawberry))
         bananaLabel.text = String(fruitStore.provideFruitStock(.banana))
         kiwiLabel.text = String(fruitStore.provideFruitStock(.kiwi))
@@ -42,6 +42,7 @@ extension JuiceOrderViewController {
     
     @IBAction func changeStockButtonTapped(_ sender: Any) {
         let pushJuiceOrderViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController")
+        
         self.navigationController?.pushViewController(pushJuiceOrderViewController!, animated: true)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -49,8 +49,8 @@ extension JuiceOrderViewController {
 
 // MARK: - JuiceMake Delegate
 extension JuiceOrderViewController: JuiceMakeDelegate {
-    func successJuiceMake() {
-        let successAlert = UIAlertController(title: "주스 나왔습니다.", message: "맛있게 드세요!", preferredStyle: .alert)
+    func successJuiceMake(_ menu: JuiceMaker.Menu) {
+        let successAlert = UIAlertController(title: "주문 성공!", message: "\(menu.koreanName) 나왔습니다! 맛있게 드세요!", preferredStyle: .alert)
         let okButton = UIAlertAction(title: "확인", style: .default)
         
         successAlert.addAction(okButton)
@@ -58,7 +58,7 @@ extension JuiceOrderViewController: JuiceMakeDelegate {
     }
     
     func failJuiceMake() {
-        let failAlert = UIAlertController(title: "재고가 없습니다.", message: "재고를 추가할까요?", preferredStyle: .alert)
+        let failAlert = UIAlertController(title: "재고가 모자라요.", message: "재고를 수정할까요?", preferredStyle: .alert)
         let noButton = UIAlertAction(title: "아니오", style: .default)
         let yesButton = UIAlertAction(title: "예", style: .default, handler: yesButtonTapped)
         

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -14,29 +14,29 @@ final class JuiceOrderViewController: UIViewController {
     @IBOutlet weak var mangoLabel: UILabel!
     
     private let recipe: [JuiceMaker.Menu: JuiceMaker.Recipe] = [.strawberryJuice         : [(.strawberry, 16)],
-                                                                 .bananaJuice             : [(.banana, 2)],
-                                                                 .pineappleJuice          : [(.pineapple, 2)],
-                                                                 .kiwiJuice               : [(.kiwi, 3)],
-                                                                 .mangoJuice              : [(.mango, 3)],
-                                                                 .strawberryAndBananaJuice: [(.strawberry, 10), (.banana, 1)],
-                                                                 .mangoAndKiwiJuice       : [(.mango, 2), (.kiwi, 1)]]
+                                                                .bananaJuice             : [(.banana, 2)],
+                                                                .pineappleJuice          : [(.pineapple, 2)],
+                                                                .kiwiJuice               : [(.kiwi, 3)],
+                                                                .mangoJuice              : [(.mango, 3)],
+                                                                .strawberryAndBananaJuice: [(.strawberry, 10), (.banana, 1)],
+                                                                .mangoAndKiwiJuice       : [(.mango, 2), (.kiwi, 1)]]
     
     private let fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
-    private lazy var yagomJuiceStore = JuiceMaker(fruitStore, recipe)
+    private lazy var juiceStore = JuiceMaker(fruitStore, recipe)
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        yagomJuiceStore.delegate = self
+        juiceStore.delegate = self
         setUpFruitLabelsText()
     }
     
     private func provideStockLabelText(fruit: Fruit) -> String {
-        guard let stockLabelText = fruitStore.provideFruitStock(fruit) else {
+        guard let stock = fruitStore.provideFruitStock(fruit) else {
             return "x"
         }
         
-        return String(stockLabelText)
+        return String(stock)
     }
     
     private func setUpFruitLabelsText() {
@@ -59,7 +59,7 @@ extension JuiceOrderViewController {
     @IBAction func tappedOrderButton(_ sender: UIButton) {
         guard let juice = JuiceMaker.Menu(rawValue: sender.tag) else { return }
         
-        yagomJuiceStore.makeJuice(menu: juice)
+        juiceStore.makeJuice(menu: juice)
     }
     
     @IBAction func tappedChangeStockButton(_ sender: Any) {
@@ -69,7 +69,7 @@ extension JuiceOrderViewController {
 
 // MARK: - JuiceMake Delegate
 extension JuiceOrderViewController: JuiceMakerDelegate {
-    func succeedJuiceMake(_ menu: JuiceMaker.Menu) {
+    func successJuiceMaking(_ menu: JuiceMaker.Menu) {
         let successAlert = UIAlertController(title: "주문 성공!", message: "\(menu.koreanName) 나왔습니다! 맛있게 드세요!", preferredStyle: .alert)
         let okButton = UIAlertAction(title: "확인", style: .default)
         
@@ -77,7 +77,7 @@ extension JuiceOrderViewController: JuiceMakerDelegate {
         present(successAlert, animated: false)
     }
     
-    func failJuiceMake() {
+    func failJuiceMaking() {
         let failAlert = UIAlertController(title: "주문 실패!", message: "재료가 모자라요. 재고를 수정할까요?", preferredStyle: .alert)
         let noButton = UIAlertAction(title: "아니오", style: .default)
         let yesButton = UIAlertAction(title: "예", style: .default, handler: tappedYesButton)

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -9,8 +9,17 @@ import UIKit
 final class JuiceOrderViewController: UIViewController {
     @IBOutlet var fruitLabel: [UILabel]!
     
+    let recipe: [JuiceMaker.Menu: [(Fruit, Int)]] =
+    ([.strawberryJuice         : [(.strawberry, 16)],
+      .bananaJuice             : [(.banana, 2)],
+      .pineappleJuice          : [(.pineapple, 2)],
+      .kiwiJuice               : [(.kiwi, 3)],
+      .mangoJuice              : [(.mango, 3)],
+      .strawberryAndBananaJuice: [(.strawberry, 10), (.banana, 1)],
+      .mangoAndKiwiJuice       : [(.mango, 2), (.kiwi, 1)]])
+    
     private let fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
-    private lazy var yagombucks = JuiceMaker(fruitStore: fruitStore)
+    private lazy var yagombucks = JuiceMaker(fruitStore, recipe)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -28,9 +37,9 @@ final class JuiceOrderViewController: UIViewController {
     }
     
     private func moveToFruitStockViewController() {
-        let pushJuiceOrderViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController")
+        guard let pushJuiceOrderViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController") else { return }
  
-        self.navigationController?.pushViewController(pushJuiceOrderViewController!, animated: true)
+        self.navigationController?.pushViewController(pushJuiceOrderViewController, animated: true)
     }
 }
 
@@ -69,6 +78,8 @@ extension JuiceOrderViewController: JuiceMakeDelegate {
     
     func changeFruitStock(fruit: Fruit, amount: String) {
         let fruitIndex = fruit.rawValue
+        
+        guard fruitIndex < fruitLabel.count else { return }
         
         fruitLabel[fruitIndex].text = amount
     }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -16,7 +16,10 @@ class JuiceOrderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-    
+}
+
+// MARK: - Button Action
+extension JuiceOrderViewController {
     @IBAction func orderButtonTapped(_ sender: UIButton) {
         guard let juice = JuiceMaker.Menu(rawValue: sender.tag) else { return }
     }
@@ -24,5 +27,31 @@ class JuiceOrderViewController: UIViewController {
     @IBAction func changeStockButtonTapped(_ sender: Any) {
         let pushJuiceOrderViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController")
         self.navigationController?.pushViewController(pushJuiceOrderViewController!, animated: true)
+    }
+}
+
+// MARK: - JuiceMake Delegate
+extension JuiceOrderViewController: JuiceMakeDelegate {
+    func successJuiceMake() {
+        // Alert
+    }
+    
+    func failJuiceMake() {
+        // Alert
+    }
+    
+    func changeFruitStock(fruit: Fruit, amount: String) {
+        switch fruit {
+            case .strawberry:
+                strawberryLabel.text = amount
+            case .banana:
+                bananaLabel.text = amount
+            case .kiwi:
+                kiwiLabel.text = amount
+            case .mango:
+                mangoLabel.text = amount
+            case .pineapple:
+                pineappleLabel.text = amount
+        }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -43,12 +43,20 @@ final class JuiceOrderViewController: UIViewController {
         setUpFruitLabelsText()
     }
     
+    private func provideStockLabelText(fruit: Fruit) -> String {
+        guard let stockLabelText = fruitStore.provideFruitStock(fruit) else {
+            return "x"
+        }
+        
+        return String(stockLabelText)
+    }
+    
     private func setUpFruitLabelsText() {
-        strawberryLabel.text = String(fruitStore.provideFruitStock(.strawberry))
-        bananaLabel.text = String(fruitStore.provideFruitStock(.banana))
-        pineappleLabel.text = String(fruitStore.provideFruitStock(.pineapple))
-        kiwiLabel.text = String(fruitStore.provideFruitStock(.kiwi))
-        mangoLabel.text = String(fruitStore.provideFruitStock(.mango))
+        strawberryLabel.text = provideStockLabelText(fruit: .strawberry)
+        bananaLabel.text = provideStockLabelText(fruit: .banana)
+        pineappleLabel.text = provideStockLabelText(fruit: .pineapple)
+        kiwiLabel.text = provideStockLabelText(fruit: .kiwi)
+        mangoLabel.text = provideStockLabelText(fruit: .mango)
     }
     
     private func navigateToFruitStockViewController() {
@@ -73,7 +81,7 @@ extension JuiceOrderViewController {
 
 // MARK: - JuiceMake Delegate
 extension JuiceOrderViewController: JuiceMakerDelegate {
-    func successJuiceMake(_ menu: JuiceMaker.Menu) {
+    func succeedJuiceMake(_ menu: JuiceMaker.Menu) {
         let successAlert = UIAlertController(title: "주문 성공!", message: "\(menu.koreanName) 나왔습니다! 맛있게 드세요!", preferredStyle: .alert)
         let okButton = UIAlertAction(title: "확인", style: .default)
         

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -6,10 +6,24 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class JuiceOrderViewController: UIViewController {
+    
+    
+    @IBOutlet weak var strawberryLabel: UILabel!
+    
+    @IBOutlet weak var bananaLabel: UILabel!
+    
+    @IBOutlet weak var pineappleLabel: UILabel!
+    
+    @IBOutlet weak var kiwiLabel: UILabel!
+    
+    @IBOutlet weak var mangoLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
     }
+    
+    
 }
 

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -5,7 +5,7 @@
 //  Created by Zion, Mint = 형민트 on 2023/05/11.
 //
 
-enum Fruit {
+enum Fruit: Int {
     case strawberry
     case banana
     case pineapple

--- a/JuiceMaker/JuiceMaker/Model/Fruit.swift
+++ b/JuiceMaker/JuiceMaker/Model/Fruit.swift
@@ -5,7 +5,7 @@
 //  Created by Zion, Mint = 형민트 on 2023/05/11.
 //
 
-enum Fruit: Int {
+enum Fruit {
     case strawberry
     case banana
     case pineapple

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -5,9 +5,9 @@
 //
 
 final class FruitStore {
-    private var fruitStocks: [Fruit : Int] 
+    private var fruitStocks: [Fruit: Int] 
     
-    init(fruitStocks: [Fruit : Int]) {
+    init(fruitStocks: [Fruit: Int]) {
         self.fruitStocks = fruitStocks
     }
     

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -25,8 +25,8 @@ final class FruitStore {
         fruitStocks[fruit] = stock + fruitAmount
     }
     
-    func provideFruitStock(_ fruit: Fruit) -> Int {
-        guard let stock = fruitStocks[fruit] else { return 0 }
+    func provideFruitStock(_ fruit: Fruit) -> Int? {
+        guard let stock = fruitStocks[fruit] else { return nil }
         
         return stock
     }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -24,4 +24,10 @@ final class FruitStore {
         
         fruitStocks[fruit] = stock + fruitAmount
     }
+    
+    func provideFruitStock(_ fruit: Fruit) -> Int {
+        guard let stock = fruitStocks[fruit] else { return 0 }
+        
+        return stock
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -26,7 +26,7 @@ final class FruitStore {
     }
     
     func provideFruitStock(_ fruit: Fruit) -> Int? {
-        guard let stock = fruitStocks[fruit] else { return nil }
+        let stock = fruitStocks[fruit]
         
         return stock
     }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -4,7 +4,7 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
-protocol JuiceMakeDelegate {
+protocol JuiceMakerDelegate {
     func successJuiceMake(_ menu: JuiceMaker.Menu)
     func failJuiceMake()
     func changeFruitStock(fruit: Fruit, amount: String)
@@ -42,8 +42,8 @@ struct JuiceMaker {
     
     typealias Recipe = [(fruit: Fruit, amount: Int)]
     private let store: FruitStore
-    var delegate: JuiceMakeDelegate?
-    var recipe: [Menu: Recipe]
+    var delegate: JuiceMakerDelegate?
+    let recipe: [Menu: Recipe]
     
     init(_ fruitStore: FruitStore, _ recipe: [Menu: Recipe]) {
         self.store = fruitStore

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -56,7 +56,7 @@ struct JuiceMaker {
         consumeFruit(recipe)
     }
     
-    func canMakeJuice(_ recipe: Recipe ) -> Bool {
+    private func canMakeJuice(_ recipe: Recipe ) -> Bool {
         guard recipe.allSatisfy({ fruit, amount in return store.isEnoughFruits(fruit, count: amount) }) else {
             delegate?.failJuiceMake()
             return false
@@ -65,7 +65,7 @@ struct JuiceMaker {
         return true
     }
     
-    func consumeFruit(_ recipe: Recipe) {
+    private func consumeFruit(_ recipe: Recipe) {
         recipe.forEach { fruit, amount in
             let leftFruitStock = store.provideFruitStock(fruit) - amount
             

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -43,32 +43,21 @@ struct JuiceMaker {
     typealias Recipe = [(fruit: Fruit, amount: Int)]
     private let store: FruitStore
     var delegate: JuiceMakeDelegate?
+    var recipe: [Menu: Recipe]
     
-    init(fruitStore: FruitStore) {
+    init(_ fruitStore: FruitStore, _ recipe: [Menu: Recipe]) {
         self.store = fruitStore
+        self.recipe = recipe
     }
 
-    private func provideRecipe(_ menu: Menu) -> Recipe {
-        switch menu {
-        case .strawberryJuice:
-            return [(.strawberry, 16)]
-        case .bananaJuice:
-            return [(.banana, 2)]
-        case .pineappleJuice:
-            return [(.pineapple, 2)]
-        case .kiwiJuice:
-            return [(.kiwi, 3)]
-        case .mangoJuice:
-            return [(.mango, 3)]
-        case .strawberryAndBananaJuice:
-            return [(.strawberry, 10), (.banana, 1)]
-        case .mangoAndKiwiJuice:
-            return [(.mango, 2), (.kiwi, 1)]
-        }
+    private func provideRecipe(_ menu: Menu) -> Recipe? {
+        guard let juiceRecipe = recipe[menu] else { return nil }
+        
+        return juiceRecipe
     }
     
     func makeJuice(menu: Menu) {
-        let recipe = provideRecipe(menu)
+        guard let recipe = provideRecipe(menu) else { return }
         
         guard canMakeJuice(recipe) else {
             delegate?.failJuiceMake()

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,8 +5,8 @@
 //
 
 struct JuiceMaker {
-    enum Menu {
-        case strawberryJuice
+    enum Menu: Int {
+        case strawberryJuice = 1
         case bananaJuice
         case pineappleJuice
         case kiwiJuice

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,7 +5,7 @@
 //
 
 protocol JuiceMakerDelegate {
-    func successJuiceMake(_ menu: JuiceMaker.Menu)
+    func succeedJuiceMake(_ menu: JuiceMaker.Menu)
     func failJuiceMake()
     func changeFruitStock(fruit: Fruit, amount: Int)
 }
@@ -65,18 +65,17 @@ struct JuiceMaker {
         }
         
         consumeFruit(recipe)
-        delegate?.successJuiceMake(menu)
+        delegate?.succeedJuiceMake(menu)
     }
     
     private func canMakeJuice(_ recipe: Recipe ) -> Bool {
-        guard recipe.allSatisfy({ fruit, amount in return store.isEnoughFruits(fruit, count: amount) }) else { return false }
-        
-        return true
+        return recipe.allSatisfy{ fruit, amount in return store.isEnoughFruits(fruit, count: amount) }
     }
     
     private func consumeFruit(_ recipe: Recipe) {
         recipe.forEach { fruit, amount in
-            let leftFruitStock = store.provideFruitStock(fruit) - amount
+            guard let fruitStock = store.provideFruitStock(fruit) else { return }
+            let leftFruitStock = fruitStock - amount
             
             delegate?.changeFruitStock(fruit: fruit, amount: leftFruitStock)
             store.changeFruitCount(fruit, count: amount)

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,8 +5,8 @@
 //
 
 protocol JuiceMakerDelegate {
-    func succeedJuiceMake(_ menu: JuiceMaker.Menu)
-    func failJuiceMake()
+    func successJuiceMaking(_ menu: JuiceMaker.Menu)
+    func failJuiceMaking()
     func changeFruitStock(fruit: Fruit, amount: Int)
 }
 
@@ -60,12 +60,12 @@ struct JuiceMaker {
         guard let recipe = provideRecipe(menu) else { return }
         
         guard canMakeJuice(recipe) else {
-            delegate?.failJuiceMake()
+            delegate?.failJuiceMaking()
             return
         }
         
         consumeFruit(recipe)
-        delegate?.succeedJuiceMake(menu)
+        delegate?.successJuiceMaking(menu)
     }
     
     private func canMakeJuice(_ recipe: Recipe ) -> Bool {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,7 +5,7 @@
 //
 
 protocol JuiceMakeDelegate {
-    func successJuiceMake()
+    func successJuiceMake(_ menu: JuiceMaker.Menu)
     func failJuiceMake()
     func changeFruitStock(fruit: Fruit, amount: String)
 }
@@ -19,6 +19,25 @@ struct JuiceMaker {
         case mangoJuice
         case strawberryAndBananaJuice
         case mangoAndKiwiJuice
+        
+        var koreanName: String {
+            switch self {
+            case .strawberryJuice:
+                return "딸기쥬스"
+            case .bananaJuice:
+                return "바나나쥬스"
+            case .pineappleJuice:
+                return "파인애플쥬스"
+            case .kiwiJuice:
+                return "키위쥬스"
+            case .mangoJuice:
+                return "망고쥬스"
+            case .strawberryAndBananaJuice:
+                return "딸바쥬스"
+            case .mangoAndKiwiJuice:
+                return "망키쥬스"
+            }
+        }
     }
     
     typealias Recipe = [(fruit: Fruit, amount: Int)]
@@ -57,6 +76,7 @@ struct JuiceMaker {
         }
         
         consumeFruit(recipe)
+        delegate?.successJuiceMake(menu)
     }
     
     private func canMakeJuice(_ recipe: Recipe ) -> Bool {
@@ -72,7 +92,5 @@ struct JuiceMaker {
             delegate?.changeFruitStock(fruit: fruit, amount: String(leftFruitStock))
             store.changeFruitCount(fruit, count: amount)
         }
-        
-        delegate?.successJuiceMake()
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -51,16 +51,16 @@ struct JuiceMaker {
     func makeJuice(menu: Menu) {
         let recipe = provideRecipe(menu)
         
-        guard canMakeJuice(recipe) else { return }
+        guard canMakeJuice(recipe) else {
+            delegate?.failJuiceMake()
+            return
+        }
         
         consumeFruit(recipe)
     }
     
     private func canMakeJuice(_ recipe: Recipe ) -> Bool {
-        guard recipe.allSatisfy({ fruit, amount in return store.isEnoughFruits(fruit, count: amount) }) else {
-            delegate?.failJuiceMake()
-            return false
-        }
+        guard recipe.allSatisfy({ fruit, amount in return store.isEnoughFruits(fruit, count: amount) }) else { return false }
         
         return true
     }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -41,14 +41,20 @@ struct JuiceMaker {
         }
     }
     
-    func canMakeJuice(menu: Menu) -> Bool {
+    func makeJuice(menu: Menu) {
         let recipe = provideRecipe(menu)
         
-        guard recipe.allSatisfy({ fruit, amount in return store.isEnoughFruits(fruit, count: amount) }) else { return false }
-
+        canMakeJuice(recipe)
+        consumeFruit(recipe)
+    }
+    
+    func canMakeJuice(_ recipe: Recipe ) {
+        guard recipe.allSatisfy({ fruit, amount in return store.isEnoughFruits(fruit, count: amount) }) else { return }
+    }
+    
+    func consumeFruit(_ recipe: Recipe) {
         recipe.forEach { fruit, amount in
             store.changeFruitCount(fruit, count: amount)
         }
-        return true
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -50,20 +50,20 @@ struct JuiceMaker {
 
     private func provideRecipe(_ menu: Menu) -> Recipe {
         switch menu {
-            case .strawberryJuice:
-                return [(.strawberry, 16)]
-            case .bananaJuice:
-                return [(.banana, 2)]
-            case .pineappleJuice:
-                return [(.pineapple, 2)]
-            case .kiwiJuice:
-                return [(.kiwi, 3)]
-            case .mangoJuice:
-                return [(.mango, 3)]
-            case .strawberryAndBananaJuice:
-                return [(.strawberry, 10), (.banana, 1)]
-            case .mangoAndKiwiJuice:
-                return [(.mango, 2), (.kiwi, 1)]
+        case .strawberryJuice:
+            return [(.strawberry, 16)]
+        case .bananaJuice:
+            return [(.banana, 2)]
+        case .pineappleJuice:
+            return [(.pineapple, 2)]
+        case .kiwiJuice:
+            return [(.kiwi, 3)]
+        case .mangoJuice:
+            return [(.mango, 3)]
+        case .strawberryAndBananaJuice:
+            return [(.strawberry, 10), (.banana, 1)]
+        case .mangoAndKiwiJuice:
+            return [(.mango, 2), (.kiwi, 1)]
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -6,7 +6,7 @@
 
 struct JuiceMaker {
     enum Menu: Int {
-        case strawberryJuice = 1
+        case strawberryJuice
         case bananaJuice
         case pineappleJuice
         case kiwiJuice

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -42,8 +42,8 @@ struct JuiceMaker {
     
     typealias Recipe = [(fruit: Fruit, amount: Int)]
     private let store: FruitStore
+    private let recipe: [Menu: Recipe]
     var delegate: JuiceMakerDelegate?
-    let recipe: [Menu: Recipe]
     
     init(_ fruitStore: FruitStore, _ recipe: [Menu: Recipe]) {
         self.store = fruitStore

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,7 +7,7 @@
 protocol JuiceMakerDelegate {
     func successJuiceMake(_ menu: JuiceMaker.Menu)
     func failJuiceMake()
-    func changeFruitStock(fruit: Fruit, amount: String)
+    func changeFruitStock(fruit: Fruit, amount: Int)
 }
 
 struct JuiceMaker {
@@ -78,7 +78,7 @@ struct JuiceMaker {
         recipe.forEach { fruit, amount in
             let leftFruitStock = store.provideFruitStock(fruit) - amount
             
-            delegate?.changeFruitStock(fruit: fruit, amount: String(leftFruitStock))
+            delegate?.changeFruitStock(fruit: fruit, amount: leftFruitStock)
             store.changeFruitCount(fruit, count: amount)
         }
     }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -381,7 +381,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
                     <connections>
-                        <outlet property="bananaLabel" destination="tKV-4l-Vtc" id="mSu-M6-Vtw"/>
+                        <outlet property="bananaLabel" destination="gKu-86-RhI" id="0Sb-Mk-LcP"/>
                         <outlet property="kiwiLabel" destination="ZDv-1m-HBY" id="atp-8L-iaL"/>
                         <outlet property="mangoLabel" destination="YJI-ER-LJR" id="Fmd-f6-iIf"/>
                         <outlet property="pineappleLabel" destination="MpT-VW-hCb" id="eqw-jE-JOI"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -268,10 +268,10 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--View Controller-->
+        <!--Fruit Stock View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" sceneMemberID="viewController">
+                <viewController id="Yu1-lM-nqp" customClass="FruitStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -370,12 +370,22 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="test:" destination="Yu1-lM-nqp" eventType="valueChanged" id="sir-SV-1do"/>
+                                </connections>
                             </stepper>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <connections>
+                        <outlet property="bananaLabel" destination="tKV-4l-Vtc" id="mSu-M6-Vtw"/>
+                        <outlet property="kiwiLabel" destination="ZDv-1m-HBY" id="atp-8L-iaL"/>
+                        <outlet property="mangoLabel" destination="YJI-ER-LJR" id="Fmd-f6-iIf"/>
+                        <outlet property="pineappleLabel" destination="MpT-VW-hCb" id="eqw-jE-JOI"/>
+                        <outlet property="strawberryLabel" destination="0yV-kn-zaT" id="jbA-dj-W9l"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -13,25 +13,25 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="JuiceOrderViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="60" y="52" width="724" height="136.66666666666666"/>
+                                <rect key="frame" x="63" y="52" width="718" height="136.66666666666666"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="148" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="296" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="444" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="592" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="60" y="208.66666666666663" width="724" height="140.33333333333337"/>
+                                <rect key="frame" x="63" y="208.66666666666663" width="718" height="140.33333333333337"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="724" height="66"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="718" height="66"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -128,11 +128,11 @@
                                                 </state>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="296" y="0.0" width="132" height="66"/>
+                                                <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="444" y="0.0" width="280" height="66"/>
+                                                <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -142,13 +142,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="74.000000000000028" width="724" height="66.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="74.000000000000028" width="718" height="66.333333333333343"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="724" height="66.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="718" height="66.333333333333329"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
@@ -156,7 +156,7 @@
                                                         </state>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
@@ -164,7 +164,7 @@
                                                         </state>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
@@ -172,7 +172,7 @@
                                                         </state>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
@@ -180,7 +180,7 @@
                                                         </state>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
@@ -217,6 +217,13 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
                     </navigationItem>
+                    <connections>
+                        <outlet property="bananaLabel" destination="gvk-pA-Lw5" id="irm-hk-mwh"/>
+                        <outlet property="kiwiLabel" destination="FZq-de-TJG" id="QLP-h2-et1"/>
+                        <outlet property="mangoLabel" destination="3Ce-SU-JeH" id="AnK-rN-aCn"/>
+                        <outlet property="pineappleLabel" destination="ccQ-Dk-PuY" id="k6o-sU-0at"/>
+                        <outlet property="strawberryLabel" destination="Qas-vP-td6" id="9Sh-vQ-M74"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -243,11 +243,11 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="bananaLabel" destination="gvk-pA-Lw5" id="irm-hk-mwh"/>
-                        <outlet property="kiwiLabel" destination="FZq-de-TJG" id="QLP-h2-et1"/>
-                        <outlet property="mangoLabel" destination="3Ce-SU-JeH" id="AnK-rN-aCn"/>
-                        <outlet property="pineappleLabel" destination="ccQ-Dk-PuY" id="k6o-sU-0at"/>
-                        <outlet property="strawberryLabel" destination="Qas-vP-td6" id="9Sh-vQ-M74"/>
+                        <outletCollection property="fruitLabel" destination="Qas-vP-td6" collectionClass="NSMutableArray" id="BVL-Ig-UDY"/>
+                        <outletCollection property="fruitLabel" destination="gvk-pA-Lw5" collectionClass="NSMutableArray" id="xYL-hS-asY"/>
+                        <outletCollection property="fruitLabel" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="Dc7-9I-x9W"/>
+                        <outletCollection property="fruitLabel" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="g5x-0Z-zfC"/>
+                        <outletCollection property="fruitLabel" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="tUj-9Z-oFF"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -243,11 +243,11 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outletCollection property="fruitLabels" destination="Qas-vP-td6" collectionClass="NSMutableArray" id="BVL-Ig-UDY"/>
-                        <outletCollection property="fruitLabels" destination="gvk-pA-Lw5" collectionClass="NSMutableArray" id="xYL-hS-asY"/>
-                        <outletCollection property="fruitLabels" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="Dc7-9I-x9W"/>
-                        <outletCollection property="fruitLabels" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="g5x-0Z-zfC"/>
-                        <outletCollection property="fruitLabels" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="tUj-9Z-oFF"/>
+                        <outlet property="bananaLabel" destination="gvk-pA-Lw5" id="9Fm-tT-Hvx"/>
+                        <outlet property="kiwiLabel" destination="FZq-de-TJG" id="EZG-1R-0Nd"/>
+                        <outlet property="mangoLabel" destination="3Ce-SU-JeH" id="FeT-5N-6FZ"/>
+                        <outlet property="pineappleLabel" destination="ccQ-Dk-PuY" id="9HR-aj-Daz"/>
+                        <outlet property="strawberryLabel" destination="Qas-vP-td6" id="qDj-nb-EOV"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -119,25 +119,31 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
                                         <rect key="frame" x="0.0" y="0.0" width="718" height="66"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                            <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
                                                 <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mfg-Dz-xPI"/>
+                                                </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
                                                 <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                            <button opaque="NO" tag="7" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
                                                 <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="VPh-kf-dH9"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -147,45 +153,60 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
                                                 <rect key="frame" x="0.0" y="0.0" width="718" height="66.333333333333329"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
+                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
                                                         <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4D0-uK-Y4N"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0WR-Su-nLw"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ogK-3R-hCy"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                    <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="OC5-xk-9H4"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uzv-jz-KUD"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                             </stackView>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="JuiceOrderViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="JuiceOrderViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BYZ-38-t0r" customClass="JuiceOrderViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -236,7 +236,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
+                            <connections>
+                                <action selector="changeStockButtonTapped:" destination="BYZ-38-t0r" id="RaK-3U-STQ"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="bananaLabel" destination="gvk-pA-Lw5" id="irm-hk-mwh"/>
@@ -271,7 +275,7 @@
         <!--Fruit Stock View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" customClass="FruitStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="FruitStockViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Yu1-lM-nqp" customClass="FruitStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -119,7 +119,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
                                         <rect key="frame" x="0.0" y="0.0" width="718" height="66"/>
                                         <subviews>
-                                            <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                            <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
                                                 <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -134,7 +134,7 @@
                                                 <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" tag="7" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                            <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
                                                 <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -153,7 +153,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
                                                 <rect key="frame" x="0.0" y="0.0" width="718" height="66.333333333333329"/>
                                                 <subviews>
-                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
                                                         <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -164,7 +164,7 @@
                                                             <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4D0-uK-Y4N"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -175,7 +175,7 @@
                                                             <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0WR-Su-nLw"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -186,7 +186,7 @@
                                                             <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ogK-3R-hCy"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -197,7 +197,7 @@
                                                             <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="OC5-xk-9H4"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                    <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -370,9 +370,6 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="test:" destination="Yu1-lM-nqp" eventType="valueChanged" id="sir-SV-1do"/>
-                                </connections>
                             </stepper>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -127,7 +127,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mfg-Dz-xPI"/>
+                                                    <action selector="tappedOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mfg-Dz-xPI"/>
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
@@ -142,7 +142,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="VPh-kf-dH9"/>
+                                                    <action selector="tappedOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="VPh-kf-dH9"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -161,7 +161,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4D0-uK-Y4N"/>
+                                                            <action selector="tappedOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4D0-uK-Y4N"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
@@ -172,7 +172,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0WR-Su-nLw"/>
+                                                            <action selector="tappedOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0WR-Su-nLw"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
@@ -183,7 +183,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ogK-3R-hCy"/>
+                                                            <action selector="tappedOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ogK-3R-hCy"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
@@ -194,7 +194,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="OC5-xk-9H4"/>
+                                                            <action selector="tappedOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="OC5-xk-9H4"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
@@ -205,7 +205,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uzv-jz-KUD"/>
+                                                            <action selector="tappedOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uzv-jz-KUD"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>
@@ -238,16 +238,16 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <action selector="changeStockButtonTapped:" destination="BYZ-38-t0r" id="RaK-3U-STQ"/>
+                                <action selector="tappedChangeStockButton:" destination="BYZ-38-t0r" id="RaK-3U-STQ"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outletCollection property="fruitLabel" destination="Qas-vP-td6" collectionClass="NSMutableArray" id="BVL-Ig-UDY"/>
-                        <outletCollection property="fruitLabel" destination="gvk-pA-Lw5" collectionClass="NSMutableArray" id="xYL-hS-asY"/>
-                        <outletCollection property="fruitLabel" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="Dc7-9I-x9W"/>
-                        <outletCollection property="fruitLabel" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="g5x-0Z-zfC"/>
-                        <outletCollection property="fruitLabel" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="tUj-9Z-oFF"/>
+                        <outletCollection property="fruitLabels" destination="Qas-vP-td6" collectionClass="NSMutableArray" id="BVL-Ig-UDY"/>
+                        <outletCollection property="fruitLabels" destination="gvk-pA-Lw5" collectionClass="NSMutableArray" id="xYL-hS-asY"/>
+                        <outletCollection property="fruitLabels" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="Dc7-9I-x9W"/>
+                        <outletCollection property="fruitLabels" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="g5x-0Z-zfC"/>
+                        <outletCollection property="fruitLabels" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="tUj-9Z-oFF"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -390,25 +390,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="901"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="cAf-jL-tPK">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="Yu1-lM-nqp" kind="relationship" relationship="rootViewController" id="wH1-3A-cBm"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="2s5-lS-967" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1637" y="21"/>
+            <point key="canvasLocation" x="762" y="908"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
@Gundy93 
안녕하세요 건디! 형민트 입니다.
Step2 PR 올립니다. 잘부탁드립니다~!

## 고민했던 점
### guard와 if 사이의 컨벤션

`makeJuice` 함수 내부에서 `canMakeJuice`의 `true`, `false`의 여부에 따라 성공과 실패 관련 사항을 처리하게 할 때 `guard 문`과 `if 문`의 사용에서 고민이 있었습니다. 처음 만들 때는 실패시 조기탈출을 위해 `guard 문`을 썼는데, 성공/ 실패에 따라 처리해야할 로직이 분명하게 나눠지기에 가독성을 위해서 `if 문`을 사용하는 것도 좋겠다는 의견이 나왔습니다. 고민 끝에 실패 시 조기탈출의 여부가 중요하다고 생각했기에 `guard 문`으로 작성하였습니다. 

```swift=
func makeJuice(menu: Menu) {
        let recipe = provideRecipe(menu)
        
        guard canMakeJuice(recipe) else {
            delegate?.failJuiceMake()
            return
        }
        
        consumeFruit(recipe)
        delegate?.successJuiceMake(menu)
    }
```

```swift=
func makeJuice(menu: Menu) {
        let recipe = provideRecipe(menu)
        
        if canMakeJuice(recipe) {
            consumeFruit(recipe)
            delegate?.successJuiceMake(menu)
        } else {
            delegate?.failJuiceMake()
        }
    }
```

## 조언을 얻고 싶은 점
### 화면전환 (modality:x push:o)
```swift=
private func moveToFruitStockViewController() {
        guard let pushJuiceOrderViewController = self.storyboard?.instantiateViewController(withIdentifier: "FruitStockViewController") else { return }
 
        self.navigationController?.pushViewController(pushJuiceOrderViewController, animated: true)
    }
```

먼저, `NavigationControlle`r의 `rootViewController`에 해당하는 `JuiceOrderViewController`는 `NavigationController` 내부에 속한 `ViewController`이기 때문에 최대한 `Navigate`를 활용한 화면 전환을 하도록 구현했습니다. 그 과정 중 스토리보드상에 불필요하게 2개의 `NavigationController`가 사용되어지고 있는 것을 발견했고 하나를 삭제했습니다. 

한편으로는 `NavigationController`로 `push`되는 `FruitStockViewController` 경우에는 `rootViewController`에 이어서 다음 화면으로 전환된다기 보다는 `rootViewController`의 데이터를 수정하는 독립적인 화면으로 판단했습니다. 따라서 이와 같이 기존 뷰에 독립적으로 출력할 수 있는 `modality` 형식으로의 화면전환을 생각해 봤으나 가로 화면에서는 상위 여백이 출력되어 `modal`임을 나타낼 수 있는 특징이 나오지 않기에 기존 `NavigationController`와의 차이점이 없어 고민 끝에 기존 사용했던 `NavigationController` 방법을 사용하였습니다.

이런 경우 형식이 `modality` 방법이나 `NavigationController` 방법이 차이가 없음에도 불구하고 이어지는 화면인지 독립적인 화면인지에 따라 방법을 선택해야 하는게 좋을 지 궁금합니다. 

## 해결하지 못한 점
### Main - ViewController 에서의 사용자 지정 initializer
```swift=
    private let fruitStore: FruitStore// = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
    private var yagombucks: JuiceMaker// = JuiceMaker(fruitStore, recipe)
    
    init() {
        fruitStore = FruitStore(fruitStocks: [.strawberry: 20, .banana: 20, .kiwi: 20, .mango: 20, .pineapple: 20])
        yagombucks = JuiceMaker(fruitStore, recipe)
        
        super.init()
    }
    
    required init?(coder: NSCoder) {
        fatalError("init(coder:) has not been implemented")
    }
```
`yagombucks`을 `lazy var`로 선언하여 연산 호출될 때 초기화를 실행하는 것 보다. 사용자 `JuiceOrderViewController`에서 사용자 지정 이니셜라이저를 사용해서 값을 초기화 하는 것이 좀 더 올바른 표현 방식이라 생각했습니다. 따라서 위와 같이 코드를 구현한 결과 잘못된 `init` 참조로 인한 `exception`이 발생했습니다.

<분석내용>
먼저 `UIViewController`를 상속받은 `JuiceOrderViewController`에서는 사용자 지정 이니셜라이저를 사용하지 않을 경우 `UIViewController`의 이니셜라이저를 자동으로 가져다가 사용하고 있는 것으로 알고 있습니다. 하지만 `JuiceOrderViewController`에서 사용자 지정 이니셜라이저를 정의하게 되면 `UIView`, `UIViewController`에서 `NSCoding protocol`을 채택하고 있기 때문에 그에 따라 정의된 `init`에 해당하는 `required init?`을 정의해 줘야합니다.

하지만 위의 코드에대한 실행 결과를 보면 `Main Storyboard`에 연결된 `JuiceOrderViewController`는 사용자 지정이니셜라이저가 호출되어 초기화 되지 못하고 잘못된 경로로 들어가 `Fatal Error`를 발생시켰습니다. `Fatal Error`는 해당 초기화 메서드가 구현되지 않았음을 나타내는 것으로 알고있습니다. 

`Main Storyboard`에 연결된 `ViewController` 사용자 지정 이니셜라이저를 사용하여 값을 초기화 해주는 것이 불가능한 것인지 그게 아니라면, 다른 초기화 방법이 존재하는 것인지가 궁금합니다.

<참고자료>
[1번](https://www.zehye.kr/ios/2021/08/03/iOS_required_init_coder/)
[2번](https://jeonyeohun.tistory.com/359)