### PR TITLE
쥬스 메이커 [STEP 2] redmango, hoon

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		785090FF2A0921F60077F4E3 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785090FE2A0921F60077F4E3 /* Fruit.swift */; };
 		785091012A0935910077F4E3 /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785091002A0935910077F4E3 /* Juice.swift */; };
 		78DB59ED2A09E90C00FD8C22 /* FruitStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DB59EC2A09E90C00FD8C22 /* FruitStoreError.swift */; };
+		78E35F082A1273120019901F /* StockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E35F072A1273120019901F /* StockViewController.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
@@ -24,6 +25,7 @@
 		785090FE2A0921F60077F4E3 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		785091002A0935910077F4E3 /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
 		78DB59EC2A09E90C00FD8C22 /* FruitStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStoreError.swift; sourceTree = "<group>"; };
+		78E35F072A1273120019901F /* StockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockViewController.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -53,6 +55,7 @@
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
 				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
+				78E35F072A1273120019901F /* StockViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -178,6 +181,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				785090FF2A0921F60077F4E3 /* Fruit.swift in Sources */,
+				78E35F082A1273120019901F /* StockViewController.swift in Sources */,
 				78DB59ED2A09E90C00FD8C22 /* FruitStoreError.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				785091012A0935910077F4E3 /* Juice.swift in Sources */,

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -10,11 +10,11 @@
 		785090FF2A0921F60077F4E3 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785090FE2A0921F60077F4E3 /* Fruit.swift */; };
 		785091012A0935910077F4E3 /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785091002A0935910077F4E3 /* Juice.swift */; };
 		78DB59ED2A09E90C00FD8C22 /* FruitStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DB59EC2A09E90C00FD8C22 /* FruitStoreError.swift */; };
-		78E35F082A1273120019901F /* StockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E35F072A1273120019901F /* StockViewController.swift */; };
+		78E35F082A1273120019901F /* StockManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E35F072A1273120019901F /* StockManagementViewController.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
 		C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF36255D0CDD00020D38 /* AppDelegate.swift */; };
 		C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */; };
-		C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* ViewController.swift */; };
+		C73DAF3B255D0CDD00020D38 /* JuiceOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */; };
 		C73DAF3E255D0CDD00020D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3C255D0CDD00020D38 /* Main.storyboard */; };
 		C73DAF40255D0CDE00020D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF3F255D0CDE00020D38 /* Assets.xcassets */; };
 		C73DAF43255D0CDF00020D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */; };
@@ -25,12 +25,12 @@
 		785090FE2A0921F60077F4E3 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		785091002A0935910077F4E3 /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
 		78DB59EC2A09E90C00FD8C22 /* FruitStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStoreError.swift; sourceTree = "<group>"; };
-		78E35F072A1273120019901F /* StockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockViewController.swift; sourceTree = "<group>"; };
+		78E35F072A1273120019901F /* StockManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockManagementViewController.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
 		C73DAF33255D0CDD00020D38 /* JuiceMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JuiceMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C73DAF36255D0CDD00020D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C73DAF3A255D0CDD00020D38 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuiceOrderViewController.swift; sourceTree = "<group>"; };
 		C73DAF3D255D0CDD00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C73DAF3F255D0CDE00020D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C73DAF42255D0CDF00020D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -54,8 +54,8 @@
 			children = (
 				C73DAF36255D0CDD00020D38 /* AppDelegate.swift */,
 				C73DAF38255D0CDD00020D38 /* SceneDelegate.swift */,
-				C73DAF3A255D0CDD00020D38 /* ViewController.swift */,
-				78E35F072A1273120019901F /* StockViewController.swift */,
+				C73DAF3A255D0CDD00020D38 /* JuiceOrderViewController.swift */,
+				78E35F072A1273120019901F /* StockManagementViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -181,11 +181,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				785090FF2A0921F60077F4E3 /* Fruit.swift in Sources */,
-				78E35F082A1273120019901F /* StockViewController.swift in Sources */,
+				78E35F082A1273120019901F /* StockManagementViewController.swift in Sources */,
 				78DB59ED2A09E90C00FD8C22 /* FruitStoreError.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				785091012A0935910077F4E3 /* Juice.swift in Sources */,
-				C73DAF3B255D0CDD00020D38 /* ViewController.swift in Sources */,
+				C73DAF3B255D0CDD00020D38 /* JuiceOrderViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,
 				C73DAF39255D0CDD00020D38 /* SceneDelegate.swift in Sources */,
 				C73DAF4C255D0D0400020D38 /* JuiceMaker.swift in Sources */,

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		785090FF2A0921F60077F4E3 /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785090FE2A0921F60077F4E3 /* Fruit.swift */; };
 		785091012A0935910077F4E3 /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785091002A0935910077F4E3 /* Juice.swift */; };
+		78715C9E2A1B13E5009AEBE5 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78715C9D2A1B13E5009AEBE5 /* CustomButton.swift */; };
 		78DB59ED2A09E90C00FD8C22 /* FruitStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DB59EC2A09E90C00FD8C22 /* FruitStoreError.swift */; };
 		78E35F082A1273120019901F /* StockManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E35F072A1273120019901F /* StockManagementViewController.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
@@ -24,6 +25,7 @@
 /* Begin PBXFileReference section */
 		785090FE2A0921F60077F4E3 /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		785091002A0935910077F4E3 /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
+		78715C9D2A1B13E5009AEBE5 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		78DB59EC2A09E90C00FD8C22 /* FruitStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStoreError.swift; sourceTree = "<group>"; };
 		78E35F072A1273120019901F /* StockManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockManagementViewController.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 				C73DAF3C255D0CDD00020D38 /* Main.storyboard */,
 				C73DAF3F255D0CDE00020D38 /* Assets.xcassets */,
 				C73DAF41255D0CDF00020D38 /* LaunchScreen.storyboard */,
+				78715C9D2A1B13E5009AEBE5 /* CustomButton.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -184,6 +187,7 @@
 				78E35F082A1273120019901F /* StockManagementViewController.swift in Sources */,
 				78DB59ED2A09E90C00FD8C22 /* FruitStoreError.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
+				78715C9E2A1B13E5009AEBE5 /* CustomButton.swift in Sources */,
 				785091012A0935910077F4E3 /* Juice.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* JuiceOrderViewController.swift in Sources */,
 				C73DAF37255D0CDD00020D38 /* AppDelegate.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+final class JuiceOrderViewController: UIViewController {
     @IBOutlet var fruitStockLabelCollection: [UILabel]!
     private var juiceMaker: JuiceMaker = JuiceMaker()
     

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -6,31 +6,30 @@
 
 import UIKit
 
+final class CustomButton: UIButton {
+    var customIdentifier: Juice?
+}
+
 final class JuiceOrderViewController: UIViewController {
     @IBOutlet var fruitStockLabelCollection: [UILabel]!
-    @IBOutlet var orderJuiceButtonCollection: [UIButton]!
+    @IBOutlet var orderJuiceButtonCollection: [CustomButton]!
     private var juiceMaker: JuiceMaker = JuiceMaker()
     
     private enum AlertType {
         case onlyConfirm
         case canCancel
     }
-    
-    private enum JuiceError: Error {
-        case outOfMenu
-    }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         fillStockLabel()
-        fillJuiceButtonIdentifier()
+        fillJuiceButtonCustomIdentifier()
     }
 
-    @IBAction func touchUpOrderButton(_ sender: UIButton) {
-        guard let buttonIdentifier = sender.accessibilityIdentifier else { return }
+    @IBAction func touchUpOrderButton(_ sender: CustomButton) {
+        guard let juice = sender.customIdentifier else { return }
         
         do {
-            let juice: Juice = try matchJuiceMenu(with: buttonIdentifier)
             try juiceMaker.makeOrder(juice)
             fillStockLabel()
             showAlert(message: "\(juice.koreanName) 쥬스 나왔습니다!", alertType: .onlyConfirm)
@@ -38,27 +37,6 @@ final class JuiceOrderViewController: UIViewController {
             showAlert(message: "재료가 모자라요. 재고를 수정할까요?", alertType: .canCancel)
         } catch {
             print("알 수 없는 오류 발생.")
-        }
-    }
-    
-    private func matchJuiceMenu(with buttonIdentifier: String) throws -> Juice {
-        switch buttonIdentifier {
-        case "strawberryJuice":
-            return .strawberryJuice
-        case "bananaJuice":
-            return .bananaJuice
-        case "pineappleJuice":
-            return .pineappleJuice
-        case "kiwiJuice":
-            return .kiwiJuice
-        case "mangoJuice":
-            return .mangoJuice
-        case "strawberryBananaJuice":
-            return .strawberryBananaJuice
-        case "mangoKiwiJuice":
-            return .mangoKiwiJuice
-        default:
-            throw JuiceError.outOfMenu
         }
     }
     
@@ -89,9 +67,9 @@ final class JuiceOrderViewController: UIViewController {
         }
     }
     
-    private func fillJuiceButtonIdentifier() {
+    private func fillJuiceButtonCustomIdentifier() {
         for index in orderJuiceButtonCollection.indices {
-            orderJuiceButtonCollection[index].accessibilityIdentifier = Juice.allCases[index].name
+            orderJuiceButtonCollection[index].customIdentifier = Juice.allCases[index]
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -17,7 +17,7 @@ final class JuiceOrderViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        changeStockLabel()
+        fillStockLabel()
     }
 
     @IBAction func touchUpOrderButton(_ sender: UIButton) {
@@ -29,7 +29,7 @@ final class JuiceOrderViewController: UIViewController {
 
         do {
             try juiceMaker.makeOrder(juice)
-            changeStockLabel()
+            fillStockLabel()
             showAlert(message: "\(juice.koreanName) 쥬스 나왔습니다!", alertType: .onlyConfirm)
         } catch FruitStoreError.outOfStock {
             showAlert(message: "재료가 모자라요. 재고를 수정할까요?", alertType: .canCancel)
@@ -57,9 +57,11 @@ final class JuiceOrderViewController: UIViewController {
         present(alert, animated: true)
     }
     
-    private func changeStockLabel() {
-        for (fruitStockLabel, fruit) in zip(fruitStockLabelCollection, Fruit.allCases) {
-            fruitStockLabel.text = juiceMaker.showRemainStock(of: fruit)
+    private func fillStockLabel() {
+        let currentStockList: [String] = juiceMaker.showRemainStock()
+        
+        for index in fruitStockLabelCollection.indices {
+            fruitStockLabelCollection[index].text = currentStockList[index]
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -10,6 +10,11 @@ final class JuiceOrderViewController: UIViewController {
     @IBOutlet var fruitStockLabelCollection: [UILabel]!
     private var juiceMaker: JuiceMaker = JuiceMaker()
     
+    enum AlertType {
+        case onlyConfirm
+        case canCancel
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         changeStockLabel()
@@ -25,28 +30,29 @@ final class JuiceOrderViewController: UIViewController {
         do {
             try juiceMaker.makeOrder(juice)
             changeStockLabel()
-            showSuccessAlert(message: "\(juice.koreanName) 쥬스 나왔습니다!")
+            showAlert(message: "\(juice.koreanName) 쥬스 나왔습니다!", alertType: .onlyConfirm)
         } catch FruitStoreError.outOfStock {
-            showFailureAlert(message: "재료가 모자라요. 재고를 수정할까요?")
+            showAlert(message: "재료가 모자라요. 재고를 수정할까요?", alertType: .canCancel)
         } catch {
             print("알 수 없는 오류 발생.")
         }
     }
     
-    private func showSuccessAlert(message: String) {
+    private func showAlert(message: String, alertType: AlertType) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        let confirmAction = UIAlertAction(title: "확인", style: .default)
-        alert.addAction(confirmAction)
-        present(alert, animated: true)
-    }
-    
-    private func showFailureAlert(message: String) {
-        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        let confirmAction = UIAlertAction(title: "예", style: .default) { _ in
-            self.performSegue(withIdentifier: "goToStockViewController", sender: nil)
+        var confirmAction: UIAlertAction = UIAlertAction(title: "확인", style: .default)
+        let cancelAction: UIAlertAction = UIAlertAction(title: "아니오", style: .destructive)
+                
+        switch alertType {
+        case .onlyConfirm:
+            break
+        case .canCancel:
+            confirmAction = UIAlertAction(title: "예", style: .default) { _ in
+                self.performSegue(withIdentifier: "goToStockViewController", sender: nil)
+            }
+            alert.addAction(cancelAction)
         }
-        let cancelAction = UIAlertAction(title: "아니오", style: .destructive)
-        alert.addAction(cancelAction)
+        
         alert.addAction(confirmAction)
         present(alert, animated: true)
     }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -6,10 +6,6 @@
 
 import UIKit
 
-final class CustomButton: UIButton {
-    var customIdentifier: Juice?
-}
-
 final class JuiceOrderViewController: UIViewController {
     @IBOutlet var fruitStockLabelCollection: [UILabel]!
     @IBOutlet var orderJuiceButtonCollection: [CustomButton]!
@@ -22,8 +18,8 @@ final class JuiceOrderViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        fillStockLabel()
-        fillJuiceButtonCustomIdentifier()
+        configureStockLabel()
+        configureJuiceButtonCustomIdentifier()
     }
 
     @IBAction func touchUpOrderButton(_ sender: CustomButton) {
@@ -31,7 +27,7 @@ final class JuiceOrderViewController: UIViewController {
         
         do {
             try juiceMaker.makeOrder(juice)
-            fillStockLabel()
+            configureStockLabel()
             showAlert(message: "\(juice.koreanName) 쥬스 나왔습니다!", alertType: .onlyConfirm)
         } catch FruitStoreError.outOfStock {
             showAlert(message: "재료가 모자라요. 재고를 수정할까요?", alertType: .canCancel)
@@ -59,7 +55,7 @@ final class JuiceOrderViewController: UIViewController {
         present(alert, animated: true)
     }
     
-    private func fillStockLabel() {
+    private func configureStockLabel() {
         let currentStockList: [String] = juiceMaker.showRemainStock()
         
         for index in fruitStockLabelCollection.indices {
@@ -67,7 +63,7 @@ final class JuiceOrderViewController: UIViewController {
         }
     }
     
-    private func fillJuiceButtonCustomIdentifier() {
+    private func configureJuiceButtonCustomIdentifier() {
         for index in orderJuiceButtonCollection.indices {
             orderJuiceButtonCollection[index].customIdentifier = Juice.allCases[index]
         }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceOrderViewController.swift
@@ -8,26 +8,29 @@ import UIKit
 
 final class JuiceOrderViewController: UIViewController {
     @IBOutlet var fruitStockLabelCollection: [UILabel]!
+    @IBOutlet var orderJuiceButtonCollection: [UIButton]!
     private var juiceMaker: JuiceMaker = JuiceMaker()
     
-    enum AlertType {
+    private enum AlertType {
         case onlyConfirm
         case canCancel
+    }
+    
+    private enum JuiceError: Error {
+        case outOfMenu
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         fillStockLabel()
+        fillJuiceButtonIdentifier()
     }
 
     @IBAction func touchUpOrderButton(_ sender: UIButton) {
-        guard let title = sender.titleLabel?.text,
-              let juice = Juice(rawValue: title)
-        else {
-            return
-        }
-
+        guard let buttonIdentifier = sender.accessibilityIdentifier else { return }
+        
         do {
+            let juice: Juice = try matchJuiceMenu(with: buttonIdentifier)
             try juiceMaker.makeOrder(juice)
             fillStockLabel()
             showAlert(message: "\(juice.koreanName) 쥬스 나왔습니다!", alertType: .onlyConfirm)
@@ -35,6 +38,27 @@ final class JuiceOrderViewController: UIViewController {
             showAlert(message: "재료가 모자라요. 재고를 수정할까요?", alertType: .canCancel)
         } catch {
             print("알 수 없는 오류 발생.")
+        }
+    }
+    
+    private func matchJuiceMenu(with buttonIdentifier: String) throws -> Juice {
+        switch buttonIdentifier {
+        case "strawberryJuice":
+            return .strawberryJuice
+        case "bananaJuice":
+            return .bananaJuice
+        case "pineappleJuice":
+            return .pineappleJuice
+        case "kiwiJuice":
+            return .kiwiJuice
+        case "mangoJuice":
+            return .mangoJuice
+        case "strawberryBananaJuice":
+            return .strawberryBananaJuice
+        case "mangoKiwiJuice":
+            return .mangoKiwiJuice
+        default:
+            throw JuiceError.outOfMenu
         }
     }
     
@@ -62,6 +86,12 @@ final class JuiceOrderViewController: UIViewController {
         
         for index in fruitStockLabelCollection.indices {
             fruitStockLabelCollection[index].text = currentStockList[index]
+        }
+    }
+    
+    private func fillJuiceButtonIdentifier() {
+        for index in orderJuiceButtonCollection.indices {
+            orderJuiceButtonCollection[index].accessibilityIdentifier = Juice.allCases[index].name
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockManagementViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockManagementViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class StockViewController: UIViewController {
+final class StockManagementViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -11,4 +11,8 @@ class StockViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
+    
+    @IBAction func goBackPreviousView(_ sender: UIButton) {
+        self.dismiss(animated: true)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/StockViewController.swift
@@ -1,0 +1,14 @@
+//
+//  StockViewController.swift
+//  JuiceMaker
+//
+//  Created by 훈맹구 on 2023/05/15.
+//
+
+import UIKit
+
+class StockViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 class ViewController: UIViewController {
-    @IBOutlet var fruitStockLabels: [UILabel]!
+    @IBOutlet var fruitStockLabelCollection: [UILabel]!
     private var juiceMaker: JuiceMaker = JuiceMaker()
     
     override func viewDidLoad() {
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
     }
 
     @IBAction func touchUpOrderButton(_ sender: UIButton) {
-        guard let title = sender.title(for: .normal),
+        guard let title = sender.titleLabel?.text,
               let juice = Juice(rawValue: title)
         else {
             return
@@ -52,7 +52,7 @@ class ViewController: UIViewController {
     }
     
     private func changeStockLabel() {
-        for (fruitStockLabel, fruit) in zip(fruitStockLabels, Fruit.allCases) {
+        for (fruitStockLabel, fruit) in zip(fruitStockLabelCollection, Fruit.allCases) {
             fruitStockLabel.text = juiceMaker.showRemainStock(of: fruit)
         }
     }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -26,7 +26,27 @@ class ViewController: UIViewController {
             return
         }
         
-        juiceMaker.makeOrder(juice)
+        if juiceMaker.makeOrder(juice) {
+            showSuccessAlert(message: "\(juice.koreanName) 쥬스 나왔습니다!")
+        } else {
+            showFailureAlert(message: "재료가 모자라요. 재고를 수정할까요?")
+        }
+    }
+    
+    func showSuccessAlert(message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let confirmAction = UIAlertAction(title: "확인", style: .default)
+        alert.addAction(confirmAction)
+        present(alert, animated: true)
+    }
+    
+    func showFailureAlert(message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let confirmAction = UIAlertAction(title: "예", style: .default)
+        let cancelAction = UIAlertAction(title: "아니오", style: .destructive)
+        alert.addAction(cancelAction)
+        alert.addAction(confirmAction)
+        present(alert, animated: true)
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -53,7 +53,7 @@ class ViewController: UIViewController {
     
     private func changeStockLabel() {
         for (fruitStockLabel, fruit) in zip(fruitStockLabels, Fruit.allCases) {
-            fruitStockLabel.text = juiceMaker.fruitStore.showRemainStock(of: fruit)
+            fruitStockLabel.text = juiceMaker.showRemainStock(of: fruit)
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -7,11 +7,7 @@
 import UIKit
 
 class ViewController: UIViewController {
-    @IBOutlet weak var strawberryStockLabel: UILabel!
-    @IBOutlet weak var bananaStockLabel: UILabel!
-    @IBOutlet weak var pineappleStockLabel: UILabel!
-    @IBOutlet weak var kiwiStockLabel: UILabel!
-    @IBOutlet weak var mangoStockLabel: UILabel!
+    @IBOutlet var fruitStockLabels: [UILabel]!
     private var juiceMaker: JuiceMaker = JuiceMaker()
     
     override func viewDidLoad() {
@@ -56,15 +52,8 @@ class ViewController: UIViewController {
     }
     
     private func changeStockLabel() {
-        strawberryStockLabel.text = juiceMaker
-            .fruitStore.showRemainStock(of: .strawberry)
-        bananaStockLabel.text = juiceMaker
-            .fruitStore.showRemainStock(of: .banana)
-        pineappleStockLabel.text = juiceMaker
-            .fruitStore.showRemainStock(of: .pineapple)
-        kiwiStockLabel.text = juiceMaker
-            .fruitStore.showRemainStock(of: .kiwi)
-        mangoStockLabel.text = juiceMaker
-            .fruitStore.showRemainStock(of: .mango)
+        for (fruitStockLabel, fruit) in zip(fruitStockLabels, Fruit.allCases) {
+            fruitStockLabel.text = juiceMaker.fruitStore.showRemainStock(of: fruit)
+        }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -12,10 +12,11 @@ class ViewController: UIViewController {
     @IBOutlet weak var pineappleStockLabel: UILabel!
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
-    var juiceMaker: JuiceMaker = JuiceMaker()
+    private var juiceMaker: JuiceMaker = JuiceMaker()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        changeStockLabel()
     }
 
     @IBAction func orderJuiceButton(_ sender: UIButton) {
@@ -24,20 +25,21 @@ class ViewController: UIViewController {
         }
         
         if juiceMaker.makeOrder(juice) {
+            changeStockLabel()
             showSuccessAlert(message: "\(juice.koreanName) 쥬스 나왔습니다!")
         } else {
             showFailureAlert(message: "재료가 모자라요. 재고를 수정할까요?")
         }
     }
     
-    func showSuccessAlert(message: String) {
+    private func showSuccessAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let confirmAction = UIAlertAction(title: "확인", style: .default)
         alert.addAction(confirmAction)
         present(alert, animated: true)
     }
     
-    func showFailureAlert(message: String) {
+    private func showFailureAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         let confirmAction = UIAlertAction(title: "예", style: .default) { _ in
             self.performSegue(withIdentifier: "goToStockViewController", sender: nil)
@@ -46,6 +48,19 @@ class ViewController: UIViewController {
         alert.addAction(cancelAction)
         alert.addAction(confirmAction)
         present(alert, animated: true)
+    }
+    
+    private func changeStockLabel() {
+        strawberryStockLabel.text = juiceMaker
+            .fruitStore.showRemainStock(of: .strawberry)
+        bananaStockLabel.text = juiceMaker
+            .fruitStore.showRemainStock(of: .banana)
+        pineappleStockLabel.text = juiceMaker
+            .fruitStore.showRemainStock(of: .pineapple)
+        kiwiStockLabel.text = juiceMaker
+            .fruitStore.showRemainStock(of: .kiwi)
+        mangoStockLabel.text = juiceMaker
+            .fruitStore.showRemainStock(of: .mango)
     }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -19,9 +19,13 @@ class ViewController: UIViewController {
         changeStockLabel()
     }
 
-    @IBAction func orderJuiceButton(_ sender: UIButton) {
-        guard let juice = Juice(rawValue: sender.tag) else { return }
-        
+    @IBAction func touchUpOrderButton(_ sender: UIButton) {
+        guard let title = sender.title(for: .normal),
+              let juice = Juice(rawValue: title)
+        else {
+            return
+        }
+
         do {
             try juiceMaker.makeOrder(juice)
             changeStockLabel()

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -8,11 +8,25 @@ import UIKit
 
 class ViewController: UIViewController {
 
+    @IBOutlet weak var strawberryStockLabel: UILabel!
+    @IBOutlet weak var bananaStockLabel: UILabel!
+    @IBOutlet weak var pineappleStockLabel: UILabel!
+    @IBOutlet weak var kiwiStockLabel: UILabel!
+    @IBOutlet weak var mangoStockLabel: UILabel!
+    
+    var juiceMaker: JuiceMaker = JuiceMaker()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
     }
 
-
+    @IBAction func orderJuiceButton(_ sender: UIButton) {
+        guard let juice = Juice(rawValue: sender.tag) else {
+            return
+        }
+        
+        juiceMaker.makeOrder(juice)
+    }
 }
 

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -7,18 +7,15 @@
 import UIKit
 
 class ViewController: UIViewController {
-
     @IBOutlet weak var strawberryStockLabel: UILabel!
     @IBOutlet weak var bananaStockLabel: UILabel!
     @IBOutlet weak var pineappleStockLabel: UILabel!
     @IBOutlet weak var kiwiStockLabel: UILabel!
     @IBOutlet weak var mangoStockLabel: UILabel!
-    
     var juiceMaker: JuiceMaker = JuiceMaker()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
     }
 
     @IBAction func orderJuiceButton(_ sender: UIButton) {
@@ -42,7 +39,9 @@ class ViewController: UIViewController {
     
     func showFailureAlert(message: String) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        let confirmAction = UIAlertAction(title: "예", style: .default)
+        let confirmAction = UIAlertAction(title: "예", style: .default) { _ in
+            self.performSegue(withIdentifier: "goToStockViewController", sender: nil)
+        }
         let cancelAction = UIAlertAction(title: "아니오", style: .destructive)
         alert.addAction(cancelAction)
         alert.addAction(confirmAction)

--- a/JuiceMaker/JuiceMaker/Controller/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ViewController.swift
@@ -20,15 +20,16 @@ class ViewController: UIViewController {
     }
 
     @IBAction func orderJuiceButton(_ sender: UIButton) {
-        guard let juice = Juice(rawValue: sender.tag) else {
-            return
-        }
+        guard let juice = Juice(rawValue: sender.tag) else { return }
         
-        if juiceMaker.makeOrder(juice) {
+        do {
+            try juiceMaker.makeOrder(juice)
             changeStockLabel()
             showSuccessAlert(message: "\(juice.koreanName) 쥬스 나왔습니다!")
-        } else {
+        } catch FruitStoreError.outOfStock {
             showFailureAlert(message: "재료가 모자라요. 재고를 수정할까요?")
+        } catch {
+            print("알 수 없는 오류 발생.")
         }
     }
     
@@ -63,4 +64,3 @@ class ViewController: UIViewController {
             .fruitStore.showRemainStock(of: .mango)
     }
 }
-

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -22,4 +22,8 @@ struct FruitStore {
             throw FruitStoreError.outOfStock(fruit: fruit)
         }
     }
+    
+    func showRemainStock(of fruit: Fruit) -> String {
+        return String(stockList[fruit] ?? 0)
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -23,7 +23,14 @@ struct FruitStore {
         }
     }
     
-    func getRemainStock(of fruit: Fruit) -> String {
-        return String(stockList[fruit] ?? 0)
+    func getRemainStock() -> [String] {
+        var fruitStockList: [String] = []
+        
+        for fruit in Fruit.allCases {
+            let currentStock: Int = stockList[fruit] ?? 0
+            fruitStockList.append(String(currentStock))
+        }
+        
+        return fruitStockList
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -23,7 +23,7 @@ struct FruitStore {
         }
     }
     
-    func showRemainStock(of fruit: Fruit) -> String {
+    func getRemainStock(of fruit: Fruit) -> String {
         return String(stockList[fruit] ?? 0)
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -19,7 +19,7 @@ struct FruitStore {
 
     func checkStock(witch fruit: Fruit, by quantity: Int) throws {
         guard let currentStock = stockList[fruit], currentStock >= quantity else {
-            throw FruitStoreError.outOfStock(fruit: fruit)
+            throw FruitStoreError.outOfStock
         }
     }
     

--- a/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStoreError.swift
@@ -6,5 +6,5 @@
 //
 
 enum FruitStoreError: Error {
-    case outOfStock(fruit: Fruit)
+    case outOfStock
 }

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -58,23 +58,4 @@ enum Juice: CaseIterable {
             return "망키"
         }
     }
-    
-    var name: String {
-        switch self {
-        case .strawberryJuice:
-            return "strawberryJuice"
-        case .bananaJuice:
-            return "bananaJuice"
-        case .pineappleJuice:
-            return "pineappleJuice"
-        case .kiwiJuice:
-            return "kiwiJuice"
-        case .mangoJuice:
-            return "mangoJuice"
-        case .strawberryBananaJuice:
-            return "strawberryBananaJuice"
-        case .mangoKiwiJuice:
-            return "mangoKiwiJuice"
-        }
-    }
 }

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -5,14 +5,14 @@
 //  Created by 훈맹구 on 2023/05/08.
 //
 
-enum Juice: Int {
-    case strawberryJuice
-    case bananaJuice
-    case kiwiJuice
-    case pineappleJuice
-    case strawberryBananaJuice
-    case mangoJuice
-    case mangoKiwiJuice
+enum Juice: String {
+    case strawberryJuice = "딸기쥬스 주문"
+    case bananaJuice = "바나나쥬스 주문"
+    case pineappleJuice = "파인애플쥬스 주문"
+    case kiwiJuice = "키위쥬스 주문"
+    case mangoJuice = "망고쥬스 주문"
+    case strawberryBananaJuice = "딸바쥬스 주문"
+    case mangoKiwiJuice = "망키쥬스 주문"
     
     struct Ingredient {
         let name: Fruit

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -5,14 +5,14 @@
 //  Created by 훈맹구 on 2023/05/08.
 //
 
-enum Juice: String {
-    case strawberryJuice = "딸기쥬스 주문"
-    case bananaJuice = "바나나쥬스 주문"
-    case pineappleJuice = "파인애플쥬스 주문"
-    case kiwiJuice = "키위쥬스 주문"
-    case mangoJuice = "망고쥬스 주문"
-    case strawberryBananaJuice = "딸바쥬스 주문"
-    case mangoKiwiJuice = "망키쥬스 주문"
+enum Juice: CaseIterable {
+    case strawberryJuice
+    case bananaJuice
+    case pineappleJuice
+    case kiwiJuice
+    case mangoJuice
+    case strawberryBananaJuice
+    case mangoKiwiJuice
     
     struct Ingredient {
         let name: Fruit
@@ -56,6 +56,25 @@ enum Juice: String {
             return "망고"
         case .mangoKiwiJuice:
             return "망키"
+        }
+    }
+    
+    var name: String {
+        switch self {
+        case .strawberryJuice:
+            return "strawberryJuice"
+        case .bananaJuice:
+            return "bananaJuice"
+        case .pineappleJuice:
+            return "pineappleJuice"
+        case .kiwiJuice:
+            return "kiwiJuice"
+        case .mangoJuice:
+            return "mangoJuice"
+        case .strawberryBananaJuice:
+            return "strawberryBananaJuice"
+        case .mangoKiwiJuice:
+            return "mangoKiwiJuice"
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -5,7 +5,7 @@
 //  Created by 훈맹구 on 2023/05/08.
 //
 
-enum Juice {
+enum Juice: Int {
     case strawberryJuice
     case bananaJuice
     case kiwiJuice

--- a/JuiceMaker/JuiceMaker/Model/Juice.swift
+++ b/JuiceMaker/JuiceMaker/Model/Juice.swift
@@ -39,4 +39,23 @@ enum Juice: Int {
                     Ingredient(name: .kiwi, quantity: 1)]
         }
     }
+    
+    var koreanName: String {
+        switch self {
+        case .strawberryJuice:
+            return "딸기"
+        case .bananaJuice:
+            return "바나나"
+        case .kiwiJuice:
+            return "키위"
+        case .pineappleJuice:
+            return "파인애플"
+        case .strawberryBananaJuice:
+            return "딸바"
+        case .mangoJuice:
+            return "망고"
+        case .mangoKiwiJuice:
+            return "망키"
+        }
+    }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,13 +7,14 @@
 struct JuiceMaker {
     var fruitStore: FruitStore = FruitStore()
     
-    mutating func makeOrder(juice: Juice) {
+    mutating func makeOrder(_ juice: Juice) {
         do {
             for ingredient in juice.recipe {
                 try fruitStore.checkStock(witch: ingredient.name, by: ingredient.quantity)
             }
             
             juice.recipe.forEach { fruitStore.decreaseStock(witch: $0.name, by: $0.quantity) }
+            print("주문하신 \(juice.recipe[0].name) 나왔습니다.")
         } catch FruitStoreError.outOfStock(let fruit) {
             print("\(fruit)의 재고가 부족합니다.")
         } catch {

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,7 +7,7 @@
 struct JuiceMaker {
     var fruitStore: FruitStore = FruitStore()
     
-    mutating func makeOrder(_ juice: Juice) {
+    mutating func makeOrder(_ juice: Juice) -> Bool {
         do {
             for ingredient in juice.recipe {
                 try fruitStore.checkStock(witch: ingredient.name, by: ingredient.quantity)
@@ -17,8 +17,12 @@ struct JuiceMaker {
             print("주문하신 \(juice.recipe[0].name) 나왔습니다.")
         } catch FruitStoreError.outOfStock(let fruit) {
             print("\(fruit)의 재고가 부족합니다.")
+            return false
         } catch {
             print("알 수 없는 오류 발생.")
+            return false
         }
+        
+        return true
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -15,7 +15,7 @@ struct JuiceMaker {
         juice.recipe.forEach { fruitStore.decreaseStock(witch: $0.name, by: $0.quantity) }
     }
     
-    func showRemainStock(of fruit: Fruit) -> String {
-        return fruitStore.getRemainStock(of: fruit)
+    func showRemainStock() -> [String] {
+        return fruitStore.getRemainStock()
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -7,22 +7,11 @@
 struct JuiceMaker {
     var fruitStore: FruitStore = FruitStore()
     
-    mutating func makeOrder(_ juice: Juice) -> Bool {
-        do {
-            for ingredient in juice.recipe {
-                try fruitStore.checkStock(witch: ingredient.name, by: ingredient.quantity)
-            }
-            
-            juice.recipe.forEach { fruitStore.decreaseStock(witch: $0.name, by: $0.quantity) }
-            print("주문하신 \(juice.recipe[0].name) 나왔습니다.")
-        } catch FruitStoreError.outOfStock(let fruit) {
-            print("\(fruit)의 재고가 부족합니다.")
-            return false
-        } catch {
-            print("알 수 없는 오류 발생.")
-            return false
+    mutating func makeOrder(_ juice: Juice) throws {
+        for ingredient in juice.recipe {
+            try fruitStore.checkStock(witch: ingredient.name, by: ingredient.quantity)
         }
         
-        return true
+        juice.recipe.forEach { fruitStore.decreaseStock(witch: $0.name, by: $0.quantity) }
     }
 }

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -5,7 +5,7 @@
 // 
 
 struct JuiceMaker {
-    var fruitStore: FruitStore = FruitStore()
+    private var fruitStore: FruitStore = FruitStore()
     
     mutating func makeOrder(_ juice: Juice) throws {
         for ingredient in juice.recipe {
@@ -13,5 +13,9 @@ struct JuiceMaker {
         }
         
         juice.recipe.forEach { fruitStore.decreaseStock(witch: $0.name, by: $0.quantity) }
+    }
+    
+    func showRemainStock(of fruit: Fruit) -> String {
+        return fruitStore.getRemainStock(of: fruit)
     }
 }

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -119,7 +119,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
                                         <rect key="frame" x="0.0" y="0.0" width="718" height="66"/>
                                         <subviews>
-                                            <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
                                                 <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -127,14 +127,14 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1G9-xx-QTc"/>
+                                                    <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tXn-ah-qD7"/>
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
                                                 <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
                                                 <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -142,7 +142,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="voe-eG-yGC"/>
+                                                    <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="goz-zp-Vu5"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -161,10 +161,10 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0hW-mG-Cit"/>
+                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1Ud-xA-3eh"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
                                                         <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -172,10 +172,10 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="oHB-et-53e"/>
+                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gi7-8w-tqH"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
                                                         <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -183,10 +183,10 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6cb-YL-4rP"/>
+                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kk9-Y2-3Ko"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
                                                         <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -194,10 +194,10 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ht0-ct-7xO"/>
+                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7IL-bX-KOA"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
                                                         <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -205,7 +205,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mgs-Cn-VAi"/>
+                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RWY-Eu-FeT"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -381,7 +381,7 @@
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="뒤로가기"/>
                                 <connections>
-                                    <action selector="goback:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="gbq-SN-l3P"/>
+                                    <action selector="goBackPreviousView:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="Jja-jM-dy8"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -375,6 +375,15 @@
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </stepper>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yJg-uA-UIe">
+                                <rect key="frame" x="47" y="17" width="83" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="뒤로가기"/>
+                                <connections>
+                                    <action selector="goback:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="gbq-SN-l3P"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -390,6 +399,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WwV-Td-3Bn" sceneMemberID="viewController">
                     <toolbarItems/>
+                    <navigationItem key="navigationItem" id="F9T-nh-SEd"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ufw-7J-6hD">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -119,7 +119,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
                                         <rect key="frame" x="0.0" y="0.0" width="718" height="66"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -134,7 +134,7 @@
                                                 <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
                                                 <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -153,7 +153,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
                                                 <rect key="frame" x="0.0" y="0.0" width="718" height="66.333333333333329"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -164,7 +164,7 @@
                                                             <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="h5F-Yz-XhM"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
                                                         <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -175,7 +175,7 @@
                                                             <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hga-28-MZe"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
                                                         <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -186,7 +186,7 @@
                                                             <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pbg-zN-QPw"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
                                                         <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -197,7 +197,7 @@
                                                             <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7ol-lh-md9"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm" customClass="CustomButton" customModule="JuiceMaker" customModuleProvider="target">
                                                         <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -248,13 +248,13 @@
                         <outletCollection property="fruitStockLabelCollection" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="T0M-FZ-YAb"/>
                         <outletCollection property="fruitStockLabelCollection" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="U9E-Nc-8NM"/>
                         <outletCollection property="fruitStockLabelCollection" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="teF-cv-lvX"/>
-                        <outletCollection property="orderJuiceButtonCollection" destination="avd-o5-3JM" collectionClass="NSMutableArray" id="DY6-PF-VdD"/>
-                        <outletCollection property="orderJuiceButtonCollection" destination="y2A-PH-DJY" collectionClass="NSMutableArray" id="pED-3U-K4F"/>
-                        <outletCollection property="orderJuiceButtonCollection" destination="BFb-ka-wGA" collectionClass="NSMutableArray" id="Hvv-NZ-Dsx"/>
-                        <outletCollection property="orderJuiceButtonCollection" destination="wcW-7H-RXw" collectionClass="NSMutableArray" id="Rtx-gJ-yHL"/>
-                        <outletCollection property="orderJuiceButtonCollection" destination="q6G-4X-bVm" collectionClass="NSMutableArray" id="YgL-lG-sFX"/>
-                        <outletCollection property="orderJuiceButtonCollection" destination="hrc-2F-fzl" collectionClass="NSMutableArray" id="6he-FV-kiA"/>
-                        <outletCollection property="orderJuiceButtonCollection" destination="ngP-kF-Yii" collectionClass="NSMutableArray" id="Rzj-ky-IR6"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="avd-o5-3JM" collectionClass="NSMutableArray" id="j01-0U-IWG"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="y2A-PH-DJY" collectionClass="NSMutableArray" id="Io3-i5-IXr"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="BFb-ka-wGA" collectionClass="NSMutableArray" id="hC7-18-6Qb"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="wcW-7H-RXw" collectionClass="NSMutableArray" id="Xa0-81-0JQ"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="q6G-4X-bVm" collectionClass="NSMutableArray" id="skg-Ne-0m3"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="hrc-2F-fzl" collectionClass="NSMutableArray" id="ITr-D9-rcd"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="ngP-kF-Yii" collectionClass="NSMutableArray" id="zkh-gF-QwL"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -127,7 +127,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tXn-ah-qD7"/>
+                                                    <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="jcR-bw-SxD"/>
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
@@ -142,7 +142,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="goz-zp-Vu5"/>
+                                                    <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="lbN-Ku-3cV"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -161,7 +161,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1Ud-xA-3eh"/>
+                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="h5F-Yz-XhM"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
@@ -172,7 +172,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gi7-8w-tqH"/>
+                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hga-28-MZe"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
@@ -183,7 +183,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kk9-Y2-3Ko"/>
+                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pbg-zN-QPw"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
@@ -194,7 +194,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7IL-bX-KOA"/>
+                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7ol-lh-md9"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
@@ -205,7 +205,7 @@
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
                                                         <connections>
-                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="RWY-Eu-FeT"/>
+                                                            <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wAV-DX-NmQ"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>
@@ -243,11 +243,11 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="nzA-AK-q90"/>
-                        <outlet property="kiwiStockLabel" destination="FZq-de-TJG" id="tqv-Ld-K9n"/>
-                        <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="Ahn-Ot-ahm"/>
-                        <outlet property="pineappleStockLabel" destination="ccQ-Dk-PuY" id="0Ng-dq-amb"/>
-                        <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="kH8-VG-vA1"/>
+                        <outletCollection property="fruitStockLabels" destination="Qas-vP-td6" collectionClass="NSMutableArray" id="Ql8-Zb-QTJ"/>
+                        <outletCollection property="fruitStockLabels" destination="gvk-pA-Lw5" collectionClass="NSMutableArray" id="1d8-tY-0xP"/>
+                        <outletCollection property="fruitStockLabels" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="T0M-FZ-YAb"/>
+                        <outletCollection property="fruitStockLabels" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="U9E-Nc-8NM"/>
+                        <outletCollection property="fruitStockLabels" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="teF-cv-lvX"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -2,7 +2,6 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -13,7 +12,7 @@
         <!--맛있는 쥬스를 만들어 드려요!-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="JuiceOrderViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -272,10 +271,10 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--Stock View Controller-->
+        <!--Stock Management View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" customClass="StockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="Yu1-lM-nqp" customClass="StockManagementViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -236,7 +236,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
-                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
+                        <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
+                            <connections>
+                                <segue destination="WwV-Td-3Bn" kind="presentation" identifier="goToStockViewController" id="G6Z-Ha-EkU"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="nzA-AK-q90"/>
@@ -268,10 +272,10 @@
             </objects>
             <point key="canvasLocation" x="19.419642857142858" y="92.753623188405811"/>
         </scene>
-        <!--View Controller-->
+        <!--Stock View Controller-->
         <scene sceneID="fkG-vv-hpE">
             <objects>
-                <viewController id="Yu1-lM-nqp" sceneMemberID="viewController">
+                <viewController id="Yu1-lM-nqp" customClass="StockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
                         <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -397,7 +401,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2s5-lS-967" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1637" y="21"/>
+            <point key="canvasLocation" x="1636" y="92"/>
         </scene>
     </scenes>
     <resources>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -19,19 +19,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="60" y="52" width="724" height="136.66666666666666"/>
+                                <rect key="frame" x="63" y="52" width="718" height="136.66666666666666"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="148" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="296" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="444" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="592" y="0.0" width="132" height="136.66666666666666"/>
+                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="136.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="132" height="105.66666666666667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="113.66666666666666" width="132" height="23"/>
+                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,78 +114,99 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="60" y="208.66666666666663" width="724" height="140.33333333333337"/>
+                                <rect key="frame" x="63" y="208.66666666666663" width="718" height="140.33333333333337"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="724" height="66"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="718" height="66"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="280" height="66"/>
+                                            <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                                <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1G9-xx-QTc"/>
+                                                </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="296" y="0.0" width="132" height="66"/>
+                                                <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="444" y="0.0" width="280" height="66"/>
+                                            <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                                <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="66"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="voe-eG-yGC"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="74.000000000000028" width="724" height="66.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="74.000000000000028" width="718" height="66.333333333333343"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="724" height="66.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="718" height="66.333333333333329"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="132" height="66.333333333333329"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="딸기쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0hW-mG-Cit"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="148" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="바나나쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="oHB-et-53e"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="296" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="파인애플쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6cb-YL-4rP"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="444" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="키위쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ht0-ct-7xO"/>
+                                                        </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="592" y="0.0" width="132" height="66.333333333333329"/>
+                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="66.333333333333329"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <state key="normal" title="망고쥬스 주문">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <connections>
+                                                            <action selector="orderJuiceButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mgs-Cn-VAi"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                             </stackView>
@@ -217,6 +238,13 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT"/>
                     </navigationItem>
+                    <connections>
+                        <outlet property="bananaStockLabel" destination="gvk-pA-Lw5" id="nzA-AK-q90"/>
+                        <outlet property="kiwiStockLabel" destination="FZq-de-TJG" id="tqv-Ld-K9n"/>
+                        <outlet property="mangoStockLabel" destination="3Ce-SU-JeH" id="Ahn-Ot-ahm"/>
+                        <outlet property="pineappleStockLabel" destination="ccQ-Dk-PuY" id="0Ng-dq-amb"/>
+                        <outlet property="strawberryStockLabel" destination="Qas-vP-td6" id="kH8-VG-vA1"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -243,11 +243,11 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outletCollection property="fruitStockLabels" destination="Qas-vP-td6" collectionClass="NSMutableArray" id="Ql8-Zb-QTJ"/>
-                        <outletCollection property="fruitStockLabels" destination="gvk-pA-Lw5" collectionClass="NSMutableArray" id="1d8-tY-0xP"/>
-                        <outletCollection property="fruitStockLabels" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="T0M-FZ-YAb"/>
-                        <outletCollection property="fruitStockLabels" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="U9E-Nc-8NM"/>
-                        <outletCollection property="fruitStockLabels" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="teF-cv-lvX"/>
+                        <outletCollection property="fruitStockLabelCollection" destination="Qas-vP-td6" collectionClass="NSMutableArray" id="Ql8-Zb-QTJ"/>
+                        <outletCollection property="fruitStockLabelCollection" destination="gvk-pA-Lw5" collectionClass="NSMutableArray" id="1d8-tY-0xP"/>
+                        <outletCollection property="fruitStockLabelCollection" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="T0M-FZ-YAb"/>
+                        <outletCollection property="fruitStockLabelCollection" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="U9E-Nc-8NM"/>
+                        <outletCollection property="fruitStockLabelCollection" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="teF-cv-lvX"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -247,6 +248,13 @@
                         <outletCollection property="fruitStockLabelCollection" destination="ccQ-Dk-PuY" collectionClass="NSMutableArray" id="T0M-FZ-YAb"/>
                         <outletCollection property="fruitStockLabelCollection" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="U9E-Nc-8NM"/>
                         <outletCollection property="fruitStockLabelCollection" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="teF-cv-lvX"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="avd-o5-3JM" collectionClass="NSMutableArray" id="DY6-PF-VdD"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="y2A-PH-DJY" collectionClass="NSMutableArray" id="pED-3U-K4F"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="BFb-ka-wGA" collectionClass="NSMutableArray" id="Hvv-NZ-Dsx"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="wcW-7H-RXw" collectionClass="NSMutableArray" id="Rtx-gJ-yHL"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="q6G-4X-bVm" collectionClass="NSMutableArray" id="YgL-lG-sFX"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="hrc-2F-fzl" collectionClass="NSMutableArray" id="6he-FV-kiA"/>
+                        <outletCollection property="orderJuiceButtonCollection" destination="ngP-kF-Yii" collectionClass="NSMutableArray" id="Rzj-ky-IR6"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/CustomButton.swift
+++ b/JuiceMaker/JuiceMaker/View/CustomButton.swift
@@ -1,0 +1,12 @@
+//
+//  CustomButton.swift
+//  JuiceMaker
+//
+//  Created by Daehoon Lee on 2023/05/22.
+//
+
+import UIKit
+
+final class CustomButton: UIButton {
+    var customIdentifier: Juice?
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,213 @@
+# 🍓🍌🧃 쥬스 메이커
+
+## 📖 목차
+1. [소개](#-소개)
+2. [팀원](#-팀원)
+3. [타임라인](#-타임라인)
+4. [시각화된 프로젝트 구조](#-시각화된-프로젝트-구조)
+5. [실행 화면](#-실행-화면)
+6. [트러블 슈팅](#-트러블-슈팅)
+7. [참고 링크](#-참고-링크)
+8. [팀 회고](#-팀-회고)
+
+</br>
+
+## 🍀 소개
+훈맹구(`hoon`, `redmango`) 팀이 만든 쥬스 메이커 프로젝트입니다.
+
+* 주요 개념: `Initialization`, `Access Control`, `Nested Types`, `Type Casting`, `Error Handling`
+
+</br>
+
+## 👨‍💻 팀원
+| redmango | hoon |
+| :--------: | :--------: |
+| <Img src = "https://hackmd.io/_uploads/HJ2D-DoNn.png" width="200"> |<Img src="https://hackmd.io/_uploads/HylLMDsN2.jpg" width="200"> |
+|[Github Profile](https://github.com/redmango1447) |[Github Profile](https://github.com/Hoon94) |
+
+
+
+</br>
+
+## ⏰ 타임라인
+|날짜|내용|
+|:--:|--|
+|2023.05.08.| - `fruit` 인스턴스 생성을 위한 `Fruit` 클래스 추가 <br> - 쥬스 레시피를 위한 `Recipe` 열거형 추가 |
+|2023.05.09.| - 쥬스를 만드는 기능과 쥬스의 재료 부족 시 오류 처리 추가 |
+|2023.05.10.| - `Fruit`, `Recipe` 사용자 타입 리팩토링 <br> - `Ingredient` 구조체 추가 | 
+|2023.05.11.| - `FruitStore` `struct` 타입으로 변경 <br> - 재료 차감시 발생하는 오류 수정 |
+|2023.05.12.| - `decereaseStock` 메서드 수정|
+
+</br>
+
+## 👀 시각화된 프로젝트 구조 - 추후 추가 예정
+
+### Flowchart
+<p align="center">
+<img width="800" src="">
+</p>
+
+
+### Diagram
+<p align="center">
+<img width="800" src="">
+</p>
+
+</br>
+
+## 💻 실행 화면 - 추후 추가 예정
+
+| 화면 1 | 화면 2 |
+|:--------:|:--------:|
+|<img src=  width="300">|<img src=  width="300">|
+
+</br>
+
+## 🧨 트러블 슈팅
+
+1️⃣ **`Fruit` 사용자 타입 생성** <br>
+-
+🔒 **문제점** <br>
+
+- 다양한 종류의 과일 예제들이 미션에서 주어졌습니다. 주어진 과일에 대해 이름과 수량을 저장하고 있어야 했기 때문에 `class` 타입을 활용하여 `Fruit`을 생성하였습니다.
+
+    ```swift
+    class Fruit {
+        var name: String
+        var quantity: Int
+
+        init(name: String, quantity: Int) {
+            self.name = name
+            self.quantity = quantity
+        }
+    }
+    ```
+
+🔑 **해결방법** <br>
+
+- 처음 생성한 `Fruit`은 수량을 의미하는 `quantity` 프로퍼티를 가지고 있었습니다. 하지만 과일이라는 네이밍의 클래스 안에 과일의 이름, 색, 당도 등의 프로퍼티는 가능하지만 과일 객체 자체가 자신의 수량을 가지고 있다는 점이 객체지향적 관점에서는 어색하다는 말씀을 듣고 이번 과제를 하며 다시 객체에 대해 생각해 보는 시간이 되었습니다.
+    ```swift
+    enum Fruit: CaseIterable {
+        case strawberry
+        case banana
+        case pineapple
+        case kiwi
+        case mango
+    }
+    ```
+    `Fruit`에서 어색한 `quantity`를 빼고 위와 같이 `enum`으로 재정의 하였습니다.
+
+
+<br>
+
+2️⃣ **과일 종류에 따른 초기화 방법** <br>
+-
+🔒 **문제점** <br>
+
+- `FruitStore`에 생성한 `stockList` 프로퍼티에 각각의 과일 초기 수량을 저장하기 위해 `dictionary` 타입을 사용하였습니다. 과일 초기 값이 10이라는 요구사항을 지키기 위해 프로퍼티에 기본 값을 할당하려 했지만 만약 초기 값이 변경 된다면 `dictionary`의 특성과 `Fruit`의 갯수에 따라 수정하기가 힘들수도 있다고 판단 되었습니다. 그에따라 처음엔 메서드를 만들어 사용하려 했습니다.
+
+
+🔑 **해결방법** <br>
+
+- 
+    ```swift
+    init(stockQuantity: Int = 10) {
+        for fruit in Fruit.allCases {
+            stockList[fruit] = stockQuantity
+        }
+    }
+    ```
+    하지만 메서드를 만들고 호출하여 `stockList`를 채우기보다는 `init` 함수를 사용하여 `FruitStore`의 인스턴스(객체)를 생성할 때 각각 과일에 대한 값들을 추가하도록 하였습니다. `init` 함수에서 `for`문을 활용하여 `Fruit`에 들어있는 과일들을 꺼내오기 위해 `CaseIterable` 프로토콜을 채택하였습니다.
+
+<br>
+
+3️⃣ **`enum Juice` 활용 방법** <br>
+-
+🔒 **문제점** <br>
+- 처음엔 `Raw Values`를 사용하려 했으나 사용 시 정확히 무엇을 뜻하는지 모른다는 조언을 듣고 `Associated Values`를 사용하기로 했습니다.
+하지만 그 결과 `JuiceMaker`내부에 스위치 문을 사용하게 되었고 반복되는 코드의 양이 너무 많아 가독성을 떨어뜨리게 되었습니다.
+
+    ```swift
+    func makeJuice(with recipe: Recipe) {
+        let fruitStore: FruitStore = FruitStore()
+
+        switch recipe {
+        case .strawberryJuice(strawberry: let quantity):
+            fruitStore.changeStock(of: fruitStore.strawberry, by: quantity)
+        case .bananaJuice(banana: let quantity):
+            fruitStore.changeStock(of: fruitStore.banana, by: quantity)
+        case .kiwiJuice(kiwi: let quantity):
+            fruitStore.changeStock(of: fruitStore.kiwi, by: quantity)
+        case ...
+        }
+    }
+    ```
+
+🔑 **해결방법** <br>
+
+ - 열거형 안에서 연산 프로퍼티 사용이 가능하다는 것을 알게 되었습니다. 초기엔 스위치문에 튜플,배열 등의 자료형을 사용하여 결과를 리턴 받아 사용했으나 `Ingredient`라는 타입을 만들어 보라는 조언에 따라 아래와 같이 코드를 생성 및 수정하여 활용했습니다.
+    
+    ```swift
+    struct Ingredient {
+        let name: Fruit
+        let quantity: Int
+    }
+    ```
+
+    ```swift
+    enum Juice {
+        case...
+
+        var recipe: [Ingredient] {
+            switch self {
+            case .strawberryJuice:
+                return [Ingredient(name: .strawberry, quantity: 16)]
+            case...
+            }
+        }
+    }
+    ```
+    
+    ```swift
+    mutating func makeOrder(juice: Juice) {
+        do {
+            for ingredient in juice.recipe {
+                try fruitStore.checkStock(witch: ingredient.name, by: ingredient.quantity)
+            }
+            
+            try juice.recipe.forEach { fruitStore.decreaseStock(witch: $0.name, by: $0.quantity) }
+        } catch FruitStoreError.outOfStock(let fruit) {
+            print("\(fruit)의 재고가 부족합니다.")
+        } catch {
+            print("알 수 없는 오류 발생.")
+        }
+    }
+    ```
+    
+    또한 `Ingredient`타입을 `FruitStore`내 메서드에 매개변수로 받아옴으로써 `JuiceMaker`는 물론이고 `FruitStore`내부 메서드들의 코드가 간소화되고 가독성이 높아졌습니다.
+
+<br>
+
+4️⃣ **`Ingredient` 타입 선언 위치** <br>
+-
+🔒 **문제점** <br>
+ 
+- `Ingredient` 타입을 처음에는 `Juice` 타입 안에 `Nested Type`으로 생성하였습니다. 생성을 하고 사용을 하다 보니 저희의 코드에서는 `FruitStore`에 있는 메서드인 `decreaseIngredient`에서 다음과 같이 사용하게 되었습니다.
+    ```swift
+    func decreaseIngredient(with recipe: [Juice.Ingredient] ) throws { ... }
+    ```
+    여기서 든 의문점이 `FruitStore`에서 어떤 쥬스를 만드는지에 대해 알 필요가 있을까라는 의문이었습니다. 예를 들면 `FruitStore`에서는 **딸기 쥬스를 만들기** 위한 딸기 10개를 감소한다가 아닌 단순하게 **무엇을 만들지는 모르겠지만** 딸기 10개를 감소한다가 더 올바른 표현이지 않을까라는 생각을 가졌습니다. 이러한 생각 때문에 `Ingredient` 타입이 `Juice` 타입 내부에 있는 것이 아닌 외부에 존재해야 한다고 생각하였습니다. 이를 수정하여 다음과 같이 메서드를 선언하였습니다.
+    ```swift
+    func decreaseIngredient(with recipe: [Ingredient] ) throws { ... }
+    ```
+
+🔑 **해결방법** <br>
+
+- `Ingredient` 타입은 `name`과 `quantity`를 프로퍼티로 가지고 있습니다. `FruitStore` 타입 안에 재고를 감소시키는 메서드에서 `Ingredient`라는 네이밍의 매개변수가 필요한지에 대해서 다시 한번 생각해 보게 되었습니다. 재료가 무엇인지를 알 필요 또한 없다고 생각이 들었고 처음 받아오는 파라미터에서 `name`과 `quantity`로 나누어서 전달 인자를 받는 방법으로 수정을 하였습니다.
+
+    ```swift
+    mutating func decreaseStock(witch fruit: Fruit, by quantity: Int) { ... }
+    ```
+    
+    위와 같이 코드를 수정하고 나서 보면 `Ingredient`는 더 이상 사용하지 않는 타입이 되었습니다. 이를 통해 `Juice` 타입 안에 다시 `Nested Type`으로 `Ingredient`을 선언하였습니다.
+


### PR DESCRIPTION
@jsa0224  5m앞에 서 계신 솜에게

## 고민되었던 점

### 여러 `UIButton`들을 하나의 `@IBAction`으로 묶기
- 쥬스를 주문하는 버튼이 각각의 쥬스 종류만큼 개별적으로 존재했습니다. 모든 주문 버튼에 관련하여 각각 `@IBAction`을 생성하는 경우 아래와 같이 중복되는 코드의 양이 무척 많았습니다.

    ```swift
    @IBAction func touchUpStrawberryJuiceOrderButton(_ sender: UIButton) { ... }
    @IBAction func touchUpBananaJuiceOrderButton(_ sender: UIButton) { ... }
    @IBAction func touchUpPineappleJuiceOrderButton(_ sender: UIButton) { ... }
    @IBAction func touchUpKiwiJuiceOrderButton(_ sender: UIButton) { ... }
    @IBAction func touchUpMangoJuiceOrderButton(_ sender: UIButton) { ... }
    @IBAction func touchUpStrawberryBananaJuiceOrderButton(_ sender: UIButton) { ... }
    @IBAction func touchUpMangoKiwiJuiceOrderButton(_ sender: UIButton) { ... }
    ```
    
    이러한 부분을 수정하기 위해 하나의 `@IBAction`에서 버튼을 구분 지어 각각의 버튼에 맞는 동작을 수행하도록 수정하였습니다.
    
    ```swift
    @IBAction func touchUpOrderButton(_ sender: UIButton) { ... }
    ```
    위와 같이 하나의 `@IBAction`에서 각각의 버튼을 구분하기 위해서는 이를 구분하기 위한 식별자가 필요했습니다. `UIButton`의 `tag`와 `title` 프로퍼티를 사용하여 식별자 역할을 할 수 있었습니다. 두 방법에 대해 다음과 같이 코드로 표현하였습니다.
    - `tag` 사용

        ```swift
        @IBAction func touchUpOrderButton(_ sender: UIButton) {
            try juiceMaker.makeOrder(sender.tag)    
        }
        ```
        
        `tag`를 사용하여 해결을 한 경우 각각의 버튼에서 가지고 있는 프로퍼티의 `tag`값을 모두 개별적으로 지정해 주어야 한다는 점에서 코드의 수정이 필요했습니다. 또한 `tag`는 기본값으로 0을 가지고 있기 때문에 새로운 버튼을 추가하고 개발자가 `tag`를 수정하지 않을 시 같은 `tag` 값을 갖는 문제가 발생하였습니다.
        
    - `title` 사용
    
        ```swift
        @IBAction func touchUpOrderButton(_ sender: UIButton) {
            guard let title = sender.titleLabel?.text,
                  let juice = Juice(rawValue: title)
            else {
                return
            }

            try juiceMaker.makeOrder(juice)
        }
        ```
        
        `title` 사용 시 버튼에 대한 기본 네이밍의 양식이 같다면 추가 수정 없이 Juice의 원시 값을 수정하여 매칭을 시킬 수 있었습니다. 이렇게 된다면 버튼이 추가될 때 `Juice`의 원시 값만 추가하여 해당 버튼의 `title`과 같은 값으로 맞춰주면 되었습니다.
        
        위의 두 경우를 비교하여 생각하였을 때 `title`을 사용하는 방식이 `tag`를 활용하는 방법보다 새로운 버튼이 추가되었을 때 더 적은 수정을 필요로 하고 혹시 모를 에러(ex: 버튼 추가 후 `tag`미 수정 등)를 미연에 방지하기 때문에 최종적으로 `title`을 활용하기로 결정하여 문제를 해결하였습니다.

### `UIOutlet Collection` 활용
- `UILable`에 재고 값을 하나하나 넣는 것보단 반복문 등을 통해 한 번에 넣는 게 더 좋다고 판단했습니다. 아래와 같이 `UIOutlet Collection`을 활용해 `UILable`을 하나로 묶어 배열처럼 사용하였습니다.

    ```swift
        private func changeStockLabel() {
            for (fruitStockLabel, fruit) in zip(fruitStockLabels, Fruit.allCases) {
                fruitStockLabel.text = juiceMaker.showRemainStock(of: fruit)
            }
        }
    ```

### `AlertAction handler` 화면 전환 방법
- `재고 수정`을 누를 경우 `Segue`를 사용해`Present Modally` 방식으로 재고 수정 `viewController`와 연결해 줬습니다. `Alert`창에서 "예"를 누를 경우에도 `AlertAction handler`를 활용해 같은 재고 수정 `viewController`로 화면전환을 해줘야 하기에 처음엔 아래와 같이 `viewController`의 `identifierID`를 활용해 인스턴스화하여 `present` 해주는 방식으로 화면 전환을 하였습니다.

    ```swift
    guard let nextView = self.storyboard?.instantiateViewController(identifier: "identifierID") else { return }
    self.present(nextView, animated: true)
    ```

    하지만 기존의 `Segue`를 어떻게 활용할 방법이 없을까 하고 고민이 들었고 결국 아래와 같이 `performSegue`을 활용해 아래와 같이 해결했습니다.
    
    ```swift
    let confirmAction = UIAlertAction(title: "예", style: .default) { _ in
        self.performSegue(withIdentifier: "goToStockViewController", sender: nil)
    }
    ```

## 조언을 얻고 싶은 부분

### 특정 `label`에 값을 받아오는 방법과 `stockList`의 딕셔너리 사용시 관찰의 어려움
- 현재 작성한 코드에서는 쥬스를 만들고 쥬스를 만들기 위해 사용한 과일의 수만큼을 해당 재고에서 감소시킨 후 그 전체 값을 다시 받아와서 `UILabel`에 새로 입력을 해줍니다.
    
    ```swift
    private func changeStockLabel() {
            for (fruitStockLabel, fruit) in zip(fruitStockLabelCollection, Fruit.allCases) {
                fruitStockLabel.text = juiceMaker.showRemainStock(of: fruit)
            }
        }
    ```
    
    위처럼 실제로 사용한 과일뿐만 아니라 전체 과일에 대해 순환을 하면서 변경되지 않은 과일의 재고도 다시 `UILabel`에 새로 할당합니다.
    
    이런 방식이 아닌 실제 사용된 과일을 특정하여 그 재고 값만을 다시 `UILabel`에 할당하는 방식을 위해서 생각한 내용이 `Observer` 방식을 활용하는 것이었습니다. 여기서 생긴 문제점은 기존에 선언한 `stockList`가 `dictionary`타입이라 하나의 프로퍼티가 모든 과일에 대한 값을 담고 있다는 것이었습니다. 이렇게 되면 관찰할 대상은 개별 과일과 수량이 아닌 전체 과일이 되기 때문에 여기서 특정 과일을 지칭하기가 어려웠습니다. 이러한 경우에 각각의 과일을 구조체와 같은 타입으로 변경하여 각각 관찰할 수 있는 인스턴스로 만드는 것이 괜찮은 방법일까요?

### `enum` 타입에서 `rawValue`의 사용과 `switch`문을 사용한 해결
- `enum`의 `case`에 따라 각각 다른 동작을 수행합니다. `enum`의 `case`에 따라 구분하기 위해서 `switch`문을 사용하여 각각의 `case`에 대한 처리를 진행하였습니다.

    ```swift
    switch juice {        
    case .strawberryJuice:
        <#code#>
    case .bananaJuice:
        <#code#>
    case .pineappleJuice:
        <#code#>
    case .kiwiJuice:
        <#code#>
    case .mangoJuice:
        <#code#>
    case .strawberryBananaJuice:
        <#code#>
    case .mangoKiwiJuice:
        <#code#>
    }
    ```

    `switch`문을 사용하는 경우 `enum`의 `case`가 추가될 시 `switch`문에서도 수정을 해야 한다는 부분에서 확장성이 떨어져 보인다고 생각하였습니다. 실례로 개방-폐쇄 원칙(OCP)을 지키기 위한 하나의 방법이 무분별한 `switch`문의 사용을 지양하는 것이라는 내용을 보았습니다. 

    이러한 생각을 가지고 개별 동작을 구분하기 위한 방법으로 `rawValue`를 활용하는 방안을 생각해 보았습니다.
    ```swift
    Juice(rawValue: title)
    ```
    위와 같이 `Juice`의 어떤 특정 `case`에 대해 `rawValue`를 사용하여 값을 초기화하는 방법을 사용하였습니다. 여기서 든 궁금점은 `enum`에서 `rawValue`의 사용은 사용자 입장에서 어떠한 타입이 사용되는지에 대한 예측이 불가능하단 점에서 지양하는 방식이라고 들었습니다. 여기서는 어떤 값에 접근하기 위해 `enumCase.rawValue`처럼 사용하는 것이 아니어서 괜찮다고 생각하였습니다.
    
    두 경우 모두 각각의 장단점들이 있었고 어떤 방법이 여기서 더 어울릴지와 이 외에 다른 생각지 못한 방법이 있을지 궁금합니다.
