### PR TITLE
쥬스 메이커 [STEP 3] dasan, kyungmin

### DIFF
--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -331,12 +331,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = HS56L7UM37;
 				INFOPLIST_FILE = JuiceMaker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.JuiceMaker;
+				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.JuiceMakercom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -349,12 +350,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = HS56L7UM37;
 				INFOPLIST_FILE = JuiceMaker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.JuiceMaker;
+				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.JuiceMakercom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
+++ b/JuiceMaker/JuiceMaker.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AC1ADF552A135C1D00A96F2A /* ModifyStockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1ADF542A135C1D00A96F2A /* ModifyStockViewController.swift */; };
+		ACEE4EDE2A1F904800F3352B /* JucieMakerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACEE4EDD2A1F904800F3352B /* JucieMakerError.swift */; };
 		ACFFF3BE2A09CA4C008A9CCA /* Fruit.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFFF3BD2A09CA4C008A9CCA /* Fruit.swift */; };
 		ACFFF3C02A09CA6D008A9CCA /* Juice.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFFF3BF2A09CA6D008A9CCA /* Juice.swift */; };
 		C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71CD66A266C7ACB0038B9CB /* FruitStore.swift */; };
@@ -22,6 +23,7 @@
 
 /* Begin PBXFileReference section */
 		AC1ADF542A135C1D00A96F2A /* ModifyStockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyStockViewController.swift; sourceTree = "<group>"; };
+		ACEE4EDD2A1F904800F3352B /* JucieMakerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JucieMakerError.swift; sourceTree = "<group>"; };
 		ACFFF3BD2A09CA4C008A9CCA /* Fruit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fruit.swift; sourceTree = "<group>"; };
 		ACFFF3BF2A09CA6D008A9CCA /* Juice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Juice.swift; sourceTree = "<group>"; };
 		C71CD66A266C7ACB0038B9CB /* FruitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitStore.swift; sourceTree = "<group>"; };
@@ -65,6 +67,7 @@
 				C71CD66A266C7ACB0038B9CB /* FruitStore.swift */,
 				ACFFF3BD2A09CA4C008A9CCA /* Fruit.swift */,
 				ACFFF3BF2A09CA6D008A9CCA /* Juice.swift */,
+				ACEE4EDD2A1F904800F3352B /* JucieMakerError.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -176,6 +179,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ACEE4EDE2A1F904800F3352B /* JucieMakerError.swift in Sources */,
 				C71CD66B266C7ACB0038B9CB /* FruitStore.swift in Sources */,
 				ACFFF3C02A09CA6D008A9CCA /* Juice.swift in Sources */,
 				C73DAF3B255D0CDD00020D38 /* JuiceMakerViewController.swift in Sources */,

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 final class JuiceMakerViewController: UIViewController {
-    let juiceMaker = JuiceMaker()
+    private let juiceMaker = JuiceMaker()
     
     @IBOutlet var fruitStockLabels: [UILabel]!
     @IBOutlet var orderButtons: [UIButton]!
@@ -21,10 +21,6 @@ final class JuiceMakerViewController: UIViewController {
         guard let modifyStockViewController = segue.destination as? ModifyStockViewController else {
             return
         }
-//        guard let juiceMakerStockViewController = segue.source as? JuiceMakerViewController else {
-//            return
-//        }
-//        delegate = modifyStockViewController
         modifyStockViewController.setStock(stocks: juiceMaker.fruitStore.fruitInventory)
     }
     
@@ -32,10 +28,11 @@ final class JuiceMakerViewController: UIViewController {
         guard let modifyStockViewController = segue.source as? ModifyStockViewController else {
             return
         }
-        juiceMaker.fruitStore.fruitInventory = modifyStockViewController.getStock()
+        let modifiedStocks: [Int] = modifyStockViewController.getStock()
+        updateFruitInventory(stocks: modifiedStocks)
         updateFruitStockLabel()
     }
-    
+        
     @IBAction func touchUpOrderButton(_ sender: UIButton) {
         guard let buttonIndex = orderButtons.firstIndex(of: sender) else {
             return
@@ -44,28 +41,34 @@ final class JuiceMakerViewController: UIViewController {
         updateFruitStockLabel()
     }
     
-    func updateFruitStockLabel() {
-        for fruitStockLabel in fruitStockLabels {
-            fruitStockLabel.text = String(juiceMaker.fruitStore.fruitInventory[fruitStockLabel.tag])
-        }
-    }
-    
-    func order(juice: Juice) {
+    private func order(juice: Juice) {
         do {
             try juiceMaker.blendFruitJuice(menu: juice)
             showAlert(message: "\(juice)나왔습니다. 맛있게 드세요!",
                       actions: UIAlertAction(title: "닫기", style: .cancel))
         } catch JuiceMakerError.outOfFruitStock {
-            showAlert(message: "재료가 모자라요. 재고를 수정할까요?",
+            showAlert(message: "\(JuiceMakerError.outOfFruitStock) 재고를 수정할까요?",
                       actions: UIAlertAction(title: "예", style: .default) {
                                 action in self.presentModifyStockView() },
-                      UIAlertAction(title: "아니오", style: .default))
+                               UIAlertAction(title: "아니오", style: .default))
         } catch {
-            print("unknown")
+            print(JuiceMakerError.unknownError)
         }
     }
     
-    func showAlert(message: String, actions: UIAlertAction...) {
+    private func updateFruitInventory(stocks: [Int]) {
+        for (inventoryIndex, stock) in stocks.enumerated() {
+            juiceMaker.fruitStore.addStock(fruit: Fruit.allCases[inventoryIndex], amount: stock)
+        }
+    }
+    
+    private func updateFruitStockLabel() {
+        for fruitStockLabel in fruitStockLabels {
+            fruitStockLabel.text = String(juiceMaker.fruitStore.fruitInventory[fruitStockLabel.tag])
+        }
+    }
+    
+    private func showAlert(message: String, actions: UIAlertAction...) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         for action in actions {
             alert.addAction(action)
@@ -73,9 +76,7 @@ final class JuiceMakerViewController: UIViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    func presentModifyStockView() {
+    private func presentModifyStockView() {
         self.performSegue(withIdentifier: "modifyStockViewSegue", sender: nil)
     }
-    
-
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -7,7 +7,8 @@
 import UIKit
 
 final class JuiceMakerViewController: UIViewController {
-    var delegate: StockReceivable?
+
+    private var delegate: Stock?
     let juiceMaker = JuiceMaker()
     @IBOutlet var fruitStockLabels: [UILabel]!
     @IBOutlet var orderButtons: [UIButton]!
@@ -19,19 +20,10 @@ final class JuiceMakerViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        guard let stock = delegate?.getStock() else {
-            return
+        if let modifiedFruitStocks = delegate?.getStock() {
+            juiceMaker.fruitStore.fruitInventory = modifiedFruitStocks
         }
         delegate = nil
-        juiceMaker.fruitStore.fruitInventory = stock
-        updateFruitStockLabel()
-    }
-    
-    @IBAction func touchUpOrderButton(_ sender: UIButton) {
-        if let buttonIndex = orderButtons.firstIndex(of: sender){
-            order(juice: Juice.allCases[buttonIndex])
-        }
-        
         updateFruitStockLabel()
     }
     
@@ -41,6 +33,14 @@ final class JuiceMakerViewController: UIViewController {
         }
         delegate = modifyStockViewController
         delegate?.setStock(stocks: juiceMaker.fruitStore.fruitInventory)
+    }
+    
+    @IBAction func touchUpOrderButton(_ sender: UIButton) {
+        if let buttonIndex = orderButtons.firstIndex(of: sender){
+            order(juice: Juice.allCases[buttonIndex])
+        }
+        
+        updateFruitStockLabel()
     }
     
     func updateFruitStockLabel() {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -18,15 +18,6 @@ final class JuiceMakerViewController: UIViewController {
         updateFruitStockLabel()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        if let modifiedFruitStocks = delegate?.getStock() {
-            juiceMaker.fruitStore.fruitInventory = modifiedFruitStocks
-        }
-        delegate = nil
-        updateFruitStockLabel()
-    }
-    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let modifyStockViewController = segue.destination as? ModifyStockViewController else {
             return
@@ -35,11 +26,19 @@ final class JuiceMakerViewController: UIViewController {
         delegate?.setStock(stocks: juiceMaker.fruitStore.fruitInventory)
     }
     
-    @IBAction func touchUpOrderButton(_ sender: UIButton) {
-        if let buttonIndex = orderButtons.firstIndex(of: sender){
-            order(juice: Juice.allCases[buttonIndex])
+    @IBAction func unwindToJuiceMakerViewController(_ segue: UIStoryboardSegue) {
+        guard let modifiedFruitStocks = delegate?.getStock() else {
+            return
         }
-        
+        juiceMaker.fruitStore.fruitInventory = modifiedFruitStocks
+        updateFruitStockLabel()
+    }
+    
+    @IBAction func touchUpOrderButton(_ sender: UIButton) {
+        guard let buttonIndex = orderButtons.firstIndex(of: sender) else {
+            return
+        }
+        order(juice: Juice.allCases[buttonIndex])
         updateFruitStockLabel()
     }
     
@@ -75,4 +74,6 @@ final class JuiceMakerViewController: UIViewController {
     func presentModifyStockView() {
         self.performSegue(withIdentifier: "modifyStockViewSegue", sender: nil)
     }
+    
+
 }

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -7,7 +7,6 @@
 import UIKit
 
 final class JuiceMakerViewController: UIViewController {
-    private var delegate: Stock?
     let juiceMaker = JuiceMaker()
     
     @IBOutlet var fruitStockLabels: [UILabel]!
@@ -22,15 +21,18 @@ final class JuiceMakerViewController: UIViewController {
         guard let modifyStockViewController = segue.destination as? ModifyStockViewController else {
             return
         }
-        delegate = modifyStockViewController
-        delegate?.setStock(stocks: juiceMaker.fruitStore.fruitInventory)
+//        guard let juiceMakerStockViewController = segue.source as? JuiceMakerViewController else {
+//            return
+//        }
+//        delegate = modifyStockViewController
+        modifyStockViewController.setStock(stocks: juiceMaker.fruitStore.fruitInventory)
     }
     
     @IBAction func unwindToJuiceMakerViewController(_ segue: UIStoryboardSegue) {
-        guard let modifiedFruitStocks = delegate?.getStock() else {
+        guard let modifyStockViewController = segue.source as? ModifyStockViewController else {
             return
         }
-        juiceMaker.fruitStore.fruitInventory = modifiedFruitStocks
+        juiceMaker.fruitStore.fruitInventory = modifyStockViewController.getStock()
         updateFruitStockLabel()
     }
     

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -7,13 +7,23 @@
 import UIKit
 
 final class JuiceMakerViewController: UIViewController {
+    var delegate: StockReceivable?
     let juiceMaker = JuiceMaker()
     @IBOutlet var fruitStockLabels: [UILabel]!
     @IBOutlet var orderButtons: [UIButton]!
-        
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        updateFruitStockLabel()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        guard let stock = delegate?.getStock() else {
+            return
+        }
+        delegate = nil
+        juiceMaker.fruitStore.fruitInventory = stock
         updateFruitStockLabel()
     }
     
@@ -23,6 +33,14 @@ final class JuiceMakerViewController: UIViewController {
         }
         
         updateFruitStockLabel()
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let modifyStockViewController = segue.destination as? ModifyStockViewController else {
+            return
+        }
+        delegate = modifyStockViewController
+        delegate?.setStock(stocks: juiceMaker.fruitStore.fruitInventory)
     }
     
     func updateFruitStockLabel() {

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -7,9 +7,9 @@
 import UIKit
 
 final class JuiceMakerViewController: UIViewController {
-
     private var delegate: Stock?
     let juiceMaker = JuiceMaker()
+    
     @IBOutlet var fruitStockLabels: [UILabel]!
     @IBOutlet var orderButtons: [UIButton]!
     

--- a/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/JuiceMakerViewController.swift
@@ -21,7 +21,7 @@ final class JuiceMakerViewController: UIViewController {
         guard let modifyStockViewController = segue.destination as? ModifyStockViewController else {
             return
         }
-        modifyStockViewController.setStock(stocks: juiceMaker.fruitStore.fruitInventory)
+        modifyStockViewController.setStock(juiceMaker.fruitStore.fruitInventory)
     }
     
     @IBAction func unwindToJuiceMakerViewController(_ segue: UIStoryboardSegue) {
@@ -48,9 +48,9 @@ final class JuiceMakerViewController: UIViewController {
                       actions: UIAlertAction(title: "닫기", style: .cancel))
         } catch JuiceMakerError.outOfFruitStock {
             showAlert(message: "\(JuiceMakerError.outOfFruitStock) 재고를 수정할까요?",
-                      actions: UIAlertAction(title: "예", style: .default) {
-                                action in self.presentModifyStockView() },
-                               UIAlertAction(title: "아니오", style: .default))
+                      actions: UIAlertAction(title: "아니오", style: .default),
+                               UIAlertAction(title: "예", style: .default, handler: presentModifyStockView))
+                               
         } catch {
             print(JuiceMakerError.unknownError)
         }
@@ -58,7 +58,7 @@ final class JuiceMakerViewController: UIViewController {
     
     private func updateFruitInventory(stocks: [Int]) {
         for (inventoryIndex, stock) in stocks.enumerated() {
-            juiceMaker.fruitStore.addStock(fruit: Fruit.allCases[inventoryIndex], amount: stock)
+            juiceMaker.fruitStore.changeStock(fruit: Fruit.allCases[inventoryIndex], amount: stock)
         }
     }
     
@@ -76,7 +76,7 @@ final class JuiceMakerViewController: UIViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    private func presentModifyStockView() {
-        self.performSegue(withIdentifier: "modifyStockViewSegue", sender: nil)
+    private func presentModifyStockView(_ action: UIAlertAction) {
+        performSegue(withIdentifier: "modifyStockViewSegue", sender: nil)
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -31,10 +31,6 @@ class ModifyStockViewController: UIViewController {
         }
     }
     
-    @IBAction func dismissModal(_ sender: UIButton) {
-        dismiss(animated: true, completion: nil)
-    }
-    
     func updateFruitStockLabel() {
         for fruitStockLabel in fruitStockLabels {
             fruitStockLabel.text = String(fruitStocks[fruitStockLabel.tag])

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -7,13 +7,41 @@
 
 import UIKit
 
-class ModifyStockViewController: UIViewController {
+protocol StockReceivable: AnyObject {
+    func setStock(stocks: [Int])
+    func getStock() -> [Int]
+}
 
+class ModifyStockViewController: UIViewController, StockReceivable {
+
+    @IBOutlet var fruitStockLabels: [UILabel]!
+    var stocks: [Int]?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-    }
-
+        guard let stocks = stocks else {
+            return
+        }
+        for (index, fruitStockLabel) in fruitStockLabels.enumerated() {
+            fruitStockLabel.text = String(stocks[index])
+        }
+    }   
+    
     @IBAction func dismissModal(_ sender: UIButton) {
+        guard let stocks = stocks else {
+            return
+        }
+        for (index, fruitStockLabel) in fruitStockLabels.enumerated() {
+            fruitStockLabel.text = String(stocks[index] + 123)
+        }
         dismiss(animated: true, completion: nil)
+    }
+    
+    func setStock(stocks: [Int]) {
+        self.stocks = stocks
+    }
+    
+    func getStock() -> [Int] {
+        return fruitStockLabels.compactMap{ $0.text }.compactMap{ Int($0) }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -8,11 +8,10 @@
 import UIKit
 
 final class ModifyStockViewController: UIViewController {
-    private var oldFruitStocks: [Int] = [Int]()
-    private var newFruitStocks: [Int] = [Int]()
+    private var fruitStocks: [Int] = [Int]()
     
     @IBOutlet var fruitStockLabels: [UILabel]!
-    @IBOutlet var fruitStockStepper: [UIStepper]!
+    @IBOutlet var fruitStockSteppers: [UIStepper]!
         
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,40 +20,31 @@ final class ModifyStockViewController: UIViewController {
     }
     
     @IBAction func touchUpStepper(_ sender: UIStepper) {
-        if let stepperIndex = fruitStockStepper.firstIndex(of: sender) {
+        if let stepperIndex = fruitStockSteppers.firstIndex(of: sender) {
             fruitStockLabels[stepperIndex].text = String(Int(sender.value))
-            newFruitStocks[stepperIndex] = Int(sender.value)
+            fruitStocks[stepperIndex] = Int(sender.value)
         }
     }
     
     private func updateFruitStockLabel() {
         for fruitStockLabel in fruitStockLabels {
-            fruitStockLabel.text = String(newFruitStocks[fruitStockLabel.tag])
+            fruitStockLabel.text = String(fruitStocks[fruitStockLabel.tag])
         }
     }
     
     private func initializeStepperValue() {
-        for fruitStockStepper in fruitStockStepper {
-            fruitStockStepper.minimumValue = Double(oldFruitStocks[fruitStockStepper.tag])
+        for fruitStockStepper in fruitStockSteppers {
+            fruitStockStepper.minimumValue = Double(fruitStocks[fruitStockStepper.tag])
         }
-    }
-    
-    private func calculateStockDifference() -> [Int] {
-        var stockDifference: [Int] = [Int]()
-        for (stockIndex, stock) in newFruitStocks.enumerated() {
-            stockDifference.append(stock - oldFruitStocks[stockIndex])
-        }
-        return stockDifference
     }
 }
 
 extension ModifyStockViewController {
-    func setStock(stocks: [Int]) {
-        oldFruitStocks = stocks
-        newFruitStocks = oldFruitStocks
+    func setStock(_ stocks: [Int]) {
+        fruitStocks = stocks
     }
     
     func getStock() -> [Int] {
-        return calculateStockDifference()
+        return fruitStocks
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -12,35 +12,48 @@ protocol Stock {
     func getStock() -> [Int]
 }
 
-class ModifyStockViewController: UIViewController, Stock {
-
+class ModifyStockViewController: UIViewController {
     var fruitStocks: [Int] = [Int]()
+    
     @IBOutlet var fruitStockLabels: [UILabel]!
+    @IBOutlet var fruitStockStepper: [UIStepper]!
         
     override func viewDidLoad() {
         super.viewDidLoad()
         updateFruitStockLabel()
+        initializeStepperValue()
+    }
+    
+    @IBAction func touchUpStepper(_ sender: UIStepper) {
+        if let stepperIndex = fruitStockStepper.firstIndex(of: sender){
+            fruitStockLabels[stepperIndex].text = String(Int(sender.value))
+            fruitStocks[stepperIndex] = Int(sender.value)
+        }
     }
     
     @IBAction func dismissModal(_ sender: UIButton) {
-        // stepper 구현 예정
-        for i in 0..<fruitStocks.count {
-            fruitStocks[i] += 100
-        }
         dismiss(animated: true, completion: nil)
-    }
-
-    func setStock(stocks: [Int]) {
-        fruitStocks = stocks
-    }
-    
-    func getStock() -> [Int] {
-        return fruitStocks
     }
     
     func updateFruitStockLabel() {
         for fruitStockLabel in fruitStockLabels {
             fruitStockLabel.text = String(fruitStocks[fruitStockLabel.tag])
         }
+    }
+    
+    func initializeStepperValue() {
+        for fruitStockStepper in fruitStockStepper {
+            fruitStockStepper.value = Double(fruitStocks[fruitStockStepper.tag])
+        }
+    }
+}
+
+extension ModifyStockViewController: Stock {
+    func setStock(stocks: [Int]) {
+        fruitStocks = stocks
+    }
+    
+    func getStock() -> [Int] {
+        return fruitStocks
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -40,6 +40,7 @@ class ModifyStockViewController: UIViewController {
     func initializeStepperValue() {
         for fruitStockStepper in fruitStockStepper {
             fruitStockStepper.value = Double(fruitStocks[fruitStockStepper.tag])
+            fruitStockStepper.minimumValue = Double(fruitStocks[fruitStockStepper.tag])
         }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -7,41 +7,40 @@
 
 import UIKit
 
-protocol StockReceivable: AnyObject {
+protocol Stock {
     func setStock(stocks: [Int])
     func getStock() -> [Int]
 }
 
-class ModifyStockViewController: UIViewController, StockReceivable {
+class ModifyStockViewController: UIViewController, Stock {
 
+    var fruitStocks: [Int] = [Int]()
     @IBOutlet var fruitStockLabels: [UILabel]!
-    var stocks: [Int]?
-    
+        
     override func viewDidLoad() {
         super.viewDidLoad()
-        guard let stocks = stocks else {
-            return
-        }
-        for (index, fruitStockLabel) in fruitStockLabels.enumerated() {
-            fruitStockLabel.text = String(stocks[index])
-        }
-    }   
+        updateFruitStockLabel()
+    }
     
     @IBAction func dismissModal(_ sender: UIButton) {
-        guard let stocks = stocks else {
-            return
-        }
-        for (index, fruitStockLabel) in fruitStockLabels.enumerated() {
-            fruitStockLabel.text = String(stocks[index] + 123)
+        // stepper 구현 예정
+        for i in 0..<fruitStocks.count {
+            fruitStocks[i] += 100
         }
         dismiss(animated: true, completion: nil)
     }
-    
+
     func setStock(stocks: [Int]) {
-        self.stocks = stocks
+        fruitStocks = stocks
     }
     
     func getStock() -> [Int] {
-        return fruitStockLabels.compactMap{ $0.text }.compactMap{ Int($0) }
+        return fruitStocks
+    }
+    
+    func updateFruitStockLabel() {
+        for fruitStockLabel in fruitStockLabels {
+            fruitStockLabel.text = String(fruitStocks[fruitStockLabel.tag])
+        }
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -2,13 +2,14 @@
 //  ModifyStockViewController.swift
 //  JuiceMaker
 //
-//  Created by Yena on 2023/05/16.
+//  Created by dasan & kyungmin on 2023/05/16.
 //
 
 import UIKit
 
-class ModifyStockViewController: UIViewController {
-    var fruitStocks: [Int] = [Int]()
+final class ModifyStockViewController: UIViewController {
+    private var fruitStocks: [Int] = [Int]()
+    private var modifiedStocks: [Int] = [Int]()
     
     @IBOutlet var fruitStockLabels: [UILabel]!
     @IBOutlet var fruitStockStepper: [UIStepper]!
@@ -20,32 +21,40 @@ class ModifyStockViewController: UIViewController {
     }
     
     @IBAction func touchUpStepper(_ sender: UIStepper) {
-        if let stepperIndex = fruitStockStepper.firstIndex(of: sender){
+        if let stepperIndex = fruitStockStepper.firstIndex(of: sender) {
             fruitStockLabels[stepperIndex].text = String(Int(sender.value))
-            fruitStocks[stepperIndex] = Int(sender.value)
+            modifiedStocks[stepperIndex] = Int(sender.value)
         }
     }
     
-    func updateFruitStockLabel() {
+    private func updateFruitStockLabel() {
         for fruitStockLabel in fruitStockLabels {
-            fruitStockLabel.text = String(fruitStocks[fruitStockLabel.tag])
+            fruitStockLabel.text = String(modifiedStocks[fruitStockLabel.tag])
         }
     }
     
-    func initializeStepperValue() {
+    private func initializeStepperValue() {
         for fruitStockStepper in fruitStockStepper {
-            fruitStockStepper.value = Double(fruitStocks[fruitStockStepper.tag])
             fruitStockStepper.minimumValue = Double(fruitStocks[fruitStockStepper.tag])
         }
+    }
+    
+    private func calculateStockDifference() -> [Int] {
+        var stockDifference: [Int] = [Int]()
+        for (stockIndex, stock) in modifiedStocks.enumerated() {
+            stockDifference.append(stock - fruitStocks[stockIndex])
+        }
+        return stockDifference
     }
 }
 
 extension ModifyStockViewController {
     func setStock(stocks: [Int]) {
         fruitStocks = stocks
+        modifiedStocks = fruitStocks
     }
     
     func getStock() -> [Int] {
-        return fruitStocks
+        return calculateStockDifference()
     }
 }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -7,11 +7,6 @@
 
 import UIKit
 
-protocol Stock {
-    func setStock(stocks: [Int])
-    func getStock() -> [Int]
-}
-
 class ModifyStockViewController: UIViewController {
     var fruitStocks: [Int] = [Int]()
     
@@ -45,7 +40,7 @@ class ModifyStockViewController: UIViewController {
     }
 }
 
-extension ModifyStockViewController: Stock {
+extension ModifyStockViewController {
     func setStock(stocks: [Int]) {
         fruitStocks = stocks
     }

--- a/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/Controller/ModifyStockViewController.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 final class ModifyStockViewController: UIViewController {
-    private var fruitStocks: [Int] = [Int]()
-    private var modifiedStocks: [Int] = [Int]()
+    private var oldFruitStocks: [Int] = [Int]()
+    private var newFruitStocks: [Int] = [Int]()
     
     @IBOutlet var fruitStockLabels: [UILabel]!
     @IBOutlet var fruitStockStepper: [UIStepper]!
@@ -23,26 +23,26 @@ final class ModifyStockViewController: UIViewController {
     @IBAction func touchUpStepper(_ sender: UIStepper) {
         if let stepperIndex = fruitStockStepper.firstIndex(of: sender) {
             fruitStockLabels[stepperIndex].text = String(Int(sender.value))
-            modifiedStocks[stepperIndex] = Int(sender.value)
+            newFruitStocks[stepperIndex] = Int(sender.value)
         }
     }
     
     private func updateFruitStockLabel() {
         for fruitStockLabel in fruitStockLabels {
-            fruitStockLabel.text = String(modifiedStocks[fruitStockLabel.tag])
+            fruitStockLabel.text = String(newFruitStocks[fruitStockLabel.tag])
         }
     }
     
     private func initializeStepperValue() {
         for fruitStockStepper in fruitStockStepper {
-            fruitStockStepper.minimumValue = Double(fruitStocks[fruitStockStepper.tag])
+            fruitStockStepper.minimumValue = Double(oldFruitStocks[fruitStockStepper.tag])
         }
     }
     
     private func calculateStockDifference() -> [Int] {
         var stockDifference: [Int] = [Int]()
-        for (stockIndex, stock) in modifiedStocks.enumerated() {
-            stockDifference.append(stock - fruitStocks[stockIndex])
+        for (stockIndex, stock) in newFruitStocks.enumerated() {
+            stockDifference.append(stock - oldFruitStocks[stockIndex])
         }
         return stockDifference
     }
@@ -50,8 +50,8 @@ final class ModifyStockViewController: UIViewController {
 
 extension ModifyStockViewController {
     func setStock(stocks: [Int]) {
-        fruitStocks = stocks
-        modifiedStocks = fruitStocks
+        oldFruitStocks = stocks
+        newFruitStocks = oldFruitStocks
     }
     
     func getStock() -> [Int] {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -5,7 +5,7 @@
 //
 
 class FruitStore {
-    private(set) var fruitInventory: [Int]
+    var fruitInventory: [Int]
 
     init(initialStock: Int = 10) {
         fruitInventory = Array(repeating: initialStock,

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -20,8 +20,8 @@ final class FruitStore {
         }
     }
     
-    func addStock(fruit: Fruit, amount: Int) {
-        fruitInventory[fruit.inventoryIndex] += amount
+    func changeStock(fruit: Fruit, amount: Int) {
+        fruitInventory[fruit.inventoryIndex] = amount
     }
     
     func reduceStock(fruit: Fruit, amount: Int) {

--- a/JuiceMaker/JuiceMaker/Model/FruitStore.swift
+++ b/JuiceMaker/JuiceMaker/Model/FruitStore.swift
@@ -4,8 +4,8 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
-class FruitStore {
-    var fruitInventory: [Int]
+final class FruitStore {
+    private(set) var fruitInventory: [Int]
 
     init(initialStock: Int = 10) {
         fruitInventory = Array(repeating: initialStock,

--- a/JuiceMaker/JuiceMaker/Model/JucieMakerError.swift
+++ b/JuiceMaker/JuiceMaker/Model/JucieMakerError.swift
@@ -1,0 +1,20 @@
+//
+//  JucieMakerError.swift
+//  JuiceMaker
+//
+//  Created by dasan & kyungmin on 2023/05/25.
+//
+
+enum JuiceMakerError: Error, CustomStringConvertible {
+    case outOfFruitStock
+    case unknownError
+    
+    var description: String {
+        switch self {
+        case .outOfFruitStock:
+            return "재료가 모자라요."
+        case .unknownError:
+            return "알 수 없는 오류입니다."
+        }
+    }
+}

--- a/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/Model/JuiceMaker.swift
@@ -4,13 +4,8 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-enum JuiceMakerError: Error {
-    case outOfFruitStock
-    case unknownError
-}
-
 struct JuiceMaker {
-    let fruitStore: FruitStore = FruitStore(initialStock: 10)
+    let fruitStore = FruitStore(initialStock: 10)
     
     func blendFruitJuice(menu fruitJuice: Juice) throws {
         try requestFruitStock(menu: fruitJuice)

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" identifier="modifyStockViewSegue" modalPresentationStyle="fullScreen" id="2Me-lx-FY7"/>
+                                <segue destination="Yu1-lM-nqp" kind="presentation" identifier="modifyStockViewSegue" id="2Me-lx-FY7"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -410,7 +410,7 @@
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="닫기"/>
                                 <connections>
-                                    <action selector="dismissModal:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="cFK-IT-hOG"/>
+                                    <segue destination="h5a-b1-bMx" kind="unwind" unwindAction="unwindToJuiceMakerViewController:" id="qzh-MZ-LbS"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -432,8 +432,9 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
+                <exit id="h5a-b1-bMx" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="761.37440758293837" y="1136.9230769230769"/>
+            <point key="canvasLocation" x="762" y="1091"/>
         </scene>
     </scenes>
     <resources>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DCG-dP-Fms">
-    <device id="retina6_0" orientation="landscape" appearance="light"/>
+    <device id="retina4_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
@@ -19,19 +19,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="63" y="52" width="442" height="112"/>
+                                <rect key="frame" x="16" y="52" width="536" height="112"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="112"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="94.5" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="83.666666666666671"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="77.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="91.666666666666657" width="75.666666666666671" height="20.333333333333329"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
+                                                <rect key="frame" x="0.0" y="85.5" width="94.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="91.666666666666657" y="0.0" width="75.666666666666657" height="112"/>
+                                        <rect key="frame" x="110.5" y="0.0" width="94.5" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="77.666666666666671"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="77.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="85.666666666666657" width="75.666666666666671" height="26.333333333333329"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
+                                                <rect key="frame" x="0.0" y="85.5" width="94.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="183.33333333333334" y="0.0" width="75.333333333333343" height="112"/>
+                                        <rect key="frame" x="221" y="0.0" width="94" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="75.333333333333329" height="77.666666666666671"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="77.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="85.666666666666657" width="75.333333333333329" height="26.333333333333329"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
+                                                <rect key="frame" x="0.0" y="85.5" width="94" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="274.66666666666669" y="0.0" width="75.666666666666686" height="112"/>
+                                        <rect key="frame" x="331" y="0.0" width="94.5" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="77.666666666666671"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="77.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="85.666666666666657" width="75.666666666666671" height="26.333333333333329"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
+                                                <rect key="frame" x="0.0" y="85.5" width="94.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="366.33333333333331" y="0.0" width="75.666666666666686" height="112"/>
+                                        <rect key="frame" x="441.5" y="0.0" width="94.5" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="77.666666666666671"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
+                                                <rect key="frame" x="0.0" y="0.0" width="94.5" height="77.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="85.666666666666657" width="75.666666666666671" height="26.333333333333329"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
+                                                <rect key="frame" x="0.0" y="85.5" width="94.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="63" y="184" width="442" height="95"/>
+                                <rect key="frame" x="16" y="184" width="536" height="116"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="442" height="43.666666666666664"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="536" height="54"/>
                                         <subviews>
                                             <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="167.33333333333334" height="43.666666666666664"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="205" height="54"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="183.33333333333334" y="0.0" width="75.333333333333343" height="43.666666666666664"/>
+                                                <rect key="frame" x="221" y="0.0" width="94" height="54"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                             <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="274.66666666666669" y="0.0" width="167.33333333333331" height="43.666666666666664"/>
+                                                <rect key="frame" x="331" y="0.0" width="205" height="54"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -148,13 +148,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="51.666666666666657" width="442" height="43.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="62" width="536" height="54"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="442" height="43.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="536" height="54"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="43.333333333333336"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="94.5" height="54"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <state key="normal">
                                                             <attributedString key="attributedTitle">
@@ -171,14 +171,14 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="91.666666666666657" y="0.0" width="75.666666666666657" height="43.333333333333336"/>
+                                                        <rect key="frame" x="110.5" y="0.0" width="94.5" height="54"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <state key="normal">
                                                             <attributedString key="attributedTitle">
                                                                 <fragment content="바나나쥬스">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -193,7 +193,7 @@
                                                                 <fragment content="주문">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -205,14 +205,14 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="183.33333333333334" y="0.0" width="75.333333333333343" height="43.333333333333336"/>
+                                                        <rect key="frame" x="221" y="0.0" width="94" height="54"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <state key="normal">
                                                             <attributedString key="attributedTitle">
                                                                 <fragment content="파인애플쥬스">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -227,7 +227,7 @@
                                                                 <fragment content="주문">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -239,14 +239,14 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="274.66666666666669" y="0.0" width="75.666666666666686" height="43.333333333333336"/>
+                                                        <rect key="frame" x="331" y="0.0" width="94.5" height="54"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <state key="normal">
                                                             <attributedString key="attributedTitle">
                                                                 <fragment content="키위쥬스">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -261,7 +261,7 @@
                                                                 <fragment content="주문">
                                                                     <attributes>
                                                                         <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="15"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -273,7 +273,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="366.33333333333331" y="0.0" width="75.666666666666686" height="43.333333333333336"/>
+                                                        <rect key="frame" x="441.5" y="0.0" width="94.5" height="54"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
                                                         <state key="normal">
                                                             <attributedString key="attributedTitle">
@@ -385,128 +385,149 @@
                         <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="z3e-9p-JS3">
-                                <rect key="frame" x="9" y="79" width="550" height="162"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="z3e-9p-JS3">
+                                <rect key="frame" x="30" y="79" width="508" height="162.5"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="mpg-Fk-gl4">
-                                        <rect key="frame" x="0.0" y="0.0" width="94" height="162"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="mpg-Fk-gl4">
+                                        <rect key="frame" x="0.0" y="0.0" width="93.5" height="162.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.5" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="94" width="93.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <rect key="contentStretch" x="0.0" y="0.0" width="0.0" height="1"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="130.5" width="93.5" height="32"/>
                                                 <connections>
                                                     <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="xJg-om-vdU"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="trailing" secondItem="ZQk-f4-zrz" secondAttribute="trailing" id="YAw-Cu-p77"/>
+                                            <constraint firstItem="0yV-kn-zaT" firstAttribute="leading" secondItem="ZQk-f4-zrz" secondAttribute="leading" id="n5Q-JQ-avP"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="kL5-Ya-uNf">
-                                        <rect key="frame" x="114" y="0.0" width="94" height="162"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="kL5-Ya-uNf">
+                                        <rect key="frame" x="103.5" y="0.0" width="93.5" height="162.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.5" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="94" width="93.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="130.5" width="93.5" height="32"/>
                                                 <connections>
                                                     <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="yTz-aK-ZQT"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="leading" secondItem="O5s-2N-3iP" secondAttribute="leading" id="QvY-jI-d3C"/>
+                                            <constraint firstItem="gKu-86-RhI" firstAttribute="trailing" secondItem="O5s-2N-3iP" secondAttribute="trailing" id="laM-gP-oI6"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="8fF-od-wye">
-                                        <rect key="frame" x="228" y="0.0" width="94" height="162"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="8fF-od-wye">
+                                        <rect key="frame" x="207" y="0.0" width="94" height="162.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <rect key="frame" x="9.5" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="94" width="94" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="130.5" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Jbz-L5-SZ1"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="trailing" secondItem="Rcr-xr-eqz" secondAttribute="trailing" id="91O-6F-vZ3"/>
+                                            <constraint firstItem="MpT-VW-hCb" firstAttribute="leading" secondItem="Rcr-xr-eqz" secondAttribute="leading" id="fdU-TM-dPM"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="1d9-Yl-dMB">
-                                        <rect key="frame" x="342" y="0.0" width="94" height="162"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="1d9-Yl-dMB">
+                                        <rect key="frame" x="311" y="0.0" width="93.5" height="162.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <rect key="frame" x="9" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="94" width="93.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="3" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="130.5" width="93.5" height="32"/>
                                                 <connections>
                                                     <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FM1-XG-vT6"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="trailing" secondItem="klA-59-Nu4" secondAttribute="trailing" id="iKk-bb-kmg"/>
+                                            <constraint firstItem="ZDv-1m-HBY" firstAttribute="leading" secondItem="klA-59-Nu4" secondAttribute="leading" id="qwq-Su-A9d"/>
+                                        </constraints>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Vuv-VT-q6h">
-                                        <rect key="frame" x="456" y="0.0" width="94" height="162"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Vuv-VT-q6h">
+                                        <rect key="frame" x="414.5" y="0.0" width="93.5" height="162.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <rect key="frame" x="9" y="0.0" width="75" height="84"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="94" width="93.5" height="26.5"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" tag="4" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <rect key="frame" x="0.0" y="130.5" width="93.5" height="32"/>
                                                 <connections>
                                                     <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="YlQ-1q-5jl"/>
                                                 </connections>
                                             </stepper>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="leading" secondItem="xbn-6P-grO" secondAttribute="leading" id="Ort-Dm-VfQ"/>
+                                            <constraint firstItem="YJI-ER-LJR" firstAttribute="trailing" secondItem="xbn-6P-grO" secondAttribute="trailing" id="rLG-IV-jHg"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                             </stackView>
@@ -533,6 +554,8 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="z3e-9p-JS3" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="96u-xt-rRn"/>
+                            <constraint firstItem="gcO-Xb-kNs" firstAttribute="trailing" secondItem="z3e-9p-JS3" secondAttribute="trailing" constant="30" id="csO-Xo-RdJ"/>
+                            <constraint firstItem="z3e-9p-JS3" firstAttribute="leading" secondItem="gcO-Xb-kNs" secondAttribute="leading" constant="30" id="mgF-0x-6lv"/>
                             <constraint firstItem="z3e-9p-JS3" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="trh-U6-apd"/>
                         </constraints>
                     </view>
@@ -554,7 +577,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
                 <exit id="h5a-b1-bMx" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="762" y="1091"/>
+            <point key="canvasLocation" x="761.61971830985919" y="1089.375"/>
         </scene>
     </scenes>
     <resources>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -334,7 +334,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" identifier="modifyStockViewSegue" id="2Me-lx-FY7"/>
+                                <segue destination="Yu1-lM-nqp" kind="presentation" identifier="modifyStockViewSegue" id="af3-ka-fJx"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -536,7 +536,7 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <color key="barTintColor" systemColor="systemBackgroundColor"/>
                                 <items>
-                                    <navigationItem title="재고 수정" id="1pL-UX-McV">
+                                    <navigationItem title="재고 추가" id="1pL-UX-McV">
                                         <barButtonItem key="rightBarButtonItem" title="닫기   " id="Rsq-2H-vzu">
                                             <connections>
                                                 <segue destination="h5a-b1-bMx" kind="unwind" unwindAction="unwindToJuiceMakerViewController:" id="JeC-Iv-nyn"/>
@@ -563,15 +563,15 @@
                     <size key="freeformSize" width="568" height="320"/>
                     <connections>
                         <outletCollection property="fruitStockLabels" destination="0yV-kn-zaT" collectionClass="NSMutableArray" id="sNZ-xZ-1To"/>
-                        <outletCollection property="fruitStockStepper" destination="ZQk-f4-zrz" collectionClass="NSMutableArray" id="ahN-Ec-Kkl"/>
                         <outletCollection property="fruitStockLabels" destination="gKu-86-RhI" collectionClass="NSMutableArray" id="Szp-EA-IKg"/>
-                        <outletCollection property="fruitStockStepper" destination="O5s-2N-3iP" collectionClass="NSMutableArray" id="kGS-qL-xPY"/>
                         <outletCollection property="fruitStockLabels" destination="MpT-VW-hCb" collectionClass="NSMutableArray" id="cfa-xG-4hX"/>
-                        <outletCollection property="fruitStockStepper" destination="Rcr-xr-eqz" collectionClass="NSMutableArray" id="vXL-qk-l95"/>
-                        <outletCollection property="fruitStockStepper" destination="klA-59-Nu4" collectionClass="NSMutableArray" id="Nqe-iH-DzN"/>
                         <outletCollection property="fruitStockLabels" destination="ZDv-1m-HBY" collectionClass="NSMutableArray" id="RWy-yd-W1h"/>
                         <outletCollection property="fruitStockLabels" destination="YJI-ER-LJR" collectionClass="NSMutableArray" id="7I6-Z0-L8o"/>
-                        <outletCollection property="fruitStockStepper" destination="xbn-6P-grO" collectionClass="NSMutableArray" id="sbw-Xk-RhY"/>
+                        <outletCollection property="fruitStockSteppers" destination="ZQk-f4-zrz" collectionClass="NSMutableArray" id="DLg-d1-MsZ"/>
+                        <outletCollection property="fruitStockSteppers" destination="O5s-2N-3iP" collectionClass="NSMutableArray" id="SWr-TA-pRu"/>
+                        <outletCollection property="fruitStockSteppers" destination="Rcr-xr-eqz" collectionClass="NSMutableArray" id="CdD-JZ-Nj5"/>
+                        <outletCollection property="fruitStockSteppers" destination="klA-59-Nu4" collectionClass="NSMutableArray" id="V68-vQ-i23"/>
+                        <outletCollection property="fruitStockSteppers" destination="xbn-6P-grO" collectionClass="NSMutableArray" id="Fce-jZ-9jT"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -15,23 +15,23 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="JuiceMakerViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zaq-m5-IIF">
-                                <rect key="frame" x="63" y="52" width="718" height="136.66666666666666"/>
+                                <rect key="frame" x="63" y="52" width="442" height="112"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tcB-i6-XX4">
-                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="136.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="mVl-JQ-6g7">
+                                                <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="83.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qas-vP-td6">
+                                                <rect key="frame" x="0.0" y="91.666666666666657" width="75.666666666666671" height="20.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -40,16 +40,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="G4B-kp-2Jo">
-                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="136.66666666666666"/>
+                                        <rect key="frame" x="91.666666666666657" y="0.0" width="75.666666666666657" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bl7-p0-c43">
+                                                <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="77.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gvk-pA-Lw5">
+                                                <rect key="frame" x="0.0" y="85.666666666666657" width="75.666666666666671" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -58,16 +58,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vji-QZ-gSn">
-                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="136.66666666666666"/>
+                                        <rect key="frame" x="183.33333333333334" y="0.0" width="75.333333333333343" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Qkv-u6-h8e">
+                                                <rect key="frame" x="0.0" y="0.0" width="75.333333333333329" height="77.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ccQ-Dk-PuY">
+                                                <rect key="frame" x="0.0" y="85.666666666666657" width="75.333333333333329" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -76,16 +76,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-3d-9vz">
-                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="136.66666666666666"/>
+                                        <rect key="frame" x="274.66666666666669" y="0.0" width="75.666666666666686" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="102.33333333333333"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kI4-bd-cgh">
+                                                <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="77.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="131" height="26.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FZq-de-TJG">
+                                                <rect key="frame" x="0.0" y="85.666666666666657" width="75.666666666666671" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -94,16 +94,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dgU-OE-25m">
-                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="136.66666666666666"/>
+                                        <rect key="frame" x="366.33333333333331" y="0.0" width="75.666666666666686" height="112"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
-                                                <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="102.33333333333333"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2DA-4v-r9P">
+                                                <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="77.666666666666671"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="70"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
-                                                <rect key="frame" x="0.0" y="110.33333333333334" width="130.66666666666666" height="26.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3Ce-SU-JeH">
+                                                <rect key="frame" x="0.0" y="85.666666666666657" width="75.666666666666671" height="26.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
@@ -114,13 +114,13 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-6k-c2D">
-                                <rect key="frame" x="63" y="208.66666666666663" width="718" height="140.33333333333337"/>
+                                <rect key="frame" x="63" y="184" width="442" height="95"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zzl-05-bVq">
-                                        <rect key="frame" x="0.0" y="0.0" width="718" height="66"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="442" height="43.666666666666664"/>
                                         <subviews>
-                                            <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
-                                                <rect key="frame" x="0.0" y="0.0" width="277.66666666666669" height="66"/>
+                                            <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="hrc-2F-fzl">
+                                                <rect key="frame" x="0.0" y="0.0" width="167.33333333333334" height="43.666666666666664"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="딸바쥬스 주문">
@@ -131,11 +131,11 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9E2-H9-FXr">
-                                                <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66"/>
+                                                <rect key="frame" x="183.33333333333334" y="0.0" width="75.333333333333343" height="43.666666666666664"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
-                                            <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
-                                                <rect key="frame" x="440.33333333333326" y="0.0" width="277.66666666666674" height="66"/>
+                                            <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ngP-kF-Yii">
+                                                <rect key="frame" x="274.66666666666669" y="0.0" width="167.33333333333331" height="43.666666666666664"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <state key="normal" title="망키쥬스 주문">
@@ -148,61 +148,157 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-0B-qbM">
-                                        <rect key="frame" x="0.0" y="74.000000000000028" width="718" height="66.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="51.666666666666657" width="442" height="43.333333333333343"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0iw-e6-NWs">
-                                                <rect key="frame" x="0.0" y="0.0" width="718" height="66.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="442" height="43.333333333333336"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="130.66666666666666" height="66.333333333333329"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="avd-o5-3JM">
+                                                        <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="43.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="딸기쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="딸기쥬스 주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZcL-H1-WiT"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
-                                                        <rect key="frame" x="146.66666666666666" y="0.0" width="130.99999999999997" height="66.333333333333329"/>
+                                                    <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="y2A-PH-DJY">
+                                                        <rect key="frame" x="91.666666666666657" y="0.0" width="75.666666666666657" height="43.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="바나나쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="바나나쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content=" ">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gas-jx-bf1"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
-                                                        <rect key="frame" x="293.66666666666669" y="0.0" width="130.66666666666669" height="66.333333333333329"/>
+                                                    <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BFb-ka-wGA">
+                                                        <rect key="frame" x="183.33333333333334" y="0.0" width="75.333333333333343" height="43.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="파인애플쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="파인애플쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content=" ">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qXB-Xb-1Y9"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
-                                                        <rect key="frame" x="440.33333333333331" y="0.0" width="130.99999999999994" height="66.333333333333329"/>
+                                                    <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wcW-7H-RXw">
+                                                        <rect key="frame" x="274.66666666666669" y="0.0" width="75.666666666666686" height="43.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="키위쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="키위쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content=" ">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name=".AppleSDGothicNeoI-Regular"/>
+                                                                        <font key="NSOriginalFont" metaFont="system" size="15"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="GQr-A2-HfG"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
-                                                        <rect key="frame" x="587.33333333333337" y="0.0" width="130.66666666666663" height="66.333333333333329"/>
+                                                    <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q6G-4X-bVm">
+                                                        <rect key="frame" x="366.33333333333331" y="0.0" width="75.666666666666686" height="43.333333333333336"/>
                                                         <color key="backgroundColor" name="AccentColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <state key="normal" title="망고쥬스 주문">
-                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <state key="normal">
+                                                            <attributedString key="attributedTitle">
+                                                                <fragment content="망고쥬스">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name="AppleSDGothicNeo-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content=" ">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name="HelveticaNeue"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                                <fragment content="주문">
+                                                                    <attributes>
+                                                                        <color key="NSColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <font key="NSFont" size="15" name="AppleSDGothicNeo-Regular"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
                                                         </state>
                                                         <connections>
                                                             <action selector="touchUpOrderButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="lym-pS-eLb"/>
@@ -242,6 +338,7 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <size key="freeformSize" width="568" height="320"/>
                     <connections>
                         <outletCollection property="fruitStockLabels" destination="3Ce-SU-JeH" collectionClass="NSMutableArray" id="xte-OM-SZF"/>
                         <outletCollection property="fruitStockLabels" destination="FZq-de-TJG" collectionClass="NSMutableArray" id="iZQ-pl-edD"/>
@@ -266,8 +363,9 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DCG-dP-Fms" sceneMemberID="viewController">
                     <toolbarItems/>
+                    <size key="freeformSize" width="568" height="320"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wpg-nM-F9y">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="32"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -284,150 +382,172 @@
             <objects>
                 <viewController storyboardIdentifier="ModifyStockViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Yu1-lM-nqp" customClass="ModifyStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tKV-4l-Vtc">
-                        <rect key="frame" x="0.0" y="0.0" width="844" height="390"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
-                                <rect key="frame" x="590" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" tag="4" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
-                                <rect key="frame" x="580" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="YlQ-1q-5jl"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
-                                <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
-                                <rect key="frame" x="429" y="156" width="46" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" tag="3" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
-                                <rect key="frame" x="410" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FM1-XG-vT6"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
-                                <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
-                                <rect key="frame" x="289" y="155" width="42" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
-                                <rect key="frame" x="261" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Jbz-L5-SZ1"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
-                                <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
-                                <rect key="frame" x="154" y="187" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="yTz-aK-ZQT"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
-                                <rect key="frame" x="72" y="161" width="51" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
-                                <rect key="frame" x="60" y="73" width="75" height="83.666666666666671"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
-                                <rect key="frame" x="174" y="158" width="53" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
-                                <rect key="frame" x="50" y="192" width="94" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <connections>
-                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="xJg-om-vdU"/>
-                                </connections>
-                            </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
-                                <rect key="frame" x="606" y="156" width="43" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="재고 추가" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sVc-E8-ZGc">
-                                <rect key="frame" x="383" y="0.0" width="78" height="37"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dXY-L6-Zi1">
-                                <rect key="frame" x="710" y="20" width="54" height="35"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="닫기"/>
-                                <connections>
-                                    <segue destination="h5a-b1-bMx" kind="unwind" unwindAction="unwindToJuiceMakerViewController:" id="qzh-MZ-LbS"/>
-                                </connections>
-                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="z3e-9p-JS3">
+                                <rect key="frame" x="9" y="79" width="550" height="162"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="mpg-Fk-gl4">
+                                        <rect key="frame" x="0.0" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍓" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-AJ-zGU">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="xJg-om-vdU"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="kL5-Ya-uNf">
+                                        <rect key="frame" x="114" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gKu-86-RhI">
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="yTz-aK-ZQT"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="8fF-od-wye">
+                                        <rect key="frame" x="228" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="MpT-VW-hCb">
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Jbz-L5-SZ1"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="1d9-Yl-dMB">
+                                        <rect key="frame" x="342" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZDv-1m-HBY">
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" tag="3" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FM1-XG-vT6"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Vuv-VT-q6h">
+                                        <rect key="frame" x="456" y="0.0" width="94" height="162"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🥭" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="w1F-9o-qJR">
+                                                <rect key="frame" x="0.0" y="0.0" width="94" height="83.666666666666671"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
+                                                <rect key="frame" x="0.0" y="93.666666666666657" width="94" height="26.333333333333329"/>
+                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" tag="4" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
+                                                <rect key="frame" x="0.0" y="130" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="YlQ-1q-5jl"/>
+                                                </connections>
+                                            </stepper>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
+                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Phh-AV-RD8">
+                                <rect key="frame" x="0.0" y="0.0" width="568" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <color key="barTintColor" systemColor="systemBackgroundColor"/>
+                                <items>
+                                    <navigationItem title="재고 수정" id="1pL-UX-McV">
+                                        <barButtonItem key="rightBarButtonItem" title="닫기   " id="Rsq-2H-vzu">
+                                            <connections>
+                                                <segue destination="h5a-b1-bMx" kind="unwind" unwindAction="unwindToJuiceMakerViewController:" id="JeC-Iv-nyn"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                                <navigationBarAppearance key="standardAppearance">
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <color key="shadowColor" systemColor="systemBackgroundColor"/>
+                                </navigationBarAppearance>
+                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="gcO-Xb-kNs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="z3e-9p-JS3" firstAttribute="centerX" secondItem="tKV-4l-Vtc" secondAttribute="centerX" id="96u-xt-rRn"/>
+                            <constraint firstItem="z3e-9p-JS3" firstAttribute="centerY" secondItem="tKV-4l-Vtc" secondAttribute="centerY" id="trh-U6-apd"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <size key="freeformSize" width="568" height="320"/>
                     <connections>
                         <outletCollection property="fruitStockLabels" destination="0yV-kn-zaT" collectionClass="NSMutableArray" id="sNZ-xZ-1To"/>
-                        <outletCollection property="fruitStockLabels" destination="gKu-86-RhI" collectionClass="NSMutableArray" id="Szp-EA-IKg"/>
-                        <outletCollection property="fruitStockLabels" destination="MpT-VW-hCb" collectionClass="NSMutableArray" id="cfa-xG-4hX"/>
-                        <outletCollection property="fruitStockLabels" destination="ZDv-1m-HBY" collectionClass="NSMutableArray" id="RWy-yd-W1h"/>
-                        <outletCollection property="fruitStockLabels" destination="YJI-ER-LJR" collectionClass="NSMutableArray" id="7I6-Z0-L8o"/>
                         <outletCollection property="fruitStockStepper" destination="ZQk-f4-zrz" collectionClass="NSMutableArray" id="ahN-Ec-Kkl"/>
+                        <outletCollection property="fruitStockLabels" destination="gKu-86-RhI" collectionClass="NSMutableArray" id="Szp-EA-IKg"/>
                         <outletCollection property="fruitStockStepper" destination="O5s-2N-3iP" collectionClass="NSMutableArray" id="kGS-qL-xPY"/>
+                        <outletCollection property="fruitStockLabels" destination="MpT-VW-hCb" collectionClass="NSMutableArray" id="cfa-xG-4hX"/>
                         <outletCollection property="fruitStockStepper" destination="Rcr-xr-eqz" collectionClass="NSMutableArray" id="vXL-qk-l95"/>
                         <outletCollection property="fruitStockStepper" destination="klA-59-Nu4" collectionClass="NSMutableArray" id="Nqe-iH-DzN"/>
+                        <outletCollection property="fruitStockLabels" destination="ZDv-1m-HBY" collectionClass="NSMutableArray" id="RWy-yd-W1h"/>
+                        <outletCollection property="fruitStockLabels" destination="YJI-ER-LJR" collectionClass="NSMutableArray" id="7I6-Z0-L8o"/>
                         <outletCollection property="fruitStockStepper" destination="xbn-6P-grO" collectionClass="NSMutableArray" id="sbw-Xk-RhY"/>
                     </connections>
                 </viewController>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -389,15 +389,6 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="R0f-7P-E5D">
-                                <rect key="frame" x="350" y="270" width="75" height="35"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
-                                <connections>
-                                    <action selector="stockButton:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="him-dK-bfh"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dXY-L6-Zi1">
                                 <rect key="frame" x="710" y="20" width="54" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -297,6 +297,9 @@
                             <stepper opaque="NO" tag="4" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="xbn-6P-grO">
                                 <rect key="frame" x="580" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="YlQ-1q-5jl"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🥝" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EHe-D1-1xN">
                                 <rect key="frame" x="429" y="65" width="75" height="83.666666666666671"/>
@@ -316,6 +319,9 @@
                             <stepper opaque="NO" tag="3" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="klA-59-Nu4">
                                 <rect key="frame" x="410" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="FM1-XG-vT6"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍍" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rac-Ji-vZK">
                                 <rect key="frame" x="271" y="65" width="75" height="83.666666666666671"/>
@@ -335,6 +341,9 @@
                             <stepper opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-xr-eqz">
                                 <rect key="frame" x="261" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="Jbz-L5-SZ1"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="🍌" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="y33-ND-gz2">
                                 <rect key="frame" x="165" y="73" width="75" height="83.666666666666671"/>
@@ -346,6 +355,9 @@
                             <stepper opaque="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="O5s-2N-3iP">
                                 <rect key="frame" x="154" y="187" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="yTz-aK-ZQT"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0yV-kn-zaT">
                                 <rect key="frame" x="72" y="161" width="51" height="23"/>
@@ -373,6 +385,9 @@
                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-f4-zrz">
                                 <rect key="frame" x="50" y="192" width="94" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <connections>
+                                    <action selector="touchUpStepper:" destination="Yu1-lM-nqp" eventType="valueChanged" id="xJg-om-vdU"/>
+                                </connections>
                             </stepper>
                             <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" fixedFrame="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="YJI-ER-LJR">
                                 <rect key="frame" x="606" y="156" width="43" height="23"/>
@@ -409,6 +424,11 @@
                         <outletCollection property="fruitStockLabels" destination="MpT-VW-hCb" collectionClass="NSMutableArray" id="cfa-xG-4hX"/>
                         <outletCollection property="fruitStockLabels" destination="ZDv-1m-HBY" collectionClass="NSMutableArray" id="RWy-yd-W1h"/>
                         <outletCollection property="fruitStockLabels" destination="YJI-ER-LJR" collectionClass="NSMutableArray" id="7I6-Z0-L8o"/>
+                        <outletCollection property="fruitStockStepper" destination="ZQk-f4-zrz" collectionClass="NSMutableArray" id="ahN-Ec-Kkl"/>
+                        <outletCollection property="fruitStockStepper" destination="O5s-2N-3iP" collectionClass="NSMutableArray" id="kGS-qL-xPY"/>
+                        <outletCollection property="fruitStockStepper" destination="Rcr-xr-eqz" collectionClass="NSMutableArray" id="vXL-qk-l95"/>
+                        <outletCollection property="fruitStockStepper" destination="klA-59-Nu4" collectionClass="NSMutableArray" id="Nqe-iH-DzN"/>
+                        <outletCollection property="fruitStockStepper" destination="xbn-6P-grO" collectionClass="NSMutableArray" id="sbw-Xk-RhY"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>

--- a/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/View/Base.lproj/Main.storyboard
@@ -238,7 +238,7 @@
                     <navigationItem key="navigationItem" title="맛있는 쥬스를 만들어 드려요!" id="Eal-fj-o4N">
                         <barButtonItem key="rightBarButtonItem" title="재고수정" id="C3q-Te-cNT">
                             <connections>
-                                <segue destination="Yu1-lM-nqp" kind="presentation" identifier="modifyStockViewSegue" id="2Me-lx-FY7"/>
+                                <segue destination="Yu1-lM-nqp" kind="presentation" identifier="modifyStockViewSegue" modalPresentationStyle="fullScreen" id="2Me-lx-FY7"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -382,6 +382,22 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="재고 추가" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sVc-E8-ZGc">
+                                <rect key="frame" x="383" y="0.0" width="78" height="37"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="R0f-7P-E5D">
+                                <rect key="frame" x="350" y="270" width="75" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <connections>
+                                    <action selector="stockButton:" destination="Yu1-lM-nqp" eventType="touchUpInside" id="him-dK-bfh"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dXY-L6-Zi1">
                                 <rect key="frame" x="710" y="20" width="54" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -396,6 +412,13 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" id="g4W-fY-l7r"/>
+                    <connections>
+                        <outletCollection property="fruitStockLabels" destination="0yV-kn-zaT" collectionClass="NSMutableArray" id="sNZ-xZ-1To"/>
+                        <outletCollection property="fruitStockLabels" destination="gKu-86-RhI" collectionClass="NSMutableArray" id="Szp-EA-IKg"/>
+                        <outletCollection property="fruitStockLabels" destination="MpT-VW-hCb" collectionClass="NSMutableArray" id="cfa-xG-4hX"/>
+                        <outletCollection property="fruitStockLabels" destination="ZDv-1m-HBY" collectionClass="NSMutableArray" id="RWy-yd-W1h"/>
+                        <outletCollection property="fruitStockLabels" destination="YJI-ER-LJR" collectionClass="NSMutableArray" id="7I6-Z0-L8o"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieh-6D-g1l" sceneMemberID="firstResponder"/>
             </objects>


### PR DESCRIPTION
원비(@wonbi92 ) 안녕하세요
다산경민 입니다
벌써 마지막 PR이네요😭
잘 부탁드립니다🍀

---
# STEP 3

## 🔍 고민되었던 점

### 1. JuiceMakerView, ModifyStockView 간 데이터 전달 방법🖥️

데이터를 전달하는 방법들에 대해 각각의 장단점을 비교하고 싶었기 때문에, 아래 4가지 방법으로 branch를 열어 테스트 해봤습니다.

#### 🔎 KVO
  - **장점**:
    - old, new value를 쉽게 얻을 수 있습니다.
  - **단점**: 
    - NSObject를 상속받는 객체에서만 사용이 가능합니다. 
    - 현재 코드에서 과일 재고의 값을 추척하여 재고의 값이 바뀌었을 때 label 업데이트하도록 Handler을 구현하였는데, 과일 재고 값을 어디서든 추적하려면 결국 **싱글톤**으로 만들어줘야했습니다.
    - **변경될 객체의 관찰**하는 것이 목표인 KVO는 다른 방법들과 비교하였을 때, **직접 정보(객체 등)을 전달할 수 없었습니다.**

#### 📡 Notification
  - **장점**: 
    - **다수의 객체들에게 동시에** 이벤트의 발생을 알려줄 수 있다는 장점이 있지만 현재 코드에선 적용될만한 장점이 아니었습니다.
    - Notification과 관련된 정보를 userInfo를 통하여 전달해줄 수 있습니다.
      ```swift
        NotificationCenter.default.post(name: Notification.Name("modifyNotification") ,
                                        object: nil, 
                                        userInfo: fruitStocks)
      ```
  - **단점**: 
    - post가 어떤 상황에 대한 알림을 준 **그 이후의 정보를 받을 수 없습니다.**
    - `Notification.Name`이 달라도 오류가 안나는 단점을 가지고 있습니다.
    - 추적해야할 것이 많아진다면 추적이 쉽지 않을 수 있습니다.

#### 🫵🏻 delegate
  - **장점**:
    - 프로토콜에 필요한 메소드들이 명확하게 명시 합니다.
    - 로직의 흐름을 따라가기 쉽습니다.
    - 많은 기능을 위임할 수 있습니다.
    - 확장성, 모듈화, 코드 분리에 적합합니다.
  - **단점**:
    - **JuiceMakerViewController가 delegate프로토콜을 채택했을 때**는 `ModifyStockViewController`가 JuiceMakerView에서 returnValue를 통해 수정 전 과일재고를 전달받고, 수정 후 과일 재고를 parameter로 넘겨줬습니다.
    - **ModifyStockViewController가 delegate프로토콜을 채택했을 때**는 `segue`를 통해 인스턴스를 delegate로 설정하다보니 segue를 통한 인스턴스 전달과 다를게 없었습니다.
    - segue가 아닌 방식으로 화면전환을 구현 했다면 필요 했을 것 습니다. 
    - 델리게이트의 장점들에 적합한 코드를 작성할때, 더 많은 기능을 위임할 때 delegate를 써야 할 것 같다고 생각 했습니다.

#### 🗄️ singleton
  - **장점**: 
    - 메모리를 아낄 수 있습니다.
    - 전역적으로 타입에 접근가능 합니다.
    - 매우 편리합니다.
  - **단점**: 
    - 과일 재고에 대하여 직접적 접근을 제한하는것이 한정적이였습니다.
    - 인스턴스끼리 결합도가 높아진다고 판단했습니다.(OCP 위반)

#### 💎 결정
각 View의 기능에 초점을 뒀을때, 다음과 같이 간단히 정리해봤습니다. 

- JuiceMakerViewController
  - 쥬스를 주문 받음
  - ModifyStockView로 화면 전환
  - juiceMaker가 소유하고 있는 fruitStore의 과일 재고를 ModifyStockView에게 넘겨줌
  - 쥬스 제작 성공, 실패에 대한 Alert을 띄움 
- ModifyStockViewController
  - 과일 재고를 추가하는 기능
  - 추가된 과일 재고를 JuiceMakerView에 넘겨줌

따라서, 각 View가 **수정되기 전 과일 재고**와 **수정 된 과일 재고** 데이터만을 소통하면 된다고 생각했습니다. 또한 과일 재고(fruitInventory)에 대한 접근제한을 해야한다고 생각했기 때문에 최종적으로 `Segue`를 통하여 과일 재고 데이터를 주고 받도록 하였습니다.


### 2. 디바이스 화면에 따라 각 Stack View들의 간격을 균일하게 주는 방법📱

  먼저 자동 오토 레이아웃 기능을 제공해주는 Stack View를 활용하였습니다. 재고 수정 화면에서 각 과일들은 `과일 그림`, `과일 재고 갯수`, `Stepper`을 가지고 있기 때문에 `이 3가지 요소`를 `Vertical Stack View`에 넣어주었고, 과일 갯수만큼 5개의 Vertical Stack View를 만들었습니다. `이 5개의 Vertical Stack View`를 `하나의 Horizontal Stack View`에 넣어주었습니다.

  Horizontal Stack View 안에 있는 **각각의 스택뷰들의 간격을 균일하게 하기위하여** Horizontal Stack View의 `spacing`에 값을 설정해주었습니다. 

  테스트하고 있는 화면을 기준으로 보기 좋게 spacing 값을 주었기 때문에 현재 화면에선 문제가 되지 않았지만, 더 작은 화면으로 시뮬레이터를 돌려보면 요소들이 화면에 넘치기도 하고 더 큰 화면에선 Horizontal Stack View 상하좌우로 많은 여백이 생겼습니다.

  적당한 spacing 값을 찾아 줄 수도 있었지만, 화면 크기에 따라 Vertical Stack View의 간격을 자동으로 조절해주면 더 편리하겠다고 생각하여 아래와 같은 방법으로 구현해보았습니다.

  1. 다른 스택뷰들을 감싸고 있는 `Horizontal Stack View`를 컨테이너 안에서 `Horizontal, Vertical 정렬` 하기
  2. Horizontal Stack View에 Safe Area 기준으로 `Trailing, Leading 제약사항` 주기
  3. Horizontal Stack View의 `Distribution`을 **[Fill Equally](https://developer.apple.com/documentation/uikit/uistackview/distribution/fillequally)** 로 변경하기
  4. 내부의 각 `Vertical Stack View`의 `Alignment`을 **Center**로 지정

  여기까지 하면 원하는 대로 간격을 균일하게 줄 수 있었지만, 과일 재고 갯수를 나타내는 Label의 너비가 글씨 크기에 맞춰져서 예쁘지 않아 제약사항을 더 추가하였습니다.

  5. Stepper의 너비와 Label의 너비를 같게 하기 위하여, 각 Label을 **Stepper을 기준**으로 `Leading`과 `Trailling`의 값을 0으로 설정
<br>

## 📌 해결하지 못한 점 
 - segue를 통해 화면을 전환하여 새로운 화면이 사라질때 unwind 메서드에 대하여 알지 못할때 생긴 고민입니다. 화면을 전환 할때 fullScreen방식이 아닌 popover방식으로 전환하면 뒤의 View가 계층에 살아있어, 새로운 화면이 사라질때 뒤에 살아있는 뷰에대하여 ViewStateMethod 중 어느 것도 실행되지 않았습니다. 이를 해결하기 위해 viewWillLayoutSubviews, viewDidLayoutSubviews를 알게 됐는데 언제 실행되는지에 대한 명확한 시점을 알기 어려웠습니다. 공식문서를 읽었을때 화면이 회전 할때 뷰가 다시 그려지면서 실행되는 것은 확인했는데 정확한 시점을 알기 어려웠습니다.
<br>

## 🙏 조언을 얻고 싶은 부분
- 이번 프로젝트를 통해서 여러가지 데이터 전달방식 외에도 또 다른 방법(의존성 주입, 클로저 등)들이 있다는 것을 알았지만, 시간이 부족하여 다 적용해보지 못하였습니다🥺 쥬스 메이커를 통하여 알아야하는 개념이나 저희가 놓친 것들을 알려주신다면 더 공부해보고 싶습니다!
<br>

## 📚 참고 링크

- [🍎Apple Docs: UIStoryboardSegue](https://developer.apple.com/documentation/uikit/uistoryboardsegue)
- [🍎Apple Docs: Cocoa design patterns](https://developer.apple.com/documentation/swift/cocoa-design-patterns)
- [🍎Apple Docs: KVO](https://developer.apple.com/documentation/swift/using-key-value-observing-in-swift)
- [🍎Apple Docs: Unwind segue로 뷰컨트롤러 닫기](https://developer.apple.com/documentation/uikit/resource_management/dismissing_a_view_controller_with_an_unwind_segue)
- [🍎Apple Docs: UnwindSegueSource](https://developer.apple.com/documentation/uikit/uistoryboardunwindseguesource)
- [🍎Apple Docs: UIStackView](https://developer.apple.com/documentation/uikit/uistackview)
- [🍎Apple Docs: viewdidlayoutsubviews](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621398-viewdidlayoutsubviews)